### PR TITLE
[bugfix] Update powerbi mcp server URL location

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "PowerBIQuery": {
       "type": "http",
-      "url": "https://msitapi.fabric.microsoft.com/v1/mcp/powerbi",
+      "url": "https://api.fabric.microsoft.com/v1/mcp/powerbi",
       "headers": {},
       "tools": [
         "ExecuteQuery"


### PR DESCRIPTION
This PR updates the url of the Power BI MCP server to match the production endpoint documented here: https://learn.microsoft.com/en-us/power-bi/developer/mcp/remote-mcp-server-get-started#set-up-the-remote-power-bi-mcp-server-in-vs-code

https://api.fabric.microsoft.com/v1/mcp/powerbi