### PR TITLE
fix: correct dataflow refresh job endpoint in dataflows-authoring-cli

### DIFF
--- a/plugins/fabric-authoring/skills/dataflows-authoring-cli/SKILL.md
+++ b/plugins/fabric-authoring/skills/dataflows-authoring-cli/SKILL.md
@@ -257,7 +257,7 @@ az rest --method post \
 ```bash
 # Trigger refresh (returns 202 + Location header for polling)
 LOCATION=$(az rest --method post \
-  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${DF_ID}/jobs/instances?jobType=Pipeline" \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${DF_ID}/jobs/Execute/instances" \
   --resource "https://api.fabric.microsoft.com" \
   --headers "Content-Length=0" \
   --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')

--- a/plugins/fabric-skills/skills/dataflows-authoring-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/dataflows-authoring-cli/SKILL.md
@@ -257,7 +257,7 @@ az rest --method post \
 ```bash
 # Trigger refresh (returns 202 + Location header for polling)
 LOCATION=$(az rest --method post \
-  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${DF_ID}/jobs/instances?jobType=Pipeline" \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${DF_ID}/jobs/Execute/instances" \
   --resource "https://api.fabric.microsoft.com" \
   --headers "Content-Length=0" \
   --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')

--- a/skills/dataflows-authoring-cli/SKILL.md
+++ b/skills/dataflows-authoring-cli/SKILL.md
@@ -257,7 +257,7 @@ az rest --method post \
 ```bash
 # Trigger refresh (returns 202 + Location header for polling)
 LOCATION=$(az rest --method post \
-  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${DF_ID}/jobs/instances?jobType=Pipeline" \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${DF_ID}/jobs/Execute/instances" \
   --resource "https://api.fabric.microsoft.com" \
   --headers "Content-Length=0" \
   --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')


### PR DESCRIPTION
## Summary

- The `dataflows-authoring-cli` skill's **Example 2 (Trigger a Refresh Job)** used `jobs/instances?jobType=Pipeline` -- which is the job endpoint for Data Pipeline items, not Dataflows Gen2.
- The correct endpoint for triggering a Dataflow Gen2 refresh is `/jobs/Execute/instances`, as documented in `DATAFLOWS-AUTHORING-CORE.md` and the authoring quickref.
- Using the wrong endpoint would return an error at runtime for anyone following the example.

## Files changed

- `skills/dataflows-authoring-cli/SKILL.md`
- `plugins/fabric-authoring/skills/dataflows-authoring-cli/SKILL.md`
- `plugins/fabric-skills/skills/dataflows-authoring-cli/SKILL.md`

## Before / After

Before (incorrect -- Pipeline job type applied to a Dataflow item):
  --url ".../items/${DF_ID}/jobs/instances?jobType=Pipeline"

After (correct -- matches DATAFLOWS-AUTHORING-CORE.md):
  --url ".../items/${DF_ID}/jobs/Execute/instances"
