### PR TITLE
fix: correct typo eventhouse-authoring-clifor in FabricDataEngineer.agent.md

### DIFF
--- a/agents/FabricDataEngineer.agent.md
+++ b/agents/FabricDataEngineer.agent.md
@@ -52,7 +52,7 @@ Route to specialized skills for endpoint-specific implementation:
 - sqldw-authoring-cli for T-SQL authoring and warehouse object changes
 - sqldw-consumption-cli for read-only T-SQL analytics and exploration
 - sqldw-operations-cli for DW performance diagnostics, slow query analysis, and query insights
-- eventhouse-authoring-clifor KQL management commands — table management, ingestion, policies, materialized views, functions
+- eventhouse-authoring-cli for KQL management commands — table management, ingestion, policies, materialized views, functions
 - eventhouse-consumption-cli for read-only KQL queries against Eventhouse / KQL Databases
 - eventstream-authoring-cli for creating and managing Eventstream topologies — sources, operators, destinations via Fabric REST API
 - eventstream-consumption-cli for listing, inspecting, and monitoring Eventstream configurations and status

--- a/plugins/fabric-authoring/agents/FabricDataEngineer.agent.md
+++ b/plugins/fabric-authoring/agents/FabricDataEngineer.agent.md
@@ -52,7 +52,7 @@ Route to specialized skills for endpoint-specific implementation:
 - sqldw-authoring-cli for T-SQL authoring and warehouse object changes
 - sqldw-consumption-cli for read-only T-SQL analytics and exploration
 - sqldw-operations-cli for DW performance diagnostics, slow query analysis, and query insights
-- eventhouse-authoring-clifor KQL management commands — table management, ingestion, policies, materialized views, functions
+- eventhouse-authoring-cli for KQL management commands — table management, ingestion, policies, materialized views, functions
 - eventhouse-consumption-cli for read-only KQL queries against Eventhouse / KQL Databases
 - eventstream-authoring-cli for creating and managing Eventstream topologies — sources, operators, destinations via Fabric REST API
 - eventstream-consumption-cli for listing, inspecting, and monitoring Eventstream configurations and status

--- a/plugins/fabric-consumption/agents/FabricDataEngineer.agent.md
+++ b/plugins/fabric-consumption/agents/FabricDataEngineer.agent.md
@@ -52,7 +52,7 @@ Route to specialized skills for endpoint-specific implementation:
 - sqldw-authoring-cli for T-SQL authoring and warehouse object changes
 - sqldw-consumption-cli for read-only T-SQL analytics and exploration
 - sqldw-operations-cli for DW performance diagnostics, slow query analysis, and query insights
-- eventhouse-authoring-clifor KQL management commands — table management, ingestion, policies, materialized views, functions
+- eventhouse-authoring-cli for KQL management commands — table management, ingestion, policies, materialized views, functions
 - eventhouse-consumption-cli for read-only KQL queries against Eventhouse / KQL Databases
 - eventstream-authoring-cli for creating and managing Eventstream topologies — sources, operators, destinations via Fabric REST API
 - eventstream-consumption-cli for listing, inspecting, and monitoring Eventstream configurations and status

--- a/plugins/fabric-operations/agents/FabricDataEngineer.agent.md
+++ b/plugins/fabric-operations/agents/FabricDataEngineer.agent.md
@@ -52,7 +52,7 @@ Route to specialized skills for endpoint-specific implementation:
 - sqldw-authoring-cli for T-SQL authoring and warehouse object changes
 - sqldw-consumption-cli for read-only T-SQL analytics and exploration
 - sqldw-operations-cli for DW performance diagnostics, slow query analysis, and query insights
-- eventhouse-authoring-clifor KQL management commands — table management, ingestion, policies, materialized views, functions
+- eventhouse-authoring-cli for KQL management commands — table management, ingestion, policies, materialized views, functions
 - eventhouse-consumption-cli for read-only KQL queries against Eventhouse / KQL Databases
 - eventstream-authoring-cli for creating and managing Eventstream topologies — sources, operators, destinations via Fabric REST API
 - eventstream-consumption-cli for listing, inspecting, and monitoring Eventstream configurations and status

--- a/plugins/fabric-skills/agents/FabricDataEngineer.agent.md
+++ b/plugins/fabric-skills/agents/FabricDataEngineer.agent.md
@@ -52,7 +52,7 @@ Route to specialized skills for endpoint-specific implementation:
 - sqldw-authoring-cli for T-SQL authoring and warehouse object changes
 - sqldw-consumption-cli for read-only T-SQL analytics and exploration
 - sqldw-operations-cli for DW performance diagnostics, slow query analysis, and query insights
-- eventhouse-authoring-clifor KQL management commands — table management, ingestion, policies, materialized views, functions
+- eventhouse-authoring-cli for KQL management commands — table management, ingestion, policies, materialized views, functions
 - eventhouse-consumption-cli for read-only KQL queries against Eventhouse / KQL Databases
 - eventstream-authoring-cli for creating and managing Eventstream topologies — sources, operators, destinations via Fabric REST API
 - eventstream-consumption-cli for listing, inspecting, and monitoring Eventstream configurations and status


### PR DESCRIPTION
## Summary

- Fixed a typo in the delegation rules section of `FabricDataEngineer.agent.md`: `eventhouse-authoring-clifor` -> `eventhouse-authoring-cli for` (missing space between `-cli` and `for`).
- Applies to the root `agents/` file and all four plugin bundle copies.

## Files changed

- `agents/FabricDataEngineer.agent.md`
- `plugins/fabric-skills/agents/FabricDataEngineer.agent.md`
- `plugins/fabric-authoring/agents/FabricDataEngineer.agent.md`
- `plugins/fabric-consumption/agents/FabricDataEngineer.agent.md`
- `plugins/fabric-operations/agents/FabricDataEngineer.agent.md`

## Before / After

Before:
  - eventhouse-authoring-clifor KQL management commands ...

After:
  - eventhouse-authoring-cli for KQL management commands ...
