### PR TITLE
Route Materialized Lake View work to spark-authoring-cli

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -35,6 +35,8 @@ Developers use REST APIs to manage artifacts, then protocol-specific connections
 - Use mssparkutils for Fabric-specific operations (fs, credentials, notebook)
 - Include partition columns for large tables
 - Run OPTIMIZE and VACUUM for table maintenance
+- For Materialized Lake View authoring and incremental refresh review, use `skills/spark-authoring-cli/SKILL.md`.
+- Resource docs: `skills/spark-authoring-cli/resources/materialized-lake-view-patterns.md` and `skills/spark-authoring-cli/resources/mlv-incremental-refresh-patterns.md`.
 
 ### Warehouse (T-SQL)
 - Check T-SQL surface area - not all SQL Server features are supported

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -56,6 +56,10 @@ rules:
     description: Use spark-operations-cli for read-only Spark job diagnosis, session health, and performance triage
     reference: skills/spark-operations-cli/SKILL.md
 
+  - name: spark_mlv_patterns
+    description: Use spark-authoring-cli for Materialized Lake View authoring and incremental refresh guidance
+    reference: skills/spark-authoring-cli/SKILL.md
+
   # Dataflows Gen2 (Data Integration)
   - name: dataflows_skills
     description: Authoring skill is dataflows-authoring-cli, consumption skill is dataflows-consumption-cli
@@ -95,6 +99,7 @@ best_practices:
   - Implement incremental processing over full refreshes
   - Document DAX measures with comments
   - Use REST APIs for programmatic Fabric management
+  - Prefer Materialized Lake Views for durable Silver/Gold Lakehouse data products when the task is Spark/Lakehouse-centric.
 
 documentation_links:
   lakehouse: https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-overview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Fabric REST APIs: https://learn.microsoft.com/en-us/rest/api/fabric/articles/
 - Use Medallion architecture: Bronze (raw) → Silver (cleaned) → Gold (aggregated)
 - Lakehouse for data engineering, Warehouse for SQL analytics
 - Delta Lake format for all Lakehouse tables
+- For Materialized Lake View SQL authoring and incremental refresh optimization, use `skills/spark-authoring-cli/SKILL.md` and its MLV resource documents.
 
 ### Development
 - PySpark with mssparkutils for notebooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ https://learn.microsoft.com/en-us/rest/api/fabric/articles/
 ### Data Engineering
 - **Lakehouse**: Delta tables, Spark, file management
   - Docs: https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-overview
+  - Authoring skill: `skills/spark-authoring-cli/SKILL.md` — notebook authoring, Lakehouse authoring, Materialized Lake Views, and refresh-friendly Spark patterns.
 - **Notebooks**: PySpark notebooks with mssparkutils
   - Docs: https://learn.microsoft.com/en-us/fabric/data-engineering/how-to-use-notebook
 - **Spark Jobs**: Production Spark workloads

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can also filter the full bundle by workload:
 | `fabric-consumption` | Read-only exploration and query workflows across Warehouses, Lakehouses, Power BI semantic models, Eventhouse/KQL databases, Eventstreams, Dataflows Gen2, and catalog search. |
 | `fabric-operations` | Performance and health diagnostics, including warehouse query insights and slow-query investigation. |
 
-The full bundle includes skills for SQL data warehouse, Spark and Lakehouse, Power BI semantic models, Eventhouse and KQL, Eventstreams, Dataflows Gen2, catalog search, migration scenarios, and medallion architecture workflows.
+The full bundle includes skills for SQL data warehouse, Spark and Lakehouse (including Materialized Lake Views), Power BI semantic models, Eventhouse and KQL, Eventstreams, Dataflows Gen2, catalog search, migration scenarios, and medallion architecture workflows.
 
 See [CHANGELOG.md](CHANGELOG.md) for public release notes.
 
@@ -61,6 +61,14 @@ After installing a bundle, open Copilot CLI in a project folder and ask for the 
 
 ```text
 Use Microsoft Fabric skills to design a medallion architecture for NYC taxi data.
+```
+
+```text
+Use Microsoft Fabric skills to design a Bronze/Silver/Gold flow with Materialized Lake Views.
+```
+
+```text
+Review this CREATE MATERIALIZED LAKE VIEW statement for incremental refresh blockers.
 ```
 
 ## Authentication

--- a/agents/FabricDataEngineer.agent.md
+++ b/agents/FabricDataEngineer.agent.md
@@ -46,7 +46,7 @@ Use this agent for cross-cutting data engineering orchestration that spans multi
 
 Route to specialized skills for endpoint-specific implementation:
 
-- spark-authoring-cli for notebook management via REST APIs, Spark engineering, Lakehouse authoring, and writing code inside Fabric notebook cells (lakehouse access patterns, notebookutils usage, Spark configuration)
+- spark-authoring-cli for notebook management via REST APIs, Spark engineering, Lakehouse authoring, Materialized Lake View authoring, incremental-refresh-friendly Spark SQL patterns, and writing code inside Fabric notebook cells (lakehouse access patterns, notebookutils usage, Spark configuration)
 - spark-consumption-cli for interactive Spark analysis
 - spark-operations-cli for read-only diagnosis of Spark job failures, session health monitoring, and performance triage
 - sqldw-authoring-cli for T-SQL authoring and warehouse object changes
@@ -67,6 +67,12 @@ Route to specialized skills for endpoint-specific implementation:
 ## Resources
 
 - Medallion architecture patterns are covered by the `e2e-medallion-architecture` skill
+- MLV authoring patterns: `skills/spark-authoring-cli/resources/materialized-lake-view-patterns.md`
+- MLV incremental refresh patterns: `skills/spark-authoring-cli/resources/mlv-incremental-refresh-patterns.md`
+
+**Routing split for MLV work**
+- Use `e2e-medallion-architecture` for end-to-end Bronze/Silver/Gold orchestration across workspaces, notebooks, pipelines, and BI.
+- Use `spark-authoring-cli` for Spark/Lakehouse endpoint depth, including `CREATE MATERIALIZED LAKE VIEW` SQL authoring, MLV refresh behavior, and incremental-refresh-readiness reviews.
 
 ## Must
 

--- a/skills/e2e-medallion-architecture/SKILL.md
+++ b/skills/e2e-medallion-architecture/SKILL.md
@@ -75,6 +75,7 @@ For Spark-specific optimization details, see [data-engineering-patterns.md](../s
 - Clear layer ownership: engineers own Bronze/Silver, analysts own Gold
 - Fabric Variable Libraries to centralize paths and configuration across layers
 - Multi-workspace deployment patterns for medium/high governance requirements (Bronze/Silver/Gold in separate workspaces)
+- Use Materialized Lake Views (MLVs) for Silver/Gold tables when the transformation is expressible in Spark SQL and benefits from declarative refresh semantics. See [spark-authoring-cli — Materialized Lake View patterns](../spark-authoring-cli/resources/materialized-lake-view-patterns.md) and [MLV incremental refresh patterns](../spark-authoring-cli/resources/mlv-incremental-refresh-patterns.md).
 
 ### AVOID
 - Storing all layers in a single lakehouse — this defeats isolation and independent optimization

--- a/skills/spark-authoring-cli/SKILL.md
+++ b/skills/spark-authoring-cli/SKILL.md
@@ -10,7 +10,10 @@ description: >
   Triggers: "develop notebook", "data engineering", "workspace setup", "pipeline design",
   "infrastructure provisioning", "Delta Lake patterns", "Spark development", "lakehouse configuration",
   "write notebook code", "notebookutils", "notebook cell", "PySpark notebook",
-  "%%sql cell", "%%configure", "fabric notebook", "run notebook", "notebook deployment".
+  "%%sql cell", "%%configure", "fabric notebook", "run notebook", "notebook deployment",
+  "materialized lake view", "MLV", "incremental refresh", "refresh materialized lake view",
+  "design silver and gold with MLVs", "optimize MLV", "why is my MLV doing full refresh",
+  "CREATE MATERIALIZED LAKE VIEW".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -85,6 +88,8 @@ This skill covers two complementary areas: (1) **managing Fabric Spark artifacts
 | Local Testing Strategy | [development-workflow.md § Local Testing Strategy](resources/development-workflow.md#local-testing-strategy) ||
 | Debugging Patterns | [development-workflow.md § Debugging Patterns](resources/development-workflow.md#debugging-patterns) ||
 | Recommended Patterns (Infrastructure) | [infrastructure-orchestration.md § Recommended patterns](resources/infrastructure-orchestration.md#recommended-patterns) ||
+| Materialized Lake View patterns | [materialized-lake-view-patterns.md § Recommended patterns](resources/materialized-lake-view-patterns.md#recommended-patterns) | Spark Lakehouse authoring guidance for MLV design (when to use MLVs, layering patterns) |
+| MLV incremental refresh patterns | [mlv-incremental-refresh-patterns.md § Recommended patterns](resources/mlv-incremental-refresh-patterns.md#recommended-patterns) | Use for refresh-readiness review and safe non-breaking rewrites |
 | Workspace Provisioning Principles | [infrastructure-orchestration.md § Workspace Provisioning Principles](resources/infrastructure-orchestration.md#workspace-provisioning-principles) ||
 | Lakehouse Configuration Guidance | [infrastructure-orchestration.md § Lakehouse Configuration Guidance](resources/infrastructure-orchestration.md#lakehouse-configuration-guidance) ||
 | Pipeline Design Patterns | [infrastructure-orchestration.md § Pipeline Design Patterns](resources/infrastructure-orchestration.md#pipeline-design-patterns) ||
@@ -149,7 +154,7 @@ This skill covers two complementary areas: (1) **managing Fabric Spark artifacts
 > Before submitting new notebook run, ALWAYS check for recent job instances first (last 5 minutes). If recent job exists, monitor it instead of creating duplicate. After submission, capture job instance ID immediately and poll status - never retry POST. See SPARK-AUTHORING-CORE.md Job Monitoring for patterns.
 >
 > **Rule 4 — For notebook code authoring, MUST follow SPARK-NOTEBOOK-AUTHORING-CORE.md.**
-> When writing code inside notebook cells, MUST read [SPARK-NOTEBOOK-AUTHORING-CORE.md](../../common/SPARK-NOTEBOOK-AUTHORING-CORE.md) first — it defines the code generation approach, rules, and a Module Index linking to detailed guides (lakehouse paths, connections, context, orchestration, etc.). Use the Spark-specific resources in this skill ([data-engineering-patterns.md](resources/data-engineering-patterns.md), [development-workflow.md](resources/development-workflow.md)) for Spark-only implementation details.
+> When writing code inside notebook cells, MUST read [SPARK-NOTEBOOK-AUTHORING-CORE.md](../../common/SPARK-NOTEBOOK-AUTHORING-CORE.md) first — it defines the code generation approach, rules, and a Module Index linking to detailed guides (lakehouse paths, connections, context, orchestration, etc.). Use the Spark-specific resources in this skill ([data-engineering-patterns.md](resources/data-engineering-patterns.md), [development-workflow.md](resources/development-workflow.md)) for Spark-only implementation details. When the task is about Materialized Lake Views, read [materialized-lake-view-patterns.md](resources/materialized-lake-view-patterns.md) for authoring/design guidance and [mlv-incremental-refresh-patterns.md](resources/mlv-incremental-refresh-patterns.md) for refresh-readiness analysis.
 
 ---
 
@@ -187,6 +192,30 @@ lakehouse_id=$(az rest --method post --resource "https://api.fabric.microsoft.co
 spark.sql("CREATE SCHEMA IF NOT EXISTS bronze")
 spark.sql("CREATE SCHEMA IF NOT EXISTS silver")
 spark.sql("CREATE SCHEMA IF NOT EXISTS gold")
+```
+
+### Create and Refresh a Materialized Lake View (MLV)
+```sql
+-- See resources/materialized-lake-view-patterns.md for design guidance
+-- and resources/mlv-incremental-refresh-patterns.md for refresh-readiness review.
+
+-- Bronze/Silver/Gold schemas in a Lakehouse with schemas enabled
+CREATE SCHEMA IF NOT EXISTS bronze;
+CREATE SCHEMA IF NOT EXISTS silver;
+CREATE SCHEMA IF NOT EXISTS gold;
+
+-- A simple Silver MLV
+CREATE MATERIALIZED LAKE VIEW silver.orders_clean AS
+SELECT
+  order_id,
+  customer_id,
+  CAST(order_ts AS TIMESTAMP) AS order_ts,
+  amount
+FROM bronze.orders_raw
+WHERE order_id IS NOT NULL;
+
+-- Refresh
+REFRESH MATERIALIZED LAKE VIEW silver.orders_clean;
 ```
 
 ### Create Lakehouse Livy Session

--- a/skills/spark-authoring-cli/resources/materialized-lake-view-patterns.md
+++ b/skills/spark-authoring-cli/resources/materialized-lake-view-patterns.md
@@ -1,0 +1,246 @@
+# Materialized Lake View Patterns — Skill Resource
+
+Public-facing authoring patterns for Microsoft Fabric Materialized Lake Views (MLVs).
+Use this resource when the task is about **writing, reviewing, or restructuring MLV SQL**,
+not when the task is about Spark job triage or broad cross-workload orchestration.
+
+---
+
+## Recommended patterns
+
+### Must
+
+1. **Use deterministic SQL in MLV definitions** — keep transformations stable across refreshes.
+2. **Prefer Delta sources with Change Data Feed (CDF) enabled** for source tables that feed MLVs.
+3. **Use Materialized Lake Views for durable layer outputs**, not for transient notebook-only logic.
+4. **Apply data quality checks close to the source-aligned layer** using `CONSTRAINT ... CHECK ... ON MISMATCH DROP` where appropriate.
+5. **Separate Bronze, Silver, and Gold responsibilities clearly**:
+   - Bronze: raw landing / source-aligned tables
+   - Silver: cleaned and conformed datasets
+   - Gold: business-facing aggregates
+6. **Keep MLVs business-stable** — preserve query semantics unless the user explicitly asks for a redesign.
+7. **Use documented syntax only** — avoid undocumented or implementation-specific features by default.
+
+### Prefer
+
+1. **Source-aligned Silver MLVs first, denormalized Silver MLVs second** — then aggregate in Gold.
+2. **`COUNT` and `SUM` for Gold metrics** when they satisfy the business requirement.
+3. **Downstream notebooks or BI logic** for ranking, moving windows, and presentation formatting.
+4. **Cross-lakehouse 4-part naming** when reading from another workspace/lakehouse.
+5. **Partitioned outputs** when downstream reads are heavily filtered by date or a small set of dimensions.
+6. **Thin Gold MLVs** that serve reusable business outputs instead of embedding every downstream convenience calculation.
+
+### Avoid
+
+1. **Window functions inside MLVs** — move them downstream.
+2. **Non-deterministic functions inside MLVs** — stamp values during ingestion instead.
+3. **`RIGHT JOIN`, `FULL OUTER JOIN`, `CROSS JOIN`** in MLVs intended for incremental refresh.
+4. **`ORDER BY` and `LIMIT`** in MLV definitions.
+5. **Standalone `SELECT DISTINCT`** as a default modeling pattern.
+6. **Embedding moving time windows** like `date_sub(current_date(), 90)` directly in the MLV.
+7. **Using MLVs as a substitute for orchestration** — pipelines and notebooks still own sequencing and validation.
+
+---
+
+## When to use Materialized Lake Views
+
+Choose an MLV when the user needs one or more of the following:
+
+- a durable curated table in a Lakehouse
+- repeatable cleansing or conformance logic
+- pre-joined analytical detail tables
+- reusable aggregate outputs for BI or downstream notebooks
+- a Bronze → Silver → Gold layer implemented directly in Fabric Lakehouse
+
+Do **not** default to MLVs when the task is primarily:
+
+- ad-hoc notebook exploration
+- one-off data movement
+- streaming/event processing
+- Spark job debugging or performance triage
+
+---
+
+## Layering patterns
+
+### Pattern 1: Source-aligned Silver MLV
+
+Use one MLV per important Bronze source when you need:
+
+- type cleanup
+- validation
+- null/range checks
+- basic derived columns
+- a stable foundation for downstream joins
+
+```sql
+CREATE OR REPLACE MATERIALIZED LAKE VIEW silver.orders_clean
+(
+    CONSTRAINT valid_order_id CHECK (order_id IS NOT NULL) ON MISMATCH DROP,
+    CONSTRAINT positive_amount CHECK (amount > 0) ON MISMATCH DROP
+)
+TBLPROPERTIES (delta.enableChangeDataFeed = true)
+PARTITIONED BY (order_date)
+AS
+SELECT
+    order_id,
+    customer_id,
+    order_date,
+    CAST(amount AS DECIMAL(12,2)) AS amount
+FROM bronze.orders;
+```
+
+### Pattern 2: Denormalized Silver MLV
+
+Use a joined Silver MLV when Gold should aggregate over a clean, stable analytical grain.
+
+```sql
+CREATE OR REPLACE MATERIALIZED LAKE VIEW silver.order_details
+TBLPROPERTIES (delta.enableChangeDataFeed = true)
+PARTITIONED BY (order_date)
+AS
+SELECT
+    o.order_id,
+    o.order_date,
+    o.amount,
+    c.customer_name,
+    c.region,
+    p.category
+FROM silver.orders_clean o
+INNER JOIN silver.customers_clean c ON o.customer_id = c.customer_id
+INNER JOIN silver.products_clean p ON o.product_id = p.product_id;
+```
+
+### Pattern 3: Gold aggregate MLV
+
+Use Gold MLVs for business-facing metrics and reusable summary tables.
+
+```sql
+CREATE OR REPLACE MATERIALIZED LAKE VIEW gold.daily_revenue
+AS
+SELECT
+    order_date,
+    region,
+    COUNT(*) AS order_count,
+    SUM(amount) AS total_revenue
+FROM silver.order_details
+GROUP BY order_date, region;
+```
+
+---
+
+## Data quality patterns
+
+Use constraints for deterministic row-level checks.
+
+```sql
+CREATE OR REPLACE MATERIALIZED LAKE VIEW silver.customers_clean
+(
+    CONSTRAINT valid_customer_id CHECK (customer_id IS NOT NULL) ON MISMATCH DROP,
+    CONSTRAINT valid_email CHECK (email LIKE '%@%') ON MISMATCH DROP
+)
+TBLPROPERTIES (delta.enableChangeDataFeed = true)
+AS
+SELECT customer_id, customer_name, email, region
+FROM bronze.customers;
+```
+
+Prefer simple expressions. Keep the logic auditable and easy to explain.
+
+---
+
+## Cross-lakehouse and schema organization
+
+### Cross-lakehouse reads
+
+Use documented 4-part naming when needed:
+
+```sql
+SELECT *
+FROM WorkspaceName.LakehouseName.bronze.orders;
+```
+
+### Schema organization
+
+For medallion-style design, organize tables and MLVs into schemas such as:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS bronze;
+CREATE SCHEMA IF NOT EXISTS silver;
+CREATE SCHEMA IF NOT EXISTS gold;
+```
+
+Keep naming predictable:
+
+- `bronze.orders`
+- `silver.orders_clean`
+- `silver.order_details`
+- `gold.daily_revenue`
+
+---
+
+## Refresh and orchestration guidance
+
+MLVs define durable data products; notebooks and pipelines define execution order.
+
+Recommended refresh order:
+
+1. source-aligned Silver MLVs
+2. denormalized Silver MLVs
+3. Gold MLVs
+4. maintenance steps on a slower cadence
+
+```sql
+REFRESH MATERIALIZED LAKE VIEW silver.orders_clean;
+REFRESH MATERIALIZED LAKE VIEW silver.customers_clean;
+REFRESH MATERIALIZED LAKE VIEW silver.order_details;
+REFRESH MATERIALIZED LAKE VIEW gold.daily_revenue;
+```
+
+---
+
+## Modeling tradeoffs
+
+### Exact distinct counts
+
+If the user requests exact distinct counts, explain that:
+
+- the requirement is valid
+- the design may be less refresh-friendly
+- one option is to pre-deduplicate earlier in the flow
+- another option is to accept that this MLV may not be the most incremental-refresh-friendly shape
+
+### Rankings and moving windows
+
+If the user requests ranking, lag/lead, or moving windows:
+
+- keep the base curated dataset in an MLV
+- move the ranking/window logic to a notebook or consuming layer
+
+### Presentation logic
+
+If the user requests rounding, formatting, or report-only columns:
+
+- store raw business measures in the MLV
+- apply presentation formatting downstream
+
+---
+
+## Routing guidance for the agent
+
+Use this resource when the user asks about:
+
+- materialized lake views
+- MLV authoring
+- designing Silver/Gold tables with MLVs
+- MLV constraints
+- `CREATE MATERIALIZED LAKE VIEW`
+- refresh ordering for MLV-based layers
+- medallion design implemented directly with MLVs
+
+Escalate to `e2e-medallion-architecture` or `FabricDataEngineer` when the request becomes:
+
+- multi-workspace architecture
+- end-to-end Bronze → Silver → Gold orchestration
+- pipeline design across multiple workloads
+- Power BI + Spark + pipeline coordinated rollout

--- a/skills/spark-authoring-cli/resources/mlv-incremental-refresh-patterns.md
+++ b/skills/spark-authoring-cli/resources/mlv-incremental-refresh-patterns.md
@@ -1,0 +1,235 @@
+# MLV Incremental Refresh Patterns — Skill Resource
+
+Public-facing guidance for reviewing and improving **incremental refresh readiness** for
+Microsoft Fabric Materialized Lake Views (MLVs).
+
+Use this resource when the task is about:
+
+- why an MLV may be doing a full refresh
+- how to rewrite an MLV without changing business logic
+- source-table readiness for incremental refresh
+- which SQL patterns are safer for refresh-friendly MLV design
+
+---
+
+## Recommended patterns
+
+### Must
+
+1. **Start from the actual MLV definition** — review the `CREATE MATERIALIZED LAKE VIEW` SQL before suggesting changes.
+2. **Preserve business meaning** — optimize refresh behavior without silently changing the result set.
+3. **Check source prerequisites first**:
+   - Delta or non-Delta
+   - CDF enabled or unknown
+   - append-only or updates/deletes
+4. **Flag hard blockers clearly** before discussing optimization ideas.
+5. **End with a structured readiness report** so the user knows what must change first.
+
+### Prefer
+
+1. **Deterministic SQL only** in MLV definitions.
+2. **Simpler aggregate shapes** such as `COUNT` and `SUM`.
+3. **Stable time filters downstream** instead of moving date windows in the MLV.
+4. **Flatter query shapes** over very deep nesting.
+5. **Downstream handling for ranking, windows, and presentation formatting**.
+
+### Avoid
+
+1. **Window functions** such as `ROW_NUMBER`, `RANK`, `LAG`, `LEAD`.
+2. **Non-deterministic functions** such as `current_timestamp()`, `current_date()`, `rand()`, `uuid()`.
+3. **Unsupported joins** such as `RIGHT JOIN`, `FULL OUTER JOIN`, and `CROSS JOIN`.
+4. **Standalone `SELECT DISTINCT`** when the goal is refresh-friendly design.
+5. **`COUNT(DISTINCT ...)` as the default Gold pattern**.
+6. **Moving date boundaries** such as `date_sub(current_date(), 90)` embedded in the MLV.
+7. **`ORDER BY` and `LIMIT`** in MLV definitions.
+
+---
+
+## Readiness workflow
+
+### Step 1: Identify every source
+
+Capture:
+
+- table name
+- Delta or non-Delta
+- CDF enabled: `✅`, `❌`, or `❓`
+- append-only or updates/deletes
+
+### Step 2: Check hard blockers
+
+Treat the following as strong full-refresh signals:
+
+| Blocker | Examples |
+|---|---|
+| Window functions | `ROW_NUMBER()`, `RANK()`, `LAG()`, `LEAD()` |
+| Unsupported joins | `RIGHT JOIN`, `FULL OUTER JOIN`, `CROSS JOIN` |
+| Ordering and limiting | `ORDER BY`, `LIMIT` |
+| Standalone DISTINCT | `SELECT DISTINCT ...` |
+| DISTINCT aggregates | `COUNT(DISTINCT customer_id)` |
+| Non-deterministic functions | `current_timestamp()`, `current_date()`, `now()`, `rand()`, `uuid()` |
+| Rolling date windows | `date_sub(current_date(), 90)` |
+| Non-Delta sources | CSV, Parquet, JSON, or unmanaged files |
+
+### Step 3: Check caution areas
+
+| Pattern | Public-facing guidance |
+|---|---|
+| `LEFT JOIN` | Review carefully, especially if the right side changes often |
+| `AVG`, `MIN`, `MAX` | Often less refresh-friendly than `COUNT` and `SUM` |
+| Deep nesting | Consider staged Silver MLVs instead of one large all-in-one query |
+| Filter subqueries | Prefer simpler shapes when possible |
+
+### Step 4: Suggest the smallest safe rewrite
+
+Only suggest changes that preserve semantics.
+
+### Step 5: Produce the report
+
+Use this exact structure:
+
+```markdown
+## IR Readiness Report
+
+**Overall Assessment:** [IR-Ready ✅ | Partially Ready ⚠️ | Not IR-Eligible ❌]
+
+### 🚫 Blockers
+### ⚠️ Warnings
+### ✅ Good Practices Detected
+### 📋 Source Table Checklist
+### 💡 Top Recommendations
+```
+
+---
+
+## Safe rewrite patterns
+
+### Pattern 1: Move ranking downstream
+
+❌ Avoid in the MLV:
+
+```sql
+CREATE MATERIALIZED LAKE VIEW gold.latest_orders AS
+SELECT *, ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date DESC) AS rn
+FROM silver.orders;
+```
+
+✅ Keep the MLV deterministic:
+
+```sql
+CREATE MATERIALIZED LAKE VIEW gold.orders_base AS
+SELECT customer_id, order_date, amount
+FROM silver.orders;
+```
+
+Then apply ranking in a notebook or consuming query.
+
+### Pattern 2: Remove moving time windows from the MLV
+
+❌ Avoid:
+
+```sql
+CREATE MATERIALIZED LAKE VIEW gold.recent_sales AS
+SELECT product_id, sale_date, amount
+FROM silver.sales
+WHERE sale_date >= date_sub(current_date(), 90);
+```
+
+✅ Prefer:
+
+```sql
+CREATE MATERIALIZED LAKE VIEW gold.sales_base AS
+SELECT product_id, sale_date, amount
+FROM silver.sales;
+```
+
+Then filter for “last 90 days” in the BI or notebook layer.
+
+### Pattern 3: Prefer simpler aggregates
+
+✅ Good refresh-friendly shape:
+
+```sql
+CREATE MATERIALIZED LAKE VIEW gold.daily_sales AS
+SELECT
+    order_date,
+    region,
+    COUNT(*) AS order_count,
+    SUM(amount) AS total_revenue
+FROM silver.orders
+GROUP BY order_date, region;
+```
+
+If users request averages, explain the tradeoff and prefer storing totals and counts when that still meets the business need.
+
+### Pattern 4: Keep presentation logic downstream
+
+Avoid turning the MLV into a reporting layer. Prefer raw business measures inside the MLV and format later.
+
+---
+
+## Source-table readiness guidance
+
+### Prefer Delta + CDF
+
+```sql
+ALTER TABLE bronze.orders SET TBLPROPERTIES (delta.enableChangeDataFeed = true);
+ALTER TABLE bronze.customers SET TBLPROPERTIES (delta.enableChangeDataFeed = true);
+```
+
+### Prefer stable ingestion behavior
+
+- Fact-like sources: append where practical
+- Dimension-like sources: targeted upserts or merges instead of repeated full overwrites
+
+### For MLV chains
+
+If an MLV feeds another MLV and downstream incremental refresh depends on that chain, enable CDF on the intermediate MLV.
+
+```sql
+CREATE MATERIALIZED LAKE VIEW silver.clean_orders
+TBLPROPERTIES (delta.enableChangeDataFeed = true)
+AS
+SELECT order_id, customer_id, amount
+FROM bronze.orders;
+```
+
+---
+
+## Example assessment language
+
+### IR-Ready ✅
+
+Use when:
+
+- no hard blockers are present
+- source prerequisites appear to be satisfied
+- the query shape is deterministic and stable
+
+### Partially Ready ⚠️
+
+Use when:
+
+- no hard blockers are obvious
+- but source readiness is unknown, or
+- caution areas remain that need validation
+
+### Not IR-Eligible ❌
+
+Use when:
+
+- one or more hard blockers are present in the current definition
+
+---
+
+## Routing guidance for the agent
+
+Use this resource when the user asks:
+
+- “Why is my MLV doing a full refresh?”
+- “Can this MLV use incremental refresh?”
+- “How can I optimize this MLV without changing business logic?”
+- “Is this SQL refresh-friendly?”
+- “What blockers are forcing full refresh?”
+
+Pair it with `materialized-lake-view-patterns.md` when the user is also designing or restructuring the overall Bronze/Silver/Gold MLV flow.


### PR DESCRIPTION
Adds explicit routing hints across the repo so Materialized Lake View (MLV) authoring and incremental-refresh review land on the spark-authoring-cli skill instead of the high-level e2e-medallion-architecture skill.

Changes:
- skills/spark-authoring-cli/SKILL.md: extend scope to cover MLV authoring and refresh-friendly Spark patterns; link new resources.
- skills/spark-authoring-cli/resources/materialized-lake-view-patterns.md (new): canonical MLV authoring patterns.
- skills/spark-authoring-cli/resources/mlv-incremental-refresh-patterns.md (new): incremental refresh patterns and review heuristics.
- skills/e2e-medallion-architecture/SKILL.md: cross-link to the new MLV resources from the PREFER section; no content duplication.
- agents/FabricDataEngineer.agent.md: extend delegation to cover MLV authoring and add a "Routing split for MLV work" note.
- AGENTS.md, CLAUDE.md, .cursorrules, .windsurfrules: routing-hint additions so MLV-related prompts pick spark-authoring-cli.
- README.md: mention MLVs in the Lakehouse bundle and add two example prompts (medallion-with-MLVs and CREATE MATERIALIZED LAKE VIEW review).