### PR TITLE
feat: add PowerBIReportGenerator agent and pbir-generator.js

### DIFF
--- a/agents/PowerBIReportGenerator.agent.md
+++ b/agents/PowerBIReportGenerator.agent.md
@@ -1,0 +1,144 @@
+---
+name: PowerBIReportGenerator
+description: >
+  Generate a complete Power BI Project (PBIP) from a natural language description of the report.
+  Use when the user wants to create a new Power BI report from scratch — including embedded sample
+  data, pages, and visuals — without manually building it in Desktop.
+delegates_to:
+  - powerbi-report-authoring
+---
+
+# PowerBIReportGenerator — Report File Generator Agent
+
+## Purpose
+
+Generate all Power BI Project (PBIP) files needed for a new report from a plain-English description.
+This includes the semantic model (with embedded inline data), report pages, and visuals — all written
+to disk in the correct PBIR format ready to open in Power BI Desktop.
+
+## Generator Tool
+
+The generator lives at:
+```
+skills/powerbi-report-authoring/pbir-generator.js
+```
+
+Run it with Node.js:
+```bash
+node -e "const {generate} = require('./skills/powerbi-report-authoring/pbir-generator'); generate(config);"
+```
+
+Or write a small driver script (e.g. `generate-my-report.js`) that calls `generate(config)` and run it.
+
+## Workflow
+
+1. **Understand the request** — identify:
+   - What data/subject the report is about
+   - What columns and measures are needed
+   - What pages and chart types make sense
+   - Where to write the output (ask the user if not specified — default to Desktop)
+
+2. **Design the config** — translate the request into a `generate()` config object:
+   - Choose meaningful measure expressions (DAX) for aggregations
+   - Pick appropriate visual types per the table below
+   - Lay out visuals with non-overlapping positions (x, y, width, height)
+   - Keep page count to 2–4; keep visual count per page to 2–4
+
+3. **Write a driver script** — create a small `.js` file containing the config and `require('./pbir-generator')` call
+
+4. **Run it** — execute with `node <driver-script>.js`
+
+5. **Open and validate** — use `powerbi-desktop open` to open the generated `.pbip`, then `powerbi-desktop screenshot-all` to capture all pages and review
+
+## Visual Type Reference
+
+| Intent | `type` value | Required fields |
+|--------|-------------|-----------------|
+| Compare values by category (vertical bars) | `clusteredColumnChart` | `category` (column name), `measure` (measure name) |
+| KPI summary numbers | `cardVisual` | `measures` (array of measure names) |
+| Full data grid | `tableEx` | `columns` (array of column names) |
+
+## PBIR Format Rules (Critical)
+
+- **Page IDs must be bare 20 lowercase hex chars** — e.g. `fa790b79ee085a2e07e2`. Never use `ReportSection` prefix — Desktop v2.155+ silently ignores those pages.
+- **Visual IDs must be bare 20 lowercase hex chars** — same rule.
+- **All JSON files must be UTF-8 without BOM** — use `[System.Text.UTF8Encoding]::new($false)` in PowerShell or `{ encoding: 'utf8' }` in Node.js (not `Set-Content -Encoding utf8` which adds BOM).
+- **Measure fields**: use `{ "Measure": { "Expression": { "SourceRef": { "Entity": "<table>" } }, "Property": "<name>" } }`
+- **Column fields**: use `{ "Column": { "Expression": { "SourceRef": { "Entity": "<table>" } }, "Property": "<name>" } }`
+- **definition.pbism** must contain only `{ "version": "1.0" }` — no `fromCloudStorage` field.
+- **`.pbip` manifest** must use `{ "report": { "path": "<Name>.Report" } }` — no `byPath` nesting, no `settings` block.
+
+## Example Config
+
+```js
+const config = {
+  outputDir: 'C:\\Users\\kevin\\Desktop\\SalesReport',
+  reportName: 'SalesReport',
+  semanticModel: {
+    entity: 'Sales',
+    source: 'inline',
+    columns: [
+      { name: 'Region',   dataType: 'string' },
+      { name: 'Product',  dataType: 'string' },
+      { name: 'Revenue',  dataType: 'int64'  },
+      { name: 'Units',    dataType: 'int64'  },
+    ],
+    measures: [
+      { name: 'Total Revenue', expression: 'SUM(Sales[Revenue])', formatString: '#,0' },
+      { name: 'Total Units',   expression: 'SUM(Sales[Units])',   formatString: '#,0' },
+      { name: 'Avg Revenue',   expression: 'AVERAGE(Sales[Revenue])', formatString: '#,0' },
+    ],
+    rows: [
+      ['North', 'Widget A', 120000, 450],
+      ['South', 'Widget B',  85000, 310],
+      ['East',  'Widget A',  96000, 380],
+      ['West',  'Widget C', 140000, 520],
+    ],
+  },
+  pages: [
+    {
+      name: 'Overview',
+      visuals: [
+        {
+          type: 'cardVisual',
+          measures: ['Total Revenue', 'Total Units', 'Avg Revenue'],
+          position: { x: 20, y: 20, z: 1000, height: 120, width: 1240, tabOrder: 1000 },
+        },
+        {
+          type: 'clusteredColumnChart',
+          category: 'Region',
+          measure: 'Total Revenue',
+          position: { x: 20, y: 160, z: 2000, height: 540, width: 1240, tabOrder: 2000 },
+        },
+      ],
+    },
+    {
+      name: 'Detail',
+      visuals: [
+        {
+          type: 'tableEx',
+          columns: ['Region', 'Product', 'Revenue', 'Units'],
+          position: { x: 20, y: 20, z: 1000, height: 680, width: 1240, tabOrder: 1000 },
+        },
+      ],
+    },
+  ],
+};
+```
+
+## After Generation
+
+Once `generate(config)` succeeds:
+
+1. Run `powerbi-report-author validate "<outputDir>/<reportName>.Report"` — expect 0 errors
+2. Run `powerbi-desktop open "<outputDir>/<reportName>.pbip" --timeout 90`
+3. Run `powerbi-desktop reload --pid <pid>` then wait 5–10 seconds
+4. Run `powerbi-desktop screenshot-all --pid <pid> --output-dir "<outputDir>/screenshots"`
+5. Review screenshots — the data banner "Some tables have incomplete data" is normal; user clicks Refresh in Desktop to load inline data
+
+## What This Agent Does NOT Handle
+
+- Reports connected to live Fabric datasets (use `powerbi-report-authoring` skill for those)
+- Complex DAX measures beyond simple aggregations
+- Custom themes, slicers, filters, drillthrough pages
+- Publishing to the Fabric service (use `powerbi-report-management` skill)

--- a/agents/PowerBISchemaGuard.agent.md
+++ b/agents/PowerBISchemaGuard.agent.md
@@ -1,0 +1,265 @@
+---
+name: PowerBISchemaGuard
+description: >
+  Review a proposed Power BI semantic model design for star-schema violations and DAX cardinal sins
+  before report generation. Acts as a quality gate between the user's data model idea and
+  PowerBIReportGenerator — blocks generation until all blocking errors are resolved.
+delegates_to:
+  - powerbi-report-authoring
+---
+
+# PowerBISchemaGuard — Star Schema Quality Gatekeeper
+
+## Purpose
+
+Stop bad models from becoming bad reports. Before any call to `PowerBIReportGenerator`, this agent:
+
+1. Runs the deterministic JS validator (`schema-validator.js`) against the proposed schema
+2. Applies judgment-based checks the validator cannot detect
+3. Presents a structured verdict: **PASS**, **WARN**, or **BLOCK**
+4. If BLOCK: explains every sin, proposes a corrected schema, and refuses to hand off to the generator
+5. If PASS/WARN: optionally hands off to `PowerBIReportGenerator` with the approved schema
+
+---
+
+## Validator Tool
+
+The deterministic validator lives at:
+
+```
+skills/powerbi-report-authoring/schema-validator.js
+```
+
+Run it from Node.js:
+
+```js
+const { validate } = require('./skills/powerbi-report-authoring/schema-validator');
+const result = validate(schema);
+console.log(result.summary);
+// result.passed  → boolean (errors only; warnings don't block)
+// result.errors  → [{ code, message, table?, column?, measure?, relationship? }]
+// result.warnings → [same shape]
+```
+
+---
+
+## Schema Input Format
+
+The validator expects a schema object describing the **semantic model design**, not the data itself.
+This is separate from the `generate()` config — it describes table types, relationships, and measures:
+
+```js
+{
+  tables: [
+    {
+      name: "FactSales",
+      type: "fact",          // "fact" | "dimension" | "date" | "measures" | "bridge"
+      columns: [
+        { name: "DateKey",      dataType: "int64",   isHidden: true },
+        { name: "ProductKey",   dataType: "int64",   isHidden: true },
+        { name: "Revenue",      dataType: "decimal"  },
+        { name: "Units",        dataType: "int64"    },
+      ],
+      measures: [
+        { name: "Total Revenue", expression: "SUM(FactSales[Revenue])", formatString: "#,0" },
+        { name: "Total Units",   expression: "SUM(FactSales[Units])",   formatString: "#,0" },
+      ]
+    },
+    {
+      name: "DimDate",
+      type: "date",
+      isDateTable: true,
+      dateColumn: "Date",
+      columns: [
+        { name: "DateKey", dataType: "int64" },
+        { name: "Date",    dataType: "date"  },
+        { name: "Year",    dataType: "int64" },
+        { name: "Month",   dataType: "string" },
+      ]
+    },
+    {
+      name: "DimProduct",
+      type: "dimension",
+      columns: [
+        { name: "ProductKey",  dataType: "int64"  },
+        { name: "ProductName", dataType: "string" },
+        { name: "Category",    dataType: "string" },
+      ]
+    },
+    {
+      name: "_Measures",
+      type: "measures"   // hidden table for consolidated measures
+    }
+  ],
+  relationships: [
+    {
+      fromTable: "FactSales",
+      fromColumn: "DateKey",
+      toTable: "DimDate",
+      toColumn: "DateKey",
+      cardinality: "many-to-one",
+      crossFilterDirection: "single"
+    },
+    {
+      fromTable: "FactSales",
+      fromColumn: "ProductKey",
+      toTable: "DimProduct",
+      toColumn: "ProductKey",
+      cardinality: "many-to-one",
+      crossFilterDirection: "single"
+    }
+  ]
+}
+```
+
+---
+
+## Cardinal Sins — What the Validator Checks
+
+### Blocking Errors (stop generation)
+
+| Code | Sin | Why It Matters |
+|------|-----|----------------|
+| `FLAT_TABLE` | Single denormalized table | No filter propagation, massive redundancy, slow performance |
+| `NO_FACT_TABLE` | Multiple tables but none marked `fact` | Ambiguous model; relationships will be wrong |
+| `NO_DATE_DIMENSION` | Date columns but no date dimension table | Time intelligence functions (DATESYTD, SAMEPERIODLASTYEAR) won't work |
+| `MANY_TO_MANY` | M:M relationship without bridge table | Unpredictable filter results, double-counting |
+| `BIDIRECTIONAL_FILTER` | Both-direction cross-filter | Filter ambiguity, circular dependencies, performance hit |
+| `STRING_RELATIONSHIP_KEY` | Text column as relationship key | Case-sensitivity bugs, slow joins, referential integrity failures |
+| `TEXT_IN_FACT` | Descriptive text columns in fact table | Dimension data repeated per row; move to a dimension table |
+| `AGGREGATION_IN_COLUMN` | SUM/AVERAGE/etc. in a calculated column | Columns are row-level; they can't aggregate across filter context |
+| `COUNT_NOT_COUNTROWS` | `COUNT(column)` in a measure | DAX COUNT() ignores blanks; COUNTROWS() is explicit and faster |
+
+### Warnings (review before proceeding)
+
+| Code | Sin | Guidance |
+|------|-----|----------|
+| `SNOWFLAKE_SCHEMA` | Dimension joined to dimension | Denormalize unless table is huge (>1M rows) |
+| `HARDCODED_VALUE` | Magic number in a measure | Use a parameter/config table instead |
+| `FK_NOT_HIDDEN` | Surrogate key visible to users | Hide all key columns — they have no report meaning |
+| `SCATTERED_MEASURES` | Measures in 3+ tables | Consolidate into `_Measures` table |
+| `MIXED_GRANULARITY` | Header + line data in same fact | Split into FactOrderHeader and FactOrderLine |
+
+---
+
+## Judgment-Based Checks (Agent Layer)
+
+These cannot be automated — apply them with reasoning:
+
+1. **Missing dimensions**: Ask "what will users slice/filter by?" — if those slices aren't in the schema, flag them as missing dimensions.
+
+2. **Wrong grain in fact table**: Verify that the described fact table rows all represent the same event or measurement. If the user says "one row per sale" but also wants "monthly targets", that's two fact tables.
+
+3. **Date spine completeness**: If reporting over time, confirm the date dimension covers the full range needed, including future dates for forecasting rows.
+
+4. **Measure completeness**: Are the core business questions answerable from the proposed measures? E.g. "compare this year vs last year" requires a date dimension, a time intelligence measure, and a proper calendar — not just a `SUM()`.
+
+5. **Naming conventions**: Table names should be `FactXxx` / `DimXxx` / `_Measures`. Column names should be business-readable, not technical (e.g. `OrderDate` not `ord_dt`).
+
+6. **Intentional flat-table exception**: A single-table schema is acceptable **only** for:
+   - Prototypes and demos with synthetic inline data (like the IdleHeroes example)
+   - Reports with no time intelligence, no slicing, and 5 or fewer columns
+   - Explicitly confirmed by the user as "I know this is flat, proceed anyway"
+   In all other cases, enforce the star schema requirement.
+
+---
+
+## Workflow
+
+### Step 1 — Elicit the schema design
+
+If the user hasn't provided a schema, ask:
+
+> "Before I generate the report, tell me about the data model:
+> - What tables will exist and what type is each (fact, dimension, date)?
+> - What are the relationships between them?
+> - What measures do you need?
+> - What will users filter/slice by?"
+
+Or, if the user provides a description in plain English, translate it into the schema format above before running the validator.
+
+### Step 2 — Run the deterministic validator
+
+```bash
+node -e "
+const { validate } = require('./skills/powerbi-report-authoring/schema-validator');
+const schema = <paste schema here>;
+const r = validate(schema);
+console.log(r.summary);
+process.exit(r.passed ? 0 : 1);
+"
+```
+
+### Step 3 — Apply judgment checks
+
+Review the schema against the judgment-based checks above. Note any issues.
+
+### Step 4 — Render the verdict
+
+**BLOCK** (errors found):
+```
+🚫 BLOCKED — Schema has N cardinal sin(s) that must be fixed before generating.
+
+[list each error with explanation and fix]
+
+Proposed fix:
+[corrected schema]
+
+Re-run the validator against the corrected schema, then proceed to generation.
+```
+
+**WARN** (warnings only, no errors):
+```
+⚠️  WARNINGS — Schema passes blocking checks but has N improvement(s):
+
+[list each warning with explanation]
+
+You may proceed to generation, but consider addressing these before going to production.
+```
+
+**PASS** (clean):
+```
+✅ PASS — Schema is clean. Handing off to PowerBIReportGenerator.
+```
+
+### Step 5 — Hand off to PowerBIReportGenerator (on PASS/WARN)
+
+Translate the validated schema into a `generate()` config and pass it to `PowerBIReportGenerator`.
+The semantic model in the generator config must match the validated schema exactly.
+
+---
+
+## Example: Catching a Cardinal Sin
+
+**User says:** "I want a report on sales. I'll put everything in one table — Region, Product, Salesperson, Revenue, Date."
+
+**Guard's response:**
+
+> Running schema validator...
+>
+> 🚫 BLOCKED — 2 cardinal sins detected:
+>
+> **[FLAT_TABLE]** Single denormalized table detected. This puts Region, Product, Salesperson in the fact table as repeating text — no filter propagation, poor performance, and impossible to use time intelligence.
+>
+> **[NO_DATE_DIMENSION]** Date column present but no date dimension. `DATESYTD`, `SAMEPERIODLASTYEAR`, and all standard time intelligence functions require a proper date table marked as a date table.
+>
+> **Proposed fix:**
+>
+> Split into a star schema:
+> - `FactSales` (fact): SalesKey, DateKey, ProductKey, SalespersonKey, Revenue
+> - `DimDate` (date): DateKey, Date, Year, Quarter, Month, Week
+> - `DimProduct` (dimension): ProductKey, ProductName, Category
+> - `DimSalesperson` (dimension): SalespersonKey, SalespersonName, Region
+>
+> Relationships: FactSales → DimDate (DateKey), FactSales → DimProduct (ProductKey), FactSales → DimSalesperson (SalespersonKey), all many-to-one, single-direction.
+>
+> Correct the design and I'll generate the report.
+
+---
+
+## What This Agent Does NOT Handle
+
+- Validating DAX correctness (syntax, column references) — use the Power BI Desktop DAX engine
+- Checking data quality or completeness in the actual rows
+- Performance benchmarking of a deployed model
+- Publishing to the Fabric service (use `powerbi-report-management`)

--- a/skills/powerbi-report-authoring/pbir-generator.js
+++ b/skills/powerbi-report-authoring/pbir-generator.js
@@ -1,0 +1,322 @@
+/**
+ * PBIR Report Generator
+ *
+ * Generates a complete Power BI Project (PBIP) from a config object.
+ *
+ * Key format rules discovered from Desktop v2.155.xxx (June 2026):
+ *  - Page IDs must be bare 20 lowercase hex chars — ReportSection+24hex is silently rejected
+ *  - Visual IDs must be bare 20 lowercase hex chars
+ *  - All JSON files must be UTF-8 without BOM
+ *  - Visual field expressions: use Measure{} for named measures, Column{} for columns
+ *
+ * Usage:
+ *   const { generate } = require('./pbir-generator');
+ *   generate(config);
+ *
+ * Config shape:
+ * {
+ *   outputDir: string,           // root folder, e.g. "C:\\Reports\\MyReport"
+ *   reportName: string,          // e.g. "MyReport"
+ *   semanticModel: {
+ *     entity: string,            // table name in the model
+ *     source: "inline" | "path",
+ *     // if source === "inline":
+ *     columns: [{ name, dataType }],   // dataType: "string" | "int64" | "double"
+ *     measures: [{ name, expression, formatString? }],
+ *     rows: Array<Array<any>>,
+ *     // if source === "path":
+ *     modelPath: string,         // relative path to existing .SemanticModel folder
+ *   },
+ *   pages: [
+ *     {
+ *       name: string,            // display name
+ *       visuals: [
+ *         // Clustered column chart
+ *         { type: "clusteredColumnChart", category: string, measure: string, position?: {...} }
+ *         // Card (multi-value)
+ *         { type: "cardVisual", measures: string[], position?: {...} }
+ *         // Table
+ *         { type: "tableEx", columns: string[], position?: {...} }
+ *       ]
+ *     }
+ *   ]
+ * }
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+// ── Utilities ──────────────────────────────────────────────────────────────
+
+function hex20() {
+  return crypto.randomBytes(10).toString('hex');  // 20 hex chars
+}
+
+const utf8NoBom = { encoding: 'utf8' };
+
+function mkdirp(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeJson(filePath, obj) {
+  mkdirp(path.dirname(filePath));
+  fs.writeFileSync(filePath, JSON.stringify(obj, null, 2), utf8NoBom);
+}
+
+// ── Field expression builders ──────────────────────────────────────────────
+
+function sourceRef(entity) {
+  return { SourceRef: { Entity: entity } };
+}
+
+function measureField(entity, property) {
+  return { Measure: { Expression: sourceRef(entity), Property: property } };
+}
+
+function columnField(entity, property) {
+  return { Column: { Expression: sourceRef(entity), Property: property } };
+}
+
+function measureProjection(entity, prop) {
+  return {
+    field: measureField(entity, prop),
+    queryRef: `${entity}.${prop}`,
+    nativeQueryRef: prop,
+  };
+}
+
+function columnProjection(entity, prop, active = false) {
+  const p = {
+    field: columnField(entity, prop),
+    queryRef: `${entity}.${prop}`,
+    nativeQueryRef: prop,
+  };
+  if (active) p.active = true;
+  return p;
+}
+
+// ── Visual builders ────────────────────────────────────────────────────────
+
+const VIS_SCHEMA =
+  'https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.9.0/schema.json';
+
+function defaultPos(overrides, defaults) {
+  return Object.assign({}, defaults, overrides || {});
+}
+
+function buildClusteredColumnChart(entity, cfg, name) {
+  const pos = defaultPos(cfg.position, { x: 20, y: 20, z: 1000, height: 500, width: 600, tabOrder: 1000 });
+  return {
+    $schema: VIS_SCHEMA,
+    name,
+    position: pos,
+    visual: {
+      visualType: 'clusteredColumnChart',
+      query: {
+        queryState: {
+          Category: { projections: [columnProjection(entity, cfg.category, true)] },
+          Y: { projections: [measureProjection(entity, cfg.measure)] },
+        },
+      },
+    },
+  };
+}
+
+function buildCardVisual(entity, cfg, name) {
+  const pos = defaultPos(cfg.position, { x: 20, y: 20, z: 1000, height: 120, width: 1240, tabOrder: 1000 });
+  return {
+    $schema: VIS_SCHEMA,
+    name,
+    position: pos,
+    visual: {
+      visualType: 'cardVisual',
+      query: {
+        queryState: {
+          Data: { projections: cfg.measures.map(m => measureProjection(entity, m)) },
+        },
+      },
+    },
+  };
+}
+
+function buildTableEx(entity, cfg, name) {
+  const pos = defaultPos(cfg.position, { x: 20, y: 20, z: 1000, height: 680, width: 1240, tabOrder: 1000 });
+  return {
+    $schema: VIS_SCHEMA,
+    name,
+    position: pos,
+    visual: {
+      visualType: 'tableEx',
+      query: {
+        queryState: {
+          Values: { projections: cfg.columns.map(c => columnProjection(entity, c)) },
+        },
+      },
+    },
+  };
+}
+
+function buildVisual(entity, cfg) {
+  const name = hex20();
+  switch (cfg.type) {
+    case 'clusteredColumnChart': return buildClusteredColumnChart(entity, cfg, name);
+    case 'cardVisual':           return buildCardVisual(entity, cfg, name);
+    case 'tableEx':              return buildTableEx(entity, cfg, name);
+    default: throw new Error(`Unknown visual type: ${cfg.type}`);
+  }
+}
+
+// ── Semantic model builder ────────────────────────────────────────────────
+
+function buildModelBim(entity, sm) {
+  const typeMap = { string: 'text', int64: 'Int64.Type', double: 'Double.Type', number: 'Double.Type' };
+  const colDefs = sm.columns.map(c => `${c.name} = ${typeMap[c.dataType] || 'text'}`).join(', ');
+  const rowLines = sm.rows.map(row => {
+    const vals = row.map(v => typeof v === 'string' ? `"${v}"` : v).join(', ');
+    return `            {${vals}}`;
+  });
+
+  const mExpr = [
+    'let',
+    `    Source = #table(`,
+    `        type table [${colDefs}],`,
+    '        {',
+    rowLines.join(',\n'),
+    '        }',
+    '    )',
+    'in',
+    '    Source',
+  ];
+
+  const bimColumns = sm.columns.map(c => ({
+    name: c.name,
+    dataType: c.dataType === 'string' ? 'string' : 'int64',
+    sourceColumn: c.name,
+  }));
+
+  const bimMeasures = (sm.measures || []).map(m => ({
+    name: m.name,
+    expression: m.expression,
+    ...(m.formatString ? { formatString: m.formatString } : {}),
+  }));
+
+  return {
+    compatibilityLevel: 1567,
+    model: {
+      culture: 'en-US',
+      dataAccessOptions: { legacyRedirects: true, returnErrorValuesAsNull: true },
+      defaultPowerBIDataSourceVersion: 'powerBI_V3',
+      sourceQueryCulture: 'en-US',
+      tables: [{
+        name: entity,
+        columns: bimColumns,
+        measures: bimMeasures,
+        partitions: [{
+          name: entity,
+          dataView: 'full',
+          source: { type: 'm', expression: mExpr },
+        }],
+      }],
+      relationships: [],
+      annotations: [{ name: 'PBIDesktopVersion', value: '2.131.901.0 (24.07)' }],
+    },
+  };
+}
+
+// ── Main generate function ─────────────────────────────────────────────────
+
+const PLATFORM_SCHEMA =
+  'https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json';
+const PAGE_SCHEMA =
+  'https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/2.1.0/schema.json';
+const REPORT_SCHEMA =
+  'https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/3.3.0/schema.json';
+const PAGES_SCHEMA =
+  'https://developer.microsoft.com/json-schemas/fabric/item/report/definition/pagesMetadata/1.0.0/schema.json';
+
+function generate(config) {
+  const { outputDir, reportName, semanticModel: sm, pages } = config;
+  const entity = sm.entity;
+
+  // ── Semantic Model ────────────────────────────────────────────────────
+  const smDir = path.join(outputDir, `${reportName}.SemanticModel`);
+
+  writeJson(path.join(smDir, '.platform'), {
+    $schema: PLATFORM_SCHEMA,
+    metadata: { type: 'SemanticModel', displayName: reportName },
+    config: {
+      version: '2.0',
+      logicalId: crypto.randomUUID(),
+    },
+  });
+
+  writeJson(path.join(smDir, 'definition.pbism'), { version: '1.0' });
+
+  if (sm.source === 'inline') {
+    writeJson(path.join(smDir, 'model.bim'), buildModelBim(entity, sm));
+  }
+
+  // ── Report ────────────────────────────────────────────────────────────
+  const rDir = path.join(outputDir, `${reportName}.Report`);
+  const smRelPath = sm.source === 'path' ? sm.modelPath : `../${reportName}.SemanticModel`;
+
+  writeJson(path.join(rDir, '.platform'), {
+    $schema: PLATFORM_SCHEMA,
+    metadata: { type: 'Report', displayName: reportName },
+    config: { version: '2.0', logicalId: crypto.randomUUID() },
+  });
+
+  writeJson(path.join(rDir, 'definition.pbir'), {
+    version: '4.0',
+    datasetReference: { byPath: { path: smRelPath } },
+  });
+
+  writeJson(path.join(rDir, 'definition', 'version.json'), { version: '2.0.0' });
+  writeJson(path.join(rDir, 'definition', 'report.json'), { $schema: REPORT_SCHEMA, themeCollection: {} });
+
+  // ── Pages ─────────────────────────────────────────────────────────────
+  const pageIds = pages.map(() => hex20());
+
+  writeJson(path.join(rDir, 'definition', 'pages', 'pages.json'), {
+    $schema: PAGES_SCHEMA,
+    pageOrder: pageIds,
+    activePageName: pageIds[0],
+  });
+
+  pages.forEach((page, i) => {
+    const pageId  = pageIds[i];
+    const pageDir = path.join(rDir, 'definition', 'pages', pageId);
+
+    writeJson(path.join(pageDir, 'page.json'), {
+      $schema: PAGE_SCHEMA,
+      name: pageId,
+      displayName: page.name,
+      displayOption: 'FitToPage',
+      height: 720,
+      width: 1280,
+    });
+
+    mkdirp(path.join(pageDir, 'visuals'));
+
+    (page.visuals || []).forEach(visCfg => {
+      const vis    = buildVisual(entity, visCfg);
+      const visDir = path.join(pageDir, 'visuals', vis.name);
+      writeJson(path.join(visDir, 'visual.json'), vis);
+    });
+  });
+
+  // ── .pbip manifest ────────────────────────────────────────────────────
+  writeJson(path.join(outputDir, `${reportName}.pbip`), {
+    version: '1.0',
+    artifacts: [{ report: { path: `${reportName}.Report` } }],
+  });
+
+  console.log(`Generated: ${path.join(outputDir, reportName + '.pbip')}`);
+  console.log(`Pages: ${pages.map((p, i) => `${p.name} (${pageIds[i]})`).join(', ')}`);
+  return { outputDir, reportName, pageIds };
+}
+
+module.exports = { generate };

--- a/skills/powerbi-report-authoring/schema-validator.js
+++ b/skills/powerbi-report-authoring/schema-validator.js
@@ -1,0 +1,341 @@
+/**
+ * Power BI Schema Validator
+ *
+ * Deterministic star-schema and DAX quality checks.
+ * Call validate(schema) before generating any PBIP with pbir-generator.js.
+ *
+ * Schema shape:
+ * {
+ *   tables: [
+ *     {
+ *       name: string,
+ *       type: "fact" | "dimension" | "date" | "measures" | "bridge",
+ *       isDateTable?: boolean,       // true for the date dimension
+ *       dateColumn?: string,         // name of the Date column in date table
+ *       columns: [
+ *         {
+ *           name: string,
+ *           dataType: "string" | "int64" | "decimal" | "date" | "datetime" | "boolean",
+ *           isHidden?: boolean,
+ *         }
+ *       ],
+ *       measures?: [
+ *         { name: string, expression: string, formatString?: string }
+ *       ]
+ *     }
+ *   ],
+ *   relationships: [
+ *     {
+ *       fromTable: string,           // many side
+ *       fromColumn: string,
+ *       toTable: string,             // one side
+ *       toColumn: string,
+ *       cardinality: "many-to-one" | "one-to-one" | "many-to-many",
+ *       crossFilterDirection: "single" | "both",
+ *       isActive?: boolean,          // defaults true
+ *     }
+ *   ]
+ * }
+ *
+ * Returns:
+ * {
+ *   passed: boolean,
+ *   errorCount: number,
+ *   warningCount: number,
+ *   errors:   [{ code, message, table?, column?, relationship?, measure? }],
+ *   warnings: [{ code, message, table?, column?, relationship?, measure? }],
+ *   summary: string,
+ * }
+ */
+
+'use strict';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function tablesByType(schema, type) {
+  return schema.tables.filter(t => t.type === type);
+}
+
+function findTable(schema, name) {
+  return schema.tables.find(t => t.name === name);
+}
+
+function findColumn(table, name) {
+  return (table.columns || []).find(c => c.name === name);
+}
+
+function hasDateLikeColumn(table) {
+  return (table.columns || []).some(c =>
+    c.dataType === 'date' || c.dataType === 'datetime' ||
+    /date/i.test(c.name)
+  );
+}
+
+// ── Individual checks ──────────────────────────────────────────────────────
+
+function checkFlatTable(schema, errors) {
+  const nonMeasureTables = schema.tables.filter(t => t.type !== 'measures');
+  if (nonMeasureTables.length === 1) {
+    errors.push({
+      code: 'FLAT_TABLE',
+      message:
+        `Only one table ('${nonMeasureTables[0].name}') — this is a flat/denormalized design. ` +
+        `Split into a fact table and dimension tables to build a proper star schema.`,
+      table: nonMeasureTables[0].name,
+    });
+  }
+}
+
+function checkNoFactTable(schema, errors) {
+  const nonMeasureTables = schema.tables.filter(t => t.type !== 'measures');
+  if (nonMeasureTables.length > 1 && tablesByType(schema, 'fact').length === 0) {
+    errors.push({
+      code: 'NO_FACT_TABLE',
+      message:
+        `No table is marked type 'fact'. A star schema requires at least one central fact table ` +
+        `containing measurable, additive values (revenue, quantity, duration, etc.).`,
+    });
+  }
+}
+
+function checkNoDateDimension(schema, errors) {
+  const dateTables = schema.tables.filter(t => t.type === 'date' || t.isDateTable);
+  const tablesNeedingDates = schema.tables.filter(
+    t => t.type !== 'measures' && hasDateLikeColumn(t)
+  );
+  if (tablesNeedingDates.length > 0 && dateTables.length === 0) {
+    errors.push({
+      code: 'NO_DATE_DIMENSION',
+      message:
+        `Date/datetime columns detected but no date dimension table exists. ` +
+        `Create a dedicated DimDate table, mark it as a date table, and relate all date columns to it. ` +
+        `Never rely on Power BI's auto date/time feature in production models.`,
+    });
+  }
+}
+
+function checkRelationships(schema, errors, warnings) {
+  if (!schema.relationships || schema.relationships.length === 0) return;
+
+  const dimNames = tablesByType(schema, 'dimension').map(t => t.name);
+
+  schema.relationships.forEach(rel => {
+    const fromTable = findTable(schema, rel.fromTable);
+    const toTable   = findTable(schema, rel.toTable);
+
+    // Many-to-many
+    if (rel.cardinality === 'many-to-many') {
+      errors.push({
+        code: 'MANY_TO_MANY',
+        message:
+          `Relationship ${rel.fromTable}[${rel.fromColumn}] → ${rel.toTable}[${rel.toColumn}] ` +
+          `is many-to-many. Use a bridge/junction table and two many-to-one relationships instead.`,
+        relationship: rel,
+      });
+    }
+
+    // Bidirectional cross-filter
+    if (rel.crossFilterDirection === 'both') {
+      errors.push({
+        code: 'BIDIRECTIONAL_FILTER',
+        message:
+          `Relationship ${rel.fromTable} → ${rel.toTable} uses bidirectional cross-filter. ` +
+          `This causes filter ambiguity, unpredictable results, and performance degradation. ` +
+          `Use single-direction filtering and CROSSFILTER() / USERELATIONSHIP() in DAX when needed.`,
+        relationship: rel,
+      });
+    }
+
+    // String/text relationship keys
+    if (fromTable) {
+      const col = findColumn(fromTable, rel.fromColumn);
+      if (col && col.dataType === 'string') {
+        errors.push({
+          code: 'STRING_RELATIONSHIP_KEY',
+          message:
+            `${rel.fromTable}[${rel.fromColumn}] is a string column used as a relationship key. ` +
+            `Use integer surrogate keys for all relationships — strings are slow and error-prone.`,
+          table: rel.fromTable,
+          column: rel.fromColumn,
+        });
+      }
+    }
+    if (toTable) {
+      const col = findColumn(toTable, rel.toColumn);
+      if (col && col.dataType === 'string') {
+        errors.push({
+          code: 'STRING_RELATIONSHIP_KEY',
+          message:
+            `${rel.toTable}[${rel.toColumn}] is a string column used as a relationship key. ` +
+            `Use integer surrogate keys for all relationships — strings are slow and error-prone.`,
+          table: rel.toTable,
+          column: rel.toColumn,
+        });
+      }
+    }
+
+    // Snowflake: dimension → dimension relationship
+    if (dimNames.includes(rel.fromTable) && dimNames.includes(rel.toTable)) {
+      warnings.push({
+        code: 'SNOWFLAKE_SCHEMA',
+        message:
+          `Dimension '${rel.fromTable}' has a relationship to dimension '${rel.toTable}'. ` +
+          `This creates a snowflake schema. Denormalize into a single flattened dimension unless ` +
+          `table size makes denormalization impractical.`,
+        relationship: rel,
+      });
+    }
+  });
+}
+
+function checkFactTableTextColumns(schema, errors) {
+  tablesByType(schema, 'fact').forEach(fact => {
+    const suspectCols = (fact.columns || []).filter(c =>
+      c.dataType === 'string' &&
+      !/key$/i.test(c.name) &&
+      !/_key$/i.test(c.name) &&
+      !/_id$/i.test(c.name) &&
+      !c.isHidden
+    );
+    if (suspectCols.length > 0) {
+      errors.push({
+        code: 'TEXT_IN_FACT',
+        message:
+          `Fact table '${fact.name}' contains text columns that likely belong in dimensions: ` +
+          suspectCols.map(c => c.name).join(', ') + `. ` +
+          `Move descriptive text to dimension tables and join via surrogate key.`,
+        table: fact.name,
+        columns: suspectCols.map(c => c.name),
+      });
+    }
+  });
+}
+
+function checkMeasures(schema, errors, warnings) {
+  const aggInColPattern   = /^=?\s*(SUM|AVERAGE|MAX|MIN|COUNT|COUNTROWS)\s*\(/i;
+  const countPattern      = /\bCOUNT\s*\(\s*[^)]+\)/i;
+  const countRowsPattern  = /\bCOUNTROWS\s*\(/i;
+  const hardcodedPattern  = /[=<>!]=?\s*\d{4,}/;
+
+  schema.tables.forEach(table => {
+    // Aggregation logic in calculated columns (heuristic: column names look like measures)
+    (table.columns || []).forEach(col => {
+      if (col.expression && aggInColPattern.test(col.expression)) {
+        errors.push({
+          code: 'AGGREGATION_IN_COLUMN',
+          message:
+            `Column '${table.name}[${col.name}]' contains aggregation logic (${col.expression.trim().slice(0, 40)}…). ` +
+            `Aggregations belong in measures, not calculated columns — columns are computed row-by-row ` +
+            `and cannot adapt to filter context.`,
+          table: table.name,
+          column: col.name,
+        });
+      }
+    });
+
+    // COUNT() instead of COUNTROWS() / DISTINCTCOUNT()
+    (table.measures || []).forEach(m => {
+      if (countPattern.test(m.expression) && !countRowsPattern.test(m.expression)) {
+        errors.push({
+          code: 'COUNT_NOT_COUNTROWS',
+          message:
+            `Measure '${table.name}[${m.name}]' uses COUNT(column) — use COUNTROWS(table) to count ` +
+            `rows or DISTINCTCOUNT(column) for unique values. COUNT() is the Excel habit; DAX has better options.`,
+          table: table.name,
+          measure: m.name,
+        });
+      }
+
+      // Hardcoded thresholds
+      if (hardcodedPattern.test(m.expression)) {
+        warnings.push({
+          code: 'HARDCODED_VALUE',
+          message:
+            `Measure '${table.name}[${m.name}]' may contain a hardcoded numeric threshold. ` +
+            `Consider a parameter table so business users can adjust values without DAX edits.`,
+          table: table.name,
+          measure: m.name,
+        });
+      }
+    });
+  });
+}
+
+function checkHiddenForeignKeys(schema, warnings) {
+  tablesByType(schema, 'fact').forEach(fact => {
+    (fact.columns || [])
+      .filter(c => /key$/i.test(c.name) || /_key$/i.test(c.name) || /_id$/i.test(c.name))
+      .filter(c => !c.isHidden)
+      .forEach(col => {
+        warnings.push({
+          code: 'FK_NOT_HIDDEN',
+          message:
+            `Foreign key '${fact.name}[${col.name}]' is visible to report users. ` +
+            `Set isHidden: true — surrogate keys have no business meaning in a report.`,
+          table: fact.name,
+          column: col.name,
+        });
+      });
+  });
+}
+
+function checkScatteredMeasures(schema, warnings) {
+  const tablesWithMeasures = schema.tables.filter(
+    t => t.type !== 'measures' && t.measures && t.measures.length > 0
+  );
+  if (tablesWithMeasures.length > 2) {
+    warnings.push({
+      code: 'SCATTERED_MEASURES',
+      message:
+        `Measures are spread across ${tablesWithMeasures.length} tables ` +
+        `(${tablesWithMeasures.map(t => t.name).join(', ')}). ` +
+        `Consolidate into a dedicated _Measures table so users have one place to find calculations.`,
+    });
+  }
+}
+
+function checkMixedGranularity(schema, warnings) {
+  // Heuristic: fact table has both header-like and line-like columns
+  tablesByType(schema, 'fact').forEach(fact => {
+    const names = (fact.columns || []).map(c => c.name.toLowerCase());
+    const hasHeader = names.some(n => /order|invoice|contract|header/i.test(n));
+    const hasLine   = names.some(n => /line|item|detail|row/i.test(n));
+    if (hasHeader && hasLine) {
+      warnings.push({
+        code: 'MIXED_GRANULARITY',
+        message:
+          `Fact table '${fact.name}' may mix header-level and line-level data. ` +
+          `Ensure all rows represent the same grain — split into separate fact tables if needed.`,
+        table: fact.name,
+      });
+    }
+  });
+}
+
+// ── Main entry point ───────────────────────────────────────────────────────
+
+function validate(schema) {
+  const errors   = [];
+  const warnings = [];
+
+  checkFlatTable(schema, errors);
+  checkNoFactTable(schema, errors);
+  checkNoDateDimension(schema, errors);
+  checkRelationships(schema, errors, warnings);
+  checkFactTableTextColumns(schema, errors);
+  checkMeasures(schema, errors, warnings);
+  checkHiddenForeignKeys(schema, warnings);
+  checkScatteredMeasures(schema, warnings);
+  checkMixedGranularity(schema, warnings);
+
+  const passed = errors.length === 0;
+  const lines  = [];
+  if (errors.length)   lines.push(`${errors.length} error(s):`  , ...errors.map(e   => `  ✗ [${e.code}] ${e.message}`));
+  if (warnings.length) lines.push(`${warnings.length} warning(s):`, ...warnings.map(w => `  ⚠ [${w.code}] ${w.message}`));
+  if (passed && !warnings.length) lines.push('✓ Schema passed all checks.');
+  else if (passed) lines.push('✓ No blocking errors — review warnings before proceeding.');
+
+  return { passed, errorCount: errors.length, warningCount: warnings.length, errors, warnings, summary: lines.join('\n') };
+}
+
+module.exports = { validate };


### PR DESCRIPTION
## Summary

- Adds `skills/powerbi-report-authoring/pbir-generator.js` — a Node.js module that generates a complete Power BI Project (PBIP) from a config object describing the semantic model, pages, and visuals
- Adds `agents/PowerBIReportGenerator.agent.md` — an agent definition that uses the generator to create Power BI reports from plain-English descriptions

## What changed and why

During a session building a Power BI report comparing Idle Heroes game players, we discovered that Power BI Desktop v2.155+ (June 2026) silently rejects PBIR page IDs using the traditional `ReportSection`+24-hex format. Only bare 20-hex-char page IDs (e.g. `fa790b79ee085a2e07e2`) are recognised. This caused blank Report views with no error message, making it very hard to diagnose.

The generator encodes this and other hard-won format rules so future report creation always produces files Desktop can load:

- Page and visual IDs generated as bare 20 lowercase hex chars
- All JSON written UTF-8 without BOM
- `definition.pbism` contains only `{ "version": "1.0" }` (no `fromCloudStorage`)
- `.pbip` manifest uses flat `{ "report": { "path": "..." } }` (no `byPath` nesting, no `settings`)
- `report.json` always includes required `themeCollection: {}`
- Field expressions use correct `Measure{}` vs `Column{}` shapes

## Supported visual types

| Type | Description |
|------|-------------|
| `clusteredColumnChart` | Vertical bars by category + measure |
| `cardVisual` | Multi-value KPI card |
| `tableEx` | Full data grid |

## Reviewer notes

- The generator is a plain Node.js CommonJS module with no external dependencies
- The agent `.md` includes the full config schema, an example, and post-generation steps (validate, open, reload, screenshot)
- Validated output passes `powerbi-report-author validate` with 0 errors
