### PR TITLE
Add source-independent dbt authoring & consumption skills (verified)

### DIFF
--- a/common/ITEM-DEFINITIONS-CORE.md
+++ b/common/ITEM-DEFINITIONS-CORE.md
@@ -558,7 +558,7 @@ The following item types also support definition APIs. See each spec link for fu
 | KQLQueryset | `RealTimeQueryset.json` | [Spec](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/eventhouse-queryset-definition) |
 | CopyJob | `copyjob-content.json` | [Spec](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/copyjob-definition) |
 | Dataflow | `queryMetadata.json`, `mashup.pq` | [Spec](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/dataflow-definition) |
-| DataBuildToolJob | `dbtjob-content.json` | [Spec](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/dbtjob-definition) |
+| DataBuildToolJob | `dbt-content.json` (live API; docs/spec say `dbtjob-content.json`) + `Code/dbt/*` project files | [Spec](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/dbtjob-definition) |
 | Eventstream | `eventstream.json`, `eventstreamProperties.json` | [Spec](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/eventstream-definition) |
 | EventSchemaSet | `EventSchemaSetDefinition.json` | [Spec](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/eventschemaset-definition) |
 | GraphQLApi | `graphql-definition.json` | [Spec](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/graphql-api-definition) |

--- a/skills/dbt-authoring-cli/SKILL.md
+++ b/skills/dbt-authoring-cli/SKILL.md
@@ -1,0 +1,611 @@
+---
+name: dbt-authoring-cli
+description: >
+  Create, update, delete, and run Fabric dbt jobs (DataBuildToolJob) via CLI (az rest / curl).
+  Uses az rest against the Fabric REST API to manage dbt job definitions containing project settings,
+  profile (adapter type, schema, connection), and command (operation, model selection, arguments).
+  Supports Fabric Warehouse, Snowflake, PostgreSQL, and Azure SQL Server adapters. Use when the
+  user wants to: (1) create a new dbt job in a Fabric workspace, (2) update dbt job settings
+  (project type, profile adapter, command operation), (3) trigger a dbt job run, (4) connect a
+  dbt job to a Fabric Warehouse or external database via connection ID, (5) manage dbt job
+  definitions for CI/CD, (6) delete a dbt job.
+  Triggers: "create dbt job", "dbt job", "dbt run", "dbt build", "dbt test", "dbt models fabric",
+  "DataBuildToolJob", "dbt warehouse", "dbt transformation fabric", "dbt CI/CD fabric".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill (e.g., `/fabric-skills:check-updates`).
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: read the local `package.json` version, then compare it against the remote version via `git fetch origin main --quiet && git show origin/main:package.json` (or the GitHub API). If the remote version is newer, show the changelog and update instructions.
+> - Skip if the check was already performed earlier in this session.
+
+> **CRITICAL NOTES**
+> 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering
+> 2. To find the item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace and, then, use JMESPath filtering
+
+# dbt Jobs — Authoring via CLI
+
+> **When to use this skill vs. alternatives** — use dbt (DataBuildToolJob) for **versioned, multi-model SQL transformations** into a Fabric Warehouse, with lineage, dependency ordering, and built-in tests. For ad-hoc DDL/DML, ingestion (`COPY INTO`), and one-off warehouse operations, prefer the **`sqldw-authoring-cli`** skill (raw `sqlcmd` T-SQL). For Lakehouse/PySpark/Delta transformations, prefer the **`spark-authoring-cli`** skill. For an end-to-end Bronze→Silver→Gold build, see the **`e2e-medallion-architecture`** skill, which can orchestrate dbt or Spark per layer.
+
+## Table of Contents
+
+| Task | Reference | Notes |
+|---|---|---|
+| Finding Workspaces and Items in Fabric | [COMMON-CLI.md § Finding Workspaces and Items in Fabric](../../common/COMMON-CLI.md#finding-workspaces-and-items-in-fabric) | **Mandatory** — *READ link first* |
+| Fabric Topology & Key Concepts | [COMMON-CORE.md § Fabric Topology & Key Concepts](../../common/COMMON-CORE.md#fabric-topology--key-concepts) ||
+| Environment URLs | [COMMON-CORE.md § Environment URLs](../../common/COMMON-CORE.md#environment-urls) ||
+| Authentication & Token Acquisition | [COMMON-CORE.md § Authentication & Token Acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition) | Wrong audience = 401; read before any auth issue |
+| Core Control-Plane REST APIs | [COMMON-CORE.md § Core Control-Plane REST APIs](../../common/COMMON-CORE.md#core-control-plane-rest-apis) | Includes pagination, LRO polling, and rate-limiting patterns |
+| Definition Envelope | [ITEM-DEFINITIONS-CORE.md § Definition Envelope](../../common/ITEM-DEFINITIONS-CORE.md#definition-envelope) | Definition payload structure |
+| Per-Item-Type Definitions | [ITEM-DEFINITIONS-CORE.md § Per-Item-Type Definitions](../../common/ITEM-DEFINITIONS-CORE.md#per-item-type-definitions) | DataBuildToolJob: live part is `dbt-content.json` (docs say `dbtjob-content.json` — discover via `getDefinition`) |
+| Job Execution | [COMMON-CORE.md § Job Execution](../../common/COMMON-CORE.md#job-execution) ||
+| Tool Selection Rationale | [COMMON-CLI.md § Tool Selection Rationale](../../common/COMMON-CLI.md#tool-selection-rationale) ||
+| Authentication Recipes | [COMMON-CLI.md § Authentication Recipes](../../common/COMMON-CLI.md#authentication-recipes) | `az login` flows and token acquisition |
+| Fabric Control-Plane API via `az rest` | [COMMON-CLI.md § Fabric Control-Plane API via az rest](../../common/COMMON-CLI.md#fabric-control-plane-api-via-az-rest) | **Always pass `--resource`**; includes pagination and LRO helpers |
+| Item CRUD Operations | [COMMON-CLI.md § Item CRUD Operations](../../common/COMMON-CLI.md#item-crud-operations) | Create, get/update definition, delete patterns |
+| Job Execution (CLI) | [COMMON-CLI.md § Job Execution](../../common/COMMON-CLI.md#job-execution) ||
+| Gotchas & Troubleshooting (CLI-Specific) | [COMMON-CLI.md § Gotchas & Troubleshooting (CLI-Specific)](../../common/COMMON-CLI.md#gotchas--troubleshooting-cli-specific) | `az rest` audience, shell escaping, token expiry |
+| Quick Reference | [COMMON-CLI.md § Quick Reference](../../common/COMMON-CLI.md#quick-reference) | `az rest` template + token audience/tool matrix |
+| dbt Job REST API Spec | [Microsoft Docs](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/dbtjob-definition) | Official definition spec |
+| dbt Job Overview | [Microsoft Docs](https://learn.microsoft.com/en-us/fabric/data-factory/dbt-job-overview) | Feature overview, supported adapters, runtime |
+| dbt Job How-To | [Microsoft Docs](https://learn.microsoft.com/en-us/fabric/data-factory/dbt-job-how-to) | Supported commands, create, schedule, monitor |
+| dbt Job Configure | [Microsoft Docs](https://learn.microsoft.com/en-us/fabric/data-factory/dbt-job-configure) | Profile settings, adapter change, advanced settings |
+
+---
+
+## Tool Stack
+
+| Tool | Role | Install |
+|---|---|---|
+| `az` CLI | **Primary**: Auth (`az login`), REST API calls (`az rest`), token acquisition | Pre-installed in most dev environments |
+| `jq` | Parse and manipulate JSON responses and definition payloads | Pre-installed or trivial |
+| `base64` | Encode/decode definition parts for the REST API | Built into bash / `[Convert]::ToBase64String()` in PowerShell |
+| `curl` | Alternative to `az rest` when raw HTTP control is needed | Pre-installed |
+
+> **Agent check** — verify before first operation:
+> ```bash
+> az --version 2>/dev/null || echo "INSTALL: https://aka.ms/install-azure-cli"
+> jq --version 2>/dev/null || echo "INSTALL: apt-get install jq OR brew install jq"
+> ```
+
+---
+
+## dbt Job Definition Structure
+
+A dbt job is a `DataBuildToolJob` item. Its definition contains:
+
+1. **A content part** describing project + profile + command settings.
+2. **The dbt project files** themselves (`dbt_project.yml`, `models/`, `macros/`, …), stored under `Code/dbt/` and surfaced as definition parts `Code/dbt/...`.
+3. **`.platform`** — common item metadata.
+
+> ⚠️ **VERIFIED PART NAME** — The official docs list the content part as `dbtjob-content.json`, but the **live Fabric API uses `dbt-content.json`** (this is the name returned by `getDefinition` and auto-seeded when you create the item). **Always discover the actual part name with `getDefinition` first; never hardcode it.** Examples below read the path dynamically.
+
+### Content part schema (`dbt-content.json`)
+
+```json
+{
+  "project": {
+    "projectType": "OneLake",
+    "folderPath": "dbt"
+  },
+  "profile": {
+    "profileType": "DataWarehouse",
+    "schema": "<target schema name>",
+    "connectionSettings": {
+      "name": "<connection / warehouse display name>",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": {
+          "workspaceId": "<guid of workspace holding the warehouse>",
+          "artifactId": "<guid of the target warehouse>",
+          "endPoint": "<fqdn>.datawarehouse.fabric.microsoft.com"
+        }
+      }
+    }
+  },
+  "command": {
+    "operation": "build",
+    "arguments": {
+      "select": "<comma-separated model names>",
+      "exclude": "<comma-separated model names>",
+      "fullRefresh": false,
+      "failFast": false,
+      "threads": 4,
+      "selectorName": "<dbt selector name>"
+    }
+  }
+}
+```
+
+> ⚠️ **VERIFIED CONNECTION SHAPE (Fabric Warehouse)** — The docs show a *flat* shape
+> (`connectionSettings.type` + `connectionSettings.properties.workspaceId`). That shape
+> **fails at runtime** with `The data source type is not supported`. The shape that
+> actually works nests the connection like a Fabric linked service:
+> `connectionSettings.name` + `connectionSettings.properties.type` +
+> `connectionSettings.properties.typeProperties.{workspaceId, artifactId, endPoint}`.
+> The `endPoint` (the warehouse `…datawarehouse.fabric.microsoft.com` FQDN) is the key
+> missing piece — include it. Get the FQDN from the warehouse item's
+> `properties.connectionString`.
+
+- `project.folderPath` is the dbt project folder **relative to the item's `Code/` folder**, so `"dbt"` means the project lives at `Code/dbt/`.
+- The connection is **absolute** (workspaceId + artifactId), so the dbt item can live in *any* workspace and still write to the referenced warehouse (see [Cross-Workspace & Cross-Database](#cross-workspace--cross-database)).
+
+### Profile types and connection patterns
+
+| Adapter | `profileType` | Connection approach |
+|---|---|---|
+| Fabric Warehouse | `DataWarehouse` | `connectionSettings` with the nested `properties.typeProperties` shape above (workspaceId + artifactId + endPoint) |
+| Snowflake | `Snowflake` | `externalReferences.connection` (connection GUID) |
+| PostgreSQL | `PostgreSql` | `externalReferences.connection` (connection GUID) |
+| Azure SQL Server | `AzureSql` | `externalReferences.connection` (connection GUID) |
+
+For non-Fabric adapters, replace `connectionSettings` with:
+
+```json
+"externalReferences": { "connection": "<connection GUID>" }
+```
+
+### Project types
+
+| Type | When to use |
+|---|---|
+| `OneLake` | dbt project stored in the dbt item's own OneLake `Code/dbt/` folder (default) |
+| `Lakehouse` | dbt project stored in a specific Fabric Lakehouse |
+
+### Supported commands (`operation` values)
+
+| Operation | Description |
+|---|---|
+| `run` | Runs all SQL models in dependency order |
+| `build` | Runs models + seeds + tests in one pass (recommended default) |
+| `seed` | Loads CSV files from the `seeds/` directory as managed tables |
+| `test` | Runs schema and data tests defined in `schema.yml` |
+| `compile` | Generates compiled SQL without executing transformations |
+| `snapshot` | Captures and tracks slowly changing dimensions over time |
+| `show` | Previews model results without persisting |
+
+### Expected dbt project layout (under `Code/dbt/`)
+
+```
+Code/dbt/
+├── dbt_project.yml      # name, profile, model-paths, materialization config
+├── models/
+│   ├── sources.yml      # source() definitions (add database: for cross-DB reads)
+│   ├── staging/         # or bronze/silver
+│   └── marts/           # or gold
+├── macros/              # optional reusable Jinja/SQL macros
+├── seeds/               # optional CSV files loaded via the seed command
+└── schema.yml           # optional tests/descriptions (can also live per-folder)
+```
+
+- `dbt_project.yml` — the `profile:` value here is cosmetic for Fabric (the real connection comes from `dbt-content.json`); set `name:` to match the top key under `models:`.
+- Each `.sql` file under `models/` is one model; subfolders map to schema paths unless overridden.
+- `sources.yml` — add a `database: <OtherDatabase>` to a source to emit cross-database 3-part names `[Other].[schema].[table]` (see [Cross-Workspace & Cross-Database](#cross-workspace--cross-database)).
+
+---
+
+## Connection
+
+### Discover Workspace and Item IDs
+
+Per [COMMON-CLI.md](../../common/COMMON-CLI.md) Finding Workspaces and Items in Fabric:
+
+```bash
+# List workspaces — find workspace ID by name
+az rest --method get \
+  --resource "https://api.fabric.microsoft.com" \
+  --url "https://api.fabric.microsoft.com/v1/workspaces" \
+  --query "value[?displayName=='MyWorkspace'].id" --output tsv
+
+# List dbt jobs in workspace — find item ID by name
+WS_ID="<workspaceId>"
+az rest --method get \
+  --resource "https://api.fabric.microsoft.com" \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$WS_ID/items?type=DataBuildToolJob" \
+  --query "value[?displayName=='MyDbtJob'].id" --output tsv
+
+# Find Fabric Warehouse ID (for profile connectionSettings)
+az rest --method get \
+  --resource "https://api.fabric.microsoft.com" \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$WS_ID/items?type=Warehouse" \
+  --query "value[?displayName=='MyWarehouse'].id" --output tsv
+```
+
+### Reusable Connection Variables
+
+```bash
+WS_ID="<workspaceId>"
+JOB_ID="<dbtJobItemId>"
+WH_ID="<warehouseItemId>"
+API="https://api.fabric.microsoft.com/v1"
+RESOURCE="https://api.fabric.microsoft.com"
+```
+
+---
+
+## Agentic Workflows
+
+### Discover → Formulate → Execute → Verify
+
+1. **Discover** → List workspaces/items, get the warehouse FQDN, `getDefinition` to read the current content part (and its real path).
+2. **Formulate** → Write the dbt project files locally and build the content part (`project`, `profile`, `command`).
+3. **Execute** → Create the item (dedicated endpoint), upload project files to `Code/dbt/`, then `updateDefinition` with **all** parts.
+4. **Verify** → Trigger the run (`jobType=Execute`) and poll until `Completed`; inspect `failureReason` on failure.
+
+```bash
+# 1. CREATE the item — use the dedicated dataBuildToolJobs endpoint (body = name + description).
+#    NOTE: POST /items with a full definition often returns InvalidDefinitionFormat for dbt — use this instead.
+JOB_ID=$(az rest --method post \
+  --resource "$RESOURCE" \
+  --url "$API/workspaces/$WS_ID/dataBuildToolJobs" \
+  --headers "Content-Type=application/json" \
+  --body '{"displayName":"MyDbtJob","description":"SilverLake -> Gold warehouse"}' \
+  --query "id" -o tsv)
+
+# 2. DISCOVER the warehouse FQDN (endPoint) and the live content-part name.
+WH_FQDN=$(az rest --method get --resource "$RESOURCE" \
+  --url "$API/workspaces/$WS_ID/items/$WH_ID" \
+  --query "properties.connectionString" -o tsv)
+
+LOCATION=$(az rest --method post --resource "$RESOURCE" \
+  --url "$API/workspaces/$WS_ID/items/$JOB_ID/getDefinition" \
+  --headers "Content-Length=0" \
+  --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+DEF=$(az rest --method get --url "$LOCATION" --resource "$RESOURCE")
+# Live API names this "dbt-content.json" (docs say "dbtjob-content.json") — read it, don't assume:
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+echo "content part = $CONTENT_PART"
+
+# 3. UPLOAD the dbt project files to OneLake under Code/dbt/ (see "Uploading Project Files" section).
+
+# 4. FORMULATE the content part (verified Warehouse connection shape — note properties.typeProperties + endPoint).
+cat > dbt-content.json <<EOF
+{
+  "project": { "projectType": "OneLake", "folderPath": "dbt" },
+  "profile": {
+    "profileType": "DataWarehouse",
+    "schema": "gold",
+    "connectionSettings": {
+      "name": "MyWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": {
+          "workspaceId": "$WS_ID",
+          "artifactId": "$WH_ID",
+          "endPoint": "$WH_FQDN"
+        }
+      }
+    }
+  },
+  "command": { "operation": "build", "arguments": { "exclude": "", "threads": 4 } }
+}
+EOF
+
+# 5. EXECUTE updateDefinition — resend EVERY part (content + all Code/dbt/* files + .platform),
+#    otherwise updateDefinition drops the model files. See build_parts() in the Examples section.
+
+# 6. VERIFY — trigger the run. jobType MUST be "Execute" (DataBuildToolJob/Run/DbtJob all 400).
+LOCATION=$(az rest --method post --resource "$RESOURCE" \
+  --url "$API/workspaces/$WS_ID/items/$JOB_ID/jobs/instances?jobType=Execute" \
+  --headers "Content-Length=0" \
+  --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+while true; do
+  RESULT=$(az rest --method get --url "$LOCATION" --resource "$RESOURCE")
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  echo "$(date -u '+%H:%M:%S') Status: $STATUS"
+  [[ "$STATUS" == "Completed" || "$STATUS" == "Failed" || "$STATUS" == "Cancelled" ]] && break
+  sleep 15
+done
+[[ "$STATUS" == "Failed" ]] && echo "$RESULT" | jq '.failureReason'
+```
+
+---
+
+## Uploading Project Files to OneLake
+
+The dbt project files live under the item's OneLake path `…/{itemId}/Code/dbt/`. Upload them with the
+OneLake DFS API (token audience **`https://storage.azure.com`**), then register them as definition parts.
+
+```bash
+# Storage-scoped token for OneLake DFS (different audience than the control plane!)
+STG_TOKEN=$(az account get-access-token --resource "https://storage.azure.com" --query accessToken -o tsv)
+ONELAKE="https://onelake.dfs.fabric.microsoft.com"
+
+upload_file() {  # $1 = local path, $2 = relative path under Code/dbt/
+  local rel="$2"
+  local url="$ONELAKE/$WS_ID/$JOB_ID/Code/dbt/$rel"
+  local len; len=$(wc -c < "$1")
+  curl -s -X PUT   -H "Authorization: Bearer $STG_TOKEN" "$url?resource=file" >/dev/null
+  curl -s -X PATCH -H "Authorization: Bearer $STG_TOKEN" --data-binary "@$1" "$url?action=append&position=0" >/dev/null
+  curl -s -X PATCH -H "Authorization: Bearer $STG_TOKEN" "$url?action=flush&position=$len" >/dev/null
+  echo "uploaded Code/dbt/$rel ($len bytes)"
+}
+
+upload_file ./dbt/dbt_project.yml          dbt_project.yml
+upload_file ./dbt/models/sources.yml       models/sources.yml
+upload_file ./dbt/models/gold/dim_x.sql    models/gold/dim_x.sql
+# … repeat for every model/macro/seed file …
+```
+
+> The files also become part of the item **definition** as `Code/dbt/...` parts. Whether you upload via
+> DFS or include them in `updateDefinition`, you must keep both views consistent — the safest pattern is to
+> upload via DFS **and** resend every file in `updateDefinition` (read-modify-write).
+
+---
+
+## Cross-Workspace & Cross-Database
+
+- **Cross-workspace**: the `profile.connectionSettings` points to an absolute `workspaceId` + `artifactId`. The dbt item therefore runs from *any* workspace and writes to the referenced warehouse regardless of where the item lives — useful for separating orchestration from storage. (Verified: a copied dbt item in a different workspace wrote to the original warehouse.)
+- **Cross-database sources**: dbt-fabric resolves a `source()` to a 3-part name when the `sources.yml` entry has a `database:` property:
+
+  ```yaml
+  version: 2
+  sources:
+    - name: silver
+      database: SilverLake     # emits [SilverLake].[dbo].[table]
+      schema: dbo
+      tables:
+        - name: salesorderheader
+  ```
+
+  This lets gold models in the warehouse read directly from a Lakehouse/warehouse in the **same workspace SQL scope** without copying data. The executing identity needs read access to the source.
+
+---
+
+## Fabric Warehouse T-SQL Surface Limits (for dbt models)
+
+Fabric Data Warehouse has a reduced T-SQL surface. dbt `table` materialization runs `CREATE TABLE AS SELECT`, so any unsupported type/expression in a model's `SELECT` fails the run. Verified gotchas:
+
+- **No `nvarchar`** — functions like `DATENAME()` (and `CONCAT()` over Unicode inputs) emit `nvarchar`, which the warehouse rejects (`The data type 'nvarchar(N)' … is not supported in this edition of SQL Server`). Wrap them: `CAST(DATENAME(MONTH, d) AS VARCHAR(20))`.
+- **Computed source columns may not exist** — e.g. AdventureWorks `SalesOrderNumber`, `TotalDue`, `LineTotal` are computed columns that are often absent in the raw landed table. Verify with `sys.columns` and derive them in SQL (`CONCAT('SO', SalesOrderID)`, `SubTotal + TaxAmt + Freight`).
+- **Validate before running** — a quick `sqlcmd -S <fqdn> -d <db> -G -Q "SELECT TOP 1 …"` against the source confirms column names and types and avoids a failed dbt run.
+- Adapter facts: **dbt-fabric** (Fabric Warehouse adapter), dbt Core 1.9 / dbt-fabric 1.9.0, Python 3.12, **Microsoft Entra OAuth** — the run authenticates as the job's identity, so no password is stored.
+
+---
+
+## Gotchas, Rules, Troubleshooting
+
+### MUST DO
+
+- **`az login` first** — all `az rest` calls use the active session. No session → 401.
+- **Always `--resource "https://api.fabric.microsoft.com"`** — wrong audience = 401.
+- **Discover the content-part name via `getDefinition`** — it is `dbt-content.json` on the live API (docs say `dbtjob-content.json`). Never hardcode.
+- **Use the verified Warehouse connection shape** — `connectionSettings.properties.{type, typeProperties:{workspaceId, artifactId, endPoint}}`. Omitting `endPoint` / using the flat doc shape → `data source type is not supported`.
+- **Create the item via `POST …/dataBuildToolJobs`** (body = `displayName` + `description`). The generic `/items` create with a full definition can return `InvalidDefinitionFormat`.
+- **Trigger runs with `jobType=Execute`** — `DataBuildToolJob`/`Run`/`DbtJob` return 400. (`POST …/dataBuildToolJobs/{id}/jobs/execute/instances` also works.)
+- **Resend ALL parts in `updateDefinition`** — sending only the content part silently drops the `Code/dbt/*` model files. Read-modify-write, preserving `.platform`.
+- **Base64-encode every part** — REST API expects `payloadType: "InlineBase64"`.
+- **Handle LRO polling** — `getDefinition`, `updateDefinition`, and job execution return 202; poll via `Location` header.
+- **Enable dbt jobs preview in Fabric tenant settings** — the feature requires admin opt-in under Tenant Settings → dbt jobs (preview).
+- **Use `externalReferences.connection` for non-Fabric adapters** (Snowflake, PostgreSQL, AzureSQL).
+- **Contributor role or higher required** — in the workspace and on the target Warehouse (and read access on cross-database sources).
+
+### AVOID
+
+- **Hardcoded GUIDs or the content-part name** — discover both via REST API.
+- **The flat doc connection shape** for Fabric Warehouse — it fails at runtime; use the nested `typeProperties` + `endPoint` shape.
+- **Partial `updateDefinition`** — always resend the full part list, or model files disappear.
+- **`nvarchar`-producing expressions in warehouse models** — `CAST(... AS VARCHAR(n))`.
+- **Skipping base64 encoding** — payloads will be rejected.
+- **Using `connectionSettings` for Snowflake/PostgreSQL/AzureSQL** — use `externalReferences.connection` instead.
+- **Constructing operation URLs manually** — always use the `Location` header from 202 responses.
+- **Running without a valid dbt project under `Code/dbt/`** — the job fails at runtime with a project-not-found error.
+
+### PREFER
+
+- **`az rest` over raw `curl`** for the control plane — handles tokens; use `curl` only for OneLake DFS uploads (storage audience).
+- **`getDefinition` before `updateDefinition`** — read-modify-write prevents accidental overwrites and discovers the part name.
+- **`jq` for JSON manipulation** — build and inspect definition payloads programmatically.
+- **Validate source schema with `sqlcmd`** before authoring models — catches missing/renamed columns early.
+- **Env vars** (`WS_ID`, `JOB_ID`, `WH_ID`, `WH_FQDN`, `API`, `RESOURCE`) for script reuse.
+- **`threads: 4`** as a safe default; increase only for large model graphs with sufficient warehouse capacity.
+- **`build` over `run`** when you also want seeds and tests in one command.
+- **`{{ ref() }}` between models, `{{ source() }}` for raw inputs** — let dbt order the DAG; cross-DB reads via source `database:`.
+- **Staged model layout** (`staging/`→`marts/` or `bronze/`→`silver/`→`gold/`) — aligns with medallion architecture.
+- **`selectorName` or `select`/`exclude`** for targeted runs during development.
+- **`sqldw-authoring-cli` for non-dbt warehouse work, `spark-authoring-cli` for Lakehouse transformations** — don't force ad-hoc DDL/ingestion or PySpark logic into dbt models; reach for the matching skill instead.
+
+### TROUBLESHOOTING
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| 401 Unauthorized | Token expired or wrong audience | `az login`; `--resource "https://api.fabric.microsoft.com"` (or `https://storage.azure.com` for OneLake DFS) |
+| 403 Forbidden on create/update | Insufficient workspace role | Requires Contributor or higher |
+| 404 on getDefinition | Wrong workspace or item ID | Re-discover via list items with `type=DataBuildToolJob` |
+| `InvalidDefinitionFormat` on create | Created via `/items` with full definition | Create with `POST …/dataBuildToolJobs` (name + description), then `updateDefinition` |
+| 400 on run trigger | Wrong `jobType` | Use `jobType=Execute` (not `DataBuildToolJob`) |
+| Run fails: `The data source type is not supported` | Flat doc connection shape / missing `endPoint` | Use nested `properties.typeProperties` with `workspaceId`+`artifactId`+`endPoint` |
+| Run fails: `nvarchar(N) … not supported` | Warehouse rejects nvarchar from `DATENAME`/`CONCAT` | `CAST(... AS VARCHAR(n))` |
+| Run fails: `Invalid column name '…'` | Computed source column absent (e.g. SalesOrderNumber) | Verify with `sys.columns`; derive the value in SQL |
+| Model files vanished after edit | Partial `updateDefinition` | Resend every part (content + all `Code/dbt/*` + `.platform`) |
+| Run fails: "dbt project not found" | Wrong `folderPath` or missing files | `folderPath` is relative to `Code/`; ensure files exist under `Code/dbt/` |
+| Run fails: "connection not found" | Invalid `artifactId`/`connection` GUID | Re-discover Warehouse ID or Fabric connection GUID |
+| 400 on create: feature not enabled | dbt jobs preview not enabled | Admin enables under Tenant Settings → dbt jobs (preview) |
+| `429 TooManyRequests` | Rate limited | Respect `Retry-After`; exponential backoff |
+
+---
+
+## Examples
+
+Shared setup for the examples:
+
+```bash
+WS_ID="<workspaceId>"
+WH_ID="<warehouseItemId>"
+RESOURCE="https://api.fabric.microsoft.com"
+API="https://api.fabric.microsoft.com/v1"
+```
+
+### Example 1: Create a dbt Job end-to-end (Fabric Warehouse adapter)
+
+```bash
+# 1. Create the item (dedicated endpoint — NOT /items with a full definition).
+JOB_ID=$(az rest --method post --resource "$RESOURCE" \
+  --url "$API/workspaces/$WS_ID/dataBuildToolJobs" \
+  --headers "Content-Type=application/json" \
+  --body '{"displayName":"MyDbtJob","description":"Silver -> Gold warehouse"}' \
+  --query "id" -o tsv)
+
+# 2. Discover the warehouse FQDN (the endPoint value).
+WH_FQDN=$(az rest --method get --resource "$RESOURCE" \
+  --url "$API/workspaces/$WS_ID/items/$WH_ID" \
+  --query "properties.connectionString" -o tsv)
+
+# 3. Upload project files to Code/dbt/ (see "Uploading Project Files to OneLake").
+
+# 4. Build the content part (verified nested Warehouse connection shape).
+cat > dbt-content.json <<EOF
+{
+  "project": { "projectType": "OneLake", "folderPath": "dbt" },
+  "profile": {
+    "profileType": "DataWarehouse",
+    "schema": "gold",
+    "connectionSettings": {
+      "name": "MyWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": {
+          "workspaceId": "$WS_ID",
+          "artifactId": "$WH_ID",
+          "endPoint": "$WH_FQDN"
+        }
+      }
+    }
+  },
+  "command": { "operation": "build", "arguments": { "exclude": "", "threads": 4 } }
+}
+EOF
+
+# 5. updateDefinition with ALL parts — see build_and_update() in Example 3.
+```
+
+### Example 2: Create a dbt Job (Snowflake / PostgreSQL / Azure SQL adapter)
+
+Non-Fabric adapters use a pre-created Fabric **connection** GUID via `externalReferences`:
+
+```bash
+CONN_ID="<connectionGuid>"   # create under Manage connections in Fabric first
+
+cat > dbt-content.json <<EOF
+{
+  "project": { "projectType": "OneLake", "folderPath": "dbt" },
+  "profile": {
+    "profileType": "Snowflake",
+    "schema": "analytics",
+    "externalReferences": { "connection": "$CONN_ID" }
+  },
+  "command": { "operation": "build", "arguments": { "fullRefresh": true, "failFast": true, "threads": 8 } }
+}
+EOF
+# Then upload project files + updateDefinition as in Example 1/3.
+```
+
+### Example 3: updateDefinition with ALL parts (the safe read-modify-write)
+
+`updateDefinition` **replaces** the part list, so you must resend the content part, every
+`Code/dbt/*` file, and `.platform` together. This helper rebuilds the full payload from the
+local project folder.
+
+```bash
+build_and_update() {
+  local local_root="./dbt"        # local folder mirroring Code/dbt/
+  local parts="[]"
+
+  add_part() {  # $1 = part path, $2 = local file
+    local b64; b64=$(base64 -w0 < "$2")
+    parts=$(echo "$parts" | jq --arg p "$1" --arg pl "$b64" \
+      '. + [{path:$p, payload:$pl, payloadType:"InlineBase64"}]')
+  }
+
+  # content part — discover the live name (dbt-content.json), fall back if absent
+  add_part "dbt-content.json" "dbt-content.json"
+
+  # every project file under Code/dbt/
+  while IFS= read -r f; do
+    rel="${f#"$local_root"/}"
+    add_part "Code/dbt/$rel" "$f"
+  done < <(find "$local_root" -type f)
+
+  # preserve .platform from the current definition
+  LOCATION=$(az rest --method post --resource "$RESOURCE" \
+    --url "$API/workspaces/$WS_ID/items/$JOB_ID/getDefinition" \
+    --headers "Content-Length=0" \
+    --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+  PLATFORM=$(az rest --method get --url "$LOCATION" --resource "$RESOURCE" \
+    | jq -r '.definition.parts[] | select(.path==".platform") | .payload')
+  [ -n "$PLATFORM" ] && parts=$(echo "$parts" | jq --arg pl "$PLATFORM" \
+    '. + [{path:".platform", payload:$pl, payloadType:"InlineBase64"}]')
+
+  az rest --method post --resource "$RESOURCE" \
+    --url "$API/workspaces/$WS_ID/items/$JOB_ID/updateDefinition" \
+    --headers "Content-Type=application/json" \
+    --body "$(jq -n --argjson parts "$parts" '{definition:{parts:$parts}}')"
+}
+
+build_and_update
+```
+
+### Example 4: Trigger a dbt Job Run and Poll for Completion
+
+```bash
+# jobType MUST be "Execute" — DataBuildToolJob/Run/DbtJob return 400.
+LOCATION=$(az rest --method post --resource "$RESOURCE" \
+  --url "$API/workspaces/$WS_ID/items/$JOB_ID/jobs/instances?jobType=Execute" \
+  --headers "Content-Length=0" \
+  --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+while true; do
+  RESULT=$(az rest --method get --url "$LOCATION" --resource "$RESOURCE")
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  echo "$(date -u '+%H:%M:%S') Status: $STATUS"   # NotStarted -> InProgress -> Completed/Failed
+  [[ "$STATUS" == "Completed" || "$STATUS" == "Failed" || "$STATUS" == "Cancelled" ]] && break
+  sleep 15
+done
+echo "Final status: $STATUS"
+[[ "$STATUS" == "Failed" ]] && echo "$RESULT" | jq '.failureReason'
+```
+
+### Example 5: Change command (operation / model selection) only
+
+```bash
+# Read-modify-write just the content part, then resend ALL parts via build_and_update.
+jq '.command.operation = "run"
+    | .command.arguments.select = "gold"
+    | .command.arguments.threads = 8' dbt-content.json > dbt-content.tmp && mv dbt-content.tmp dbt-content.json
+build_and_update   # from Example 3 — never send the content part alone
+```
+
+### Example 6: Cross-database source model (read a Lakehouse from a Warehouse gold model)
+
+`models/sources.yml`:
+
+```yaml
+version: 2
+sources:
+  - name: silver
+    database: SilverLake     # different item in the same workspace SQL scope
+    schema: dbo
+    tables:
+      - name: salesorderheader
+```
+
+`models/gold/dim_orderdate.sql` (note the `CAST(... AS VARCHAR)` to dodge the nvarchar limit):
+
+```sql
+{{ config(materialized='table') }}
+SELECT DISTINCT
+    (YEAR(OrderDate)*10000 + MONTH(OrderDate)*100 + DAY(OrderDate)) AS DateKey,
+    CAST(OrderDate AS DATE)                          AS DateValue,
+    YEAR(OrderDate)                                  AS [Year],
+    CAST(DATENAME(MONTH, OrderDate) AS VARCHAR(20))  AS MonthName
+FROM {{ source('silver', 'salesorderheader') }}
+WHERE OrderDate IS NOT NULL
+```
+
+### Example 7: Delete a dbt Job
+
+```bash
+az rest --method delete --resource "$RESOURCE" \
+  --url "$API/workspaces/$WS_ID/items/$JOB_ID"
+```

--- a/skills/dbt-consumption-cli/SKILL.md
+++ b/skills/dbt-consumption-cli/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: dbt-consumption-cli
+description: >
+  List, inspect, monitor, and trigger Fabric dbt jobs (DataBuildToolJob) via read-only and
+  run-focused CLI operations (az rest / curl). Enumerate dbt jobs across workspaces, decode
+  the dbt content part (live name `dbt-content.json`) to inspect project, profile, and command
+  settings, list the dbt project files (`Code/dbt/*`), check run history and status, poll active
+  job instances, and trigger dbt job runs. Use when the
+  user wants to: (1) list dbt jobs in a workspace, (2) inspect a dbt job definition (project
+  type, adapter, command operation, model selection), (3) check job run history and status,
+  (4) trigger a dbt job run, (5) monitor a running dbt job, (6) compare dbt job configurations
+  across workspaces.
+  Triggers: "dbt job status", "dbt run history", "list dbt jobs", "dbt job monitor", "check dbt
+  run", "inspect dbt job", "dbt job definition", "trigger dbt job", "dbt job fabric".
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill (e.g., `/fabric-skills:check-updates`).
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: read the local `package.json` version, then compare it against the remote version via `git fetch origin main --quiet && git show origin/main:package.json` (or the GitHub API). If the remote version is newer, show the changelog and update instructions.
+> - Skip if the check was already performed earlier in this session.
+
+> **CRITICAL NOTES**
+> 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering
+> 2. To find the item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace and, then, use JMESPath filtering
+
+# dbt Jobs — Consumption via CLI
+
+> **Related skills** — this skill lists, inspects, monitors, and triggers dbt job runs. To author/create dbt jobs, use **`dbt-authoring-cli`**. To query or validate the **resulting Warehouse tables** a dbt run produced (row counts, sampling, schema checks), use **`sqldw-consumption-cli`**.
+
+## Table of Contents
+
+| Task | Reference | Notes |
+|---|---|---|
+| Finding Workspaces and Items in Fabric | [COMMON-CLI.md § Finding Workspaces and Items in Fabric](../../common/COMMON-CLI.md#finding-workspaces-and-items-in-fabric) | **Mandatory** — *READ link first* |
+| Fabric Topology & Key Concepts | [COMMON-CORE.md § Fabric Topology & Key Concepts](../../common/COMMON-CORE.md#fabric-topology--key-concepts) ||
+| Environment URLs | [COMMON-CORE.md § Environment URLs](../../common/COMMON-CORE.md#environment-urls) ||
+| Authentication & Token Acquisition | [COMMON-CORE.md § Authentication & Token Acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition) | Wrong audience = 401; read before any auth issue |
+| Core Control-Plane REST APIs | [COMMON-CORE.md § Core Control-Plane REST APIs](../../common/COMMON-CORE.md#core-control-plane-rest-apis) | Includes pagination, LRO polling, and rate-limiting patterns |
+| Job Execution | [COMMON-CORE.md § Job Execution](../../common/COMMON-CORE.md#job-execution) | LRO polling patterns |
+| Tool Selection Rationale | [COMMON-CLI.md § Tool Selection Rationale](../../common/COMMON-CLI.md#tool-selection-rationale) ||
+| Authentication Recipes | [COMMON-CLI.md § Authentication Recipes](../../common/COMMON-CLI.md#authentication-recipes) | `az login` flows and token acquisition |
+| Fabric Control-Plane API via `az rest` | [COMMON-CLI.md § Fabric Control-Plane API via az rest](../../common/COMMON-CLI.md#fabric-control-plane-api-via-az-rest) | **Always pass `--resource`**; includes pagination and LRO helpers |
+| Job Execution (CLI) | [COMMON-CLI.md § Job Execution](../../common/COMMON-CLI.md#job-execution) ||
+| Gotchas & Troubleshooting (CLI-Specific) | [COMMON-CLI.md § Gotchas & Troubleshooting (CLI-Specific)](../../common/COMMON-CLI.md#gotchas--troubleshooting-cli-specific) | `az rest` audience, shell escaping, token expiry |
+| Quick Reference | [COMMON-CLI.md § Quick Reference](../../common/COMMON-CLI.md#quick-reference) | `az rest` template + token audience/tool matrix |
+| dbt Job REST API Spec | [Microsoft Docs](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/dbtjob-definition) | Official definition spec |
+| dbt Job Overview | [Microsoft Docs](https://learn.microsoft.com/en-us/fabric/data-factory/dbt-job-overview) | Feature overview, supported adapters, runtime |
+| dbt Job How-To | [Microsoft Docs](https://learn.microsoft.com/en-us/fabric/data-factory/dbt-job-how-to) | Supported commands, create, schedule, monitor |
+| dbt Job Configure | [Microsoft Docs](https://learn.microsoft.com/en-us/fabric/data-factory/dbt-job-configure) | Profile settings, adapter change, advanced settings |
+
+---
+
+## Tool Stack
+
+| Tool | Role | Install |
+|---|---|---|
+| `az` CLI | **Primary**: Auth (`az login`), Fabric REST API via `az rest` | Pre-installed in most dev environments |
+| `curl` | Alternative HTTP client for REST calls | Pre-installed |
+| `jq` | Parse JSON responses, extract fields, format output | Pre-installed or trivial |
+| `base64` | Decode definition parts from base64 | Built into bash; PowerShell uses `[Convert]::FromBase64String` |
+| `bash`/`pwsh` | Script execution | Pre-installed |
+
+> **Agent check** — verify before first operation:
+> ```bash
+> az account show >/dev/null 2>&1 || echo "RUN: az login"
+> command -v jq >/dev/null 2>&1 || echo "INSTALL: apt-get install jq OR brew install jq"
+> ```
+
+---
+
+## Connection
+
+### Resolve Workspace ID and Job ID
+
+Per [COMMON-CLI.md](../../common/COMMON-CLI.md) Finding Workspaces and Items in Fabric:
+
+```bash
+# Find workspace ID by name
+WS_ID=$(az rest --method get \
+  --resource "https://api.fabric.microsoft.com" \
+  --url "https://api.fabric.microsoft.com/v1/workspaces" \
+  --query "value[?displayName=='My Workspace'].id" --output tsv)
+
+# Find dbt job ID by name within workspace
+JOB_ID=$(az rest --method get \
+  --resource "https://api.fabric.microsoft.com" \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$WS_ID/items?type=DataBuildToolJob" \
+  --query "value[?displayName=='MyDbtJob'].id" --output tsv)
+```
+
+### Reusable Connection Variables
+
+```bash
+WS_ID="<workspaceId>"
+JOB_ID="<dbtJobItemId>"
+API="https://api.fabric.microsoft.com/v1"
+RESOURCE="https://api.fabric.microsoft.com"
+```
+
+---
+
+## Agentic Exploration ("Explore My dbt Jobs")
+
+### Supported Commands Reference
+
+| Operation | What it does |
+|---|---|
+| `run` | Runs all SQL models in dependency order |
+| `build` | Builds models + seeds + tests in a single pass |
+| `seed` | Loads CSV files from `seeds/` directory as managed tables |
+| `test` | Runs schema and data tests defined in `schema.yml` |
+| `compile` | Generates compiled SQL without executing transformations |
+| `snapshot` | Captures slowly changing dimensions over time |
+
+### Discovery Sequence
+
+Run these in order to fully explore dbt jobs in a workspace.
+
+```bash
+# 1. List workspaces → find target
+az rest --method get --resource "https://api.fabric.microsoft.com" \
+  --url "$API/workspaces" --query "value[].{name:displayName, id:id}" -o table
+
+# 2. List all dbt jobs in workspace
+az rest --method get --resource "https://api.fabric.microsoft.com" \
+  --url "$API/workspaces/$WS_ID/items?type=DataBuildToolJob" \
+  --query "value[].{name:displayName, id:id, desc:description}" -o table
+
+# 3. Get dbt job properties
+az rest --method get --resource "https://api.fabric.microsoft.com" \
+  --url "$API/workspaces/$WS_ID/items/$JOB_ID"
+
+# 4. Get definition → decode the dbt content part (live name: dbt-content.json; docs say dbtjob-content.json)
+LOCATION=$(az rest --method post --resource "https://api.fabric.microsoft.com" \
+  --url "$API/workspaces/$WS_ID/items/$JOB_ID/getDefinition" \
+  --headers "Content-Length=0" \
+  --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+DEF=$(az rest --method get --url "$LOCATION" --resource "https://api.fabric.microsoft.com")
+# Discover the content part dynamically, then decode it:
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+echo "$DEF" | jq -r --arg p "$CONTENT_PART" '.definition.parts[] | select(.path==$p) | .payload' | base64 -d | jq .
+
+# List the dbt project files that ship with the item (under Code/dbt/)
+echo "$DEF" | jq -r '.definition.parts[].path | select(startswith("Code/dbt/"))'
+
+# 5. Check job run history
+az rest --method get --resource "https://api.fabric.microsoft.com" \
+  --url "$API/workspaces/$WS_ID/items/$JOB_ID/jobs/instances" \
+  --query "value[].{status:status, type:jobType, start:startTimeUtc, end:endTimeUtc, error:failureReason}" -o table
+```
+
+### Agentic Workflow
+
+1. **Discover** → Steps 1–3 to list and identify dbt jobs.
+2. **Inspect** → Step 4 to understand project type, adapter, command, and model selection.
+3. **Monitor** → Step 5 for run history and error patterns.
+4. **Iterate** → Drill into specific failures or configuration details.
+5. **Present** → Summarize findings or generate a comparison table across jobs.
+> **Monitoring note**: The Fabric UI provides a Lineage View (model dependency graph), Compiled SQL View (rendered SQL per model), and a Run Results Panel (per-model success/failure/timing). Via CLI, the equivalent is the job instance status and `failureReason` field from the polling response.
+---
+
+## Gotchas, Rules, Troubleshooting
+
+### MUST DO
+
+- **Always `az login` first** — `az rest` uses the active session. No session → cryptic failure.
+- **Always `--resource "https://api.fabric.microsoft.com"`** — wrong audience = 401.
+- **Handle pagination** — repeat requests with `continuationToken` until absent/null.
+- **Handle LRO for `getDefinition`** — returns `202 Accepted` with `Location` header; poll until complete.
+- **Discover the content-part name** — it is `dbt-content.json` on the live API (docs say `dbtjob-content.json`); decode whatever `getDefinition` returns rather than hardcoding.
+- **Decode base64 before inspecting** — the content part is base64-encoded in the definition.
+- **Use POST for `getDefinition`** — it is NOT a GET endpoint.
+- **Trigger runs with `jobType=Execute`** — `DataBuildToolJob`/`Run`/`DbtJob` return 400.
+
+### AVOID
+
+- **Hardcoded GUIDs** — always discover via list-then-filter pattern.
+- **Assuming `getDefinition` is GET** — it is POST (common mistake; GET returns 405).
+- **Ignoring pagination** — list endpoints may return partial results.
+- **Polling too aggressively** — respect `Retry-After` headers on 429s.
+
+### PREFER
+
+- **`az rest` over raw `curl`** — handles auth automatically.
+- **List-then-filter pattern** — no server-side name filter for items; filter client-side by `displayName`.
+- **Exponential backoff** for job polling — 15s → 30s → 60s cap.
+- **`jq` for response parsing** — cleaner than shell string manipulation.
+- **JMESPath `--query`** for simple field extraction directly in `az rest`.
+- **Env vars** (`WS_ID`, `JOB_ID`, `API`, `RESOURCE`) for script reuse.
+
+### TROUBLESHOOTING
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Token expired or wrong audience | `az login`; ensure `--resource "https://api.fabric.microsoft.com"` |
+| `403 Forbidden` on `getDefinition` | Insufficient role | Requires Contributor role or higher |
+| `404 Not Found` | Wrong workspace or item ID | Re-discover via list items with `type=DataBuildToolJob` |
+| `getDefinition` returns `202` | LRO pattern | Poll the `Location` header URL until operation completes |
+| Empty job list | No dbt jobs in workspace, or feature not enabled | Check tenant setting; feature requires admin opt-in |
+| Base64 decode shows invalid JSON | Content encoding issue | Try `base64 -d` (Linux) or `[Convert]::FromBase64String` (PowerShell) |
+| `429 TooManyRequests` | Rate limited | Respect `Retry-After` header; implement exponential backoff |
+| Job history shows no entries | Job never triggered | Trigger via `jobs/instances?jobType=Execute` |
+| 400 on run trigger | Wrong `jobType` value | Use `jobType=Execute` (not `DataBuildToolJob`) |
+| Content part not found by name | Hardcoded `dbtjob-content.json` | Discover dynamically by matching part paths against the regex `dbt.?content\.json` |
+
+---
+
+## Examples
+
+### Example 1: List All dbt Jobs in a Workspace
+
+```bash
+az rest --method get \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items?type=DataBuildToolJob" \
+  --resource "https://api.fabric.microsoft.com" \
+  --query "value[].{Name:displayName, Id:id}" -o table
+```
+
+### Example 2: Inspect a dbt Job Definition
+
+```bash
+# Step 1: Request definition (POST — may return 202 with Location header)
+LOCATION=$(az rest --method post \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${JOB_ID}/getDefinition" \
+  --resource "https://api.fabric.microsoft.com" \
+  --headers "Content-Length=0" \
+  --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+# Step 2: Poll until definition is ready
+DEF=$(az rest --method get --url "${LOCATION}" \
+  --resource "https://api.fabric.microsoft.com")
+
+# Step 3: Decode the dbt content part and display all settings (discover the part name first)
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+echo "$DEF" | jq -r --arg p "$CONTENT_PART" '.definition.parts[] | select(.path==$p) | .payload' \
+  | base64 -d | jq '{
+      projectType: .project.projectType,
+      folderPath: .project.folderPath,
+      adapter: .profile.profileType,
+      schema: .profile.schema,
+      endPoint: .profile.connectionSettings.properties.typeProperties.endPoint,
+      operation: .command.operation,
+      select: .command.arguments.select,
+      threads: .command.arguments.threads,
+      fullRefresh: .command.arguments.fullRefresh
+    }'
+```
+
+### Example 3: Check dbt Job Run History
+
+```bash
+# Get recent job instances with status and timing
+az rest --method get \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${JOB_ID}/jobs/instances" \
+  --resource "https://api.fabric.microsoft.com" \
+  --query "value[].{Status:status, Start:startTimeUtc, End:endTimeUtc, Error:failureReason}" -o table
+```
+
+### Example 4: Trigger a dbt Job Run and Monitor
+
+```bash
+# Trigger run — jobType MUST be "Execute" (DataBuildToolJob/Run/DbtJob return 400)
+LOCATION=$(az rest --method post \
+  --url "https://api.fabric.microsoft.com/v1/workspaces/${WS_ID}/items/${JOB_ID}/jobs/instances?jobType=Execute" \
+  --resource "https://api.fabric.microsoft.com" \
+  --headers "Content-Length=0" \
+  --output none --include-response-headers 2>&1 | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+echo "Polling job at: $LOCATION"
+
+# Poll for completion
+while true; do
+  RESULT=$(az rest --method get --url "$LOCATION" --resource "https://api.fabric.microsoft.com")
+  STATUS=$(echo "$RESULT" | jq -r '.status')
+  echo "$(date -u '+%H:%M:%S') → $STATUS"
+  [[ "$STATUS" == "Completed" || "$STATUS" == "Failed" || "$STATUS" == "Cancelled" ]] && break
+  sleep 15
+done
+
+# Show failure reason if failed
+if [[ "$STATUS" == "Failed" ]]; then
+  echo "Failure reason:"
+  echo "$RESULT" | jq '.failureReason'
+fi
+```
+
+### Example 5: Compare dbt Job Configurations Across Workspaces
+
+```bash
+# Collect and compare definitions from two workspaces
+for WS in "$WS_ID_1" "$WS_ID_2"; do
+  echo "=== Workspace: $WS ==="
+  az rest --method get \
+    --url "https://api.fabric.microsoft.com/v1/workspaces/$WS/items?type=DataBuildToolJob" \
+    --resource "https://api.fabric.microsoft.com" \
+    --query "value[].{Name:displayName, Id:id}" -o table
+done
+```

--- a/skills/e2e-medallion-architecture/SKILL.md
+++ b/skills/e2e-medallion-architecture/SKILL.md
@@ -55,16 +55,14 @@ For Spark-specific optimization details, see [data-engineering-patterns.md](../s
 ## Must/Prefer/Avoid
 
 ### MUST DO
-- **Choose lakehouse architecture** based on schema-enabled availability (see [infrastructure-orchestration.md](../spark-authoring-cli/resources/infrastructure-orchestration.md)):
-  - **Preferred:** Schema-enabled lakehouse → create ONE workspace + ONE lakehouse with `bronze`, `silver`, `gold` schemas
-  - **Legacy:** Non-schema-enabled → create separate workspaces per layer (Bronze, Silver, Gold) for governance and access control
-- **Use Livy API for schema and table creation** — to create schemas and tables in a schema-enabled lakehouse, submit Spark SQL statements via Livy sessions (`POST /livyApi/versions/2023-12-01/sessions` → `POST .../statements`). This is the only programmatic REST path for DDL operations (CREATE SCHEMA, CREATE TABLE) in Fabric lakehouses.
+- Create a **separate lakehouse** for each medallion layer (Bronze, Silver, Gold)
 - Add **metadata columns** in Bronze: ingestion timestamp, source file, batch ID
 - Apply **data quality rules** in the Bronze-to-Silver transformation (deduplication, null handling, range validation)
 - Use **Delta Lake format** for all medallion layer tables
 - Use **partition-aware overwrite** in Silver/Gold writes to avoid reprocessing unchanged data
 - Include **validation steps** after each layer (row counts, schema checks, anomaly detection)
 - Follow the **`.ipynb` validation + Fabric nuances** in [notebook-api-operations.md](../spark-authoring-cli/resources/notebook-api-operations.md#ipynb-validation--fabric-nuances) when creating notebooks via REST API — every code cell must include `"outputs": []` and `"execution_count": null`
+- **Default to separate workspaces per layer** for governance and access control: one workspace each for Bronze, Silver, and Gold
 - **Complete the full end-to-end flow** — do not stop after creating notebooks; always bind lakehouses, execute notebooks sequentially (Bronze → Silver → Gold), verify results, and connect Power BI to the Gold layer unless the user explicitly requests a partial setup
 
 ### PREFER
@@ -77,12 +75,10 @@ For Spark-specific optimization details, see [data-engineering-patterns.md](../s
 - Clear layer ownership: engineers own Bronze/Silver, analysts own Gold
 - Fabric Variable Libraries to centralize paths and configuration across layers
 - Multi-workspace deployment patterns for medium/high governance requirements (Bronze/Silver/Gold in separate workspaces)
-- Use Materialized Lake Views (MLVs) for Silver/Gold tables when the transformation is expressible in Spark SQL and benefits from declarative refresh semantics. See [spark-authoring-cli — Materialized Lake View patterns](../spark-authoring-cli/resources/materialized-lake-view-patterns.md) and [MLV incremental refresh patterns](../spark-authoring-cli/resources/mlv-incremental-refresh-patterns.md).
-- For MLV refresh scheduling and monitoring (create/delete schedules, trigger on-demand refresh, check job status), use [mlv-operations-cli](../mlv-operations-cli/SKILL.md). Note: "materialized view", "spark materialized view", and "MLV" all refer to the same Fabric feature.
+- **Spark notebooks for Lakehouse/PySpark transformations; dbt for SQL-first transformations that land in a Fabric Warehouse** — when a Silver/Gold layer is a Warehouse and the transformations are expressible in T-SQL, the `dbt-authoring-cli` skill (DataBuildToolJob, dbt Core in Fabric) offers versioned models, lineage, and built-in tests as an alternative to hand-written notebooks/stored procedures
 
 ### AVOID
-- **Storing all layers in a single lakehouse WITHOUT schemas** — non-schema lakehouses require notebook init cells or Environment configuration to enable OneLake Spark Catalog for RLS/CLS and MLVs. Use separate lakehouses for isolation if schemas aren't available.
-- **Creating 3 separate lakehouses when schema-enabled lakehouse is available** — use schemas within one lakehouse instead (cleaner, no boilerplate init cells, more efficient for MLV cross-schema transformations)
+- Storing all layers in a single lakehouse — this defeats isolation and independent optimization
 - Skipping the Silver layer and going directly from Bronze to Gold
 - Hardcoded workspace IDs, lakehouse IDs, or FQDNs — discover via REST API
 - SELECT * without LIMIT on Bronze tables (they grow unboundedly)
@@ -96,26 +92,9 @@ For Spark-specific optimization details, see [data-engineering-patterns.md](../s
 
 ## Workspace Setup Guidance
 
-When setting up a medallion workspace, choose your architecture pattern first (see [infrastructure-orchestration.md](../spark-authoring-cli/resources/infrastructure-orchestration.md) for detailed guidance):
+When setting up a medallion workspace, guide LLM to generate commands for:
 
-### Option A: Schema-Enabled Lakehouse (Preferred)
-
-1. **Create single workspace**: `{project}-{env}`
-2. **Create one lakehouse** with schemas: `{project}_lakehouse`
-3. **Create schemas within the lakehouse**:
-   - `bronze` schema for raw ingestion
-   - `silver` schema for cleaned/validated data
-   - `gold` schema for aggregated analytics
-4. **Choose transformation approach**:
-   - **Option 4a:** Use notebooks for each layer (PySpark or Spark SQL transformations)
-   - **Option 4b:** Use Materialized Lake Views (Spark SQL) for declarative transformations with incremental refresh (when query is IR-eligible) — see [materialized-lake-view-patterns.md](../spark-authoring-cli/resources/materialized-lake-view-patterns.md) and [mlv-incremental-refresh-patterns.md](../spark-authoring-cli/resources/mlv-incremental-refresh-patterns.md)
-   - **Note:** PySpark MLVs exist but use full refresh only (no incremental) — use when you need UDFs/complex Python logic
-   - **MLV benefit:** OneLake Spark Catalog is **automatically enabled** for schema-enabled lakehouses — MLVs work out-of-box with no notebook init cells or Environment configuration required
-5. **RBAC** (optional): Use row-level security and column masking within schemas for fine-grained access control (also requires OneLake Spark Catalog)
-
-### Option B: Separate Lakehouses (Legacy)
-
-1. **Create three workspaces**:
+1. **Default architecture: create three workspaces** (recommended):
    - `{project}-bronze-{env}`
    - `{project}-silver-{env}`
    - `{project}-gold-{env}`
@@ -127,34 +106,15 @@ When setting up a medallion workspace, choose your architecture pattern first (s
    - Bronze: ingestion/engineering write permissions
    - Silver: engineering/data quality permissions
    - Gold: analytics/BI consumer access with stricter curation controls
-4. **Enable OneLake Spark Catalog for non-schema lakehouses** (required for RLS/CLS and catalog-backed access patterns):
-   - **Primary:** Set `spark.sql.fabric.catalog.enable-schemaless-lakehouses=true` in an Environment and attach it to notebooks.
-   - **Alternative:** Omit default lakehouse binding from notebooks. Use four-part fully-qualified references (`workspace.lakehouse.schema.table`). OneLake Spark Catalog auto-enables when no default lakehouse is set.
-   - **Alternative (internal/unsupported):** Add this as the **first cell** in every notebook:
-   ```python
-   %%pyspark
-   !echo "spark.sql.fabric.catalog.enable-schemaless-lakehouses=true" >> /home/trusted-service-user/.trident-context
-   ```
-   - **⚠️ Note:** This workaround uses an internal runtime configuration path that may change in future Fabric releases. **Prefer schema-enabled lakehouses** for stable, documented OneLake Spark Catalog support.
-   - With this configuration, non-schema lakehouses support:
-     - ✅ Row-level security (RLS) and column-level security (CLS)
-   - **Note:** MLVs require schema-enabled lakehouses (Option A). For non-schema lakehouses, use notebooks with Delta tables.
-
-### Common Steps (Both Options)
-
-After completing Option A or Option B above, perform these steps:
-
-1. **Create notebooks** for each layer (one per transformation stage) — follow `.ipynb` validation + Fabric nuances
-2. **Bind each notebook to its lakehouse** — set `metadata.dependencies.lakehouse` with the correct lakehouse ID (see [notebook-api-operations.md § Default Lakehouse Binding](../spark-authoring-cli/resources/notebook-api-operations.md#default-lakehouse-binding)):
-   - Option A: All notebooks → same lakehouse, use schema prefixes (`bronze.table`, `silver.table`)
-   - Option B:
-     - Bronze notebook → Bronze workspace/lakehouse
-     - Silver notebook → Silver workspace/lakehouse (reads Bronze via cross-workspace OneLake access / fully qualified references)
-     - Gold notebook → Gold workspace/lakehouse (reads Silver via cross-workspace access)
-3. **Confirm notebook deployment** — check that `updateDefinition` returned `Succeeded`; this is sufficient confirmation that content and lakehouse binding persisted. Do NOT call `getDefinition` to re-verify — it is an async LRO and adds unnecessary latency.
-4. **Execute notebooks** sequentially — Bronze first, then Silver, then Gold — using `POST .../jobs/instances?jobType=RunNotebook` with the correct `defaultLakehouse` in execution config (both `id` and `name` required)
-5. **Connect Power BI to Gold layer** — discover the Gold lakehouse SQL endpoint, create a Direct Lake semantic model, create a report with visuals on the Gold summary table (see [Gold Layer → Power BI Consumption](#gold-layer--power-bi-consumption))
-6. **Create pipeline** to orchestrate the Bronze → Silver → Gold flow for recurring execution
+4. **Create notebooks** for each layer (one per transformation stage) — follow `.ipynb` validation + Fabric nuances
+5. **Bind each notebook to its lakehouse** — set `metadata.dependencies.lakehouse` with the correct lakehouse ID (see [notebook-api-operations.md § Default Lakehouse Binding](../spark-authoring-cli/resources/notebook-api-operations.md#default-lakehouse-binding)):
+   - Bronze notebook → Bronze workspace/lakehouse
+   - Silver notebook → Silver workspace/lakehouse (reads Bronze via cross-workspace oneLake access / fully qualified references)
+   - Gold notebook → Gold workspace/lakehouse (reads Silver via cross-workspace access)
+6. **Confirm notebook deployment** — check that `updateDefinition` returned `Succeeded`; this is sufficient confirmation that content and lakehouse binding persisted. Do NOT call `getDefinition` to re-verify — it is an async LRO and adds unnecessary latency.
+7. **Execute notebooks** sequentially — Bronze first, then Silver, then Gold — using `POST .../jobs/instances?jobType=RunNotebook` with the correct `defaultLakehouse` in execution config (both `id` and `name` required)
+8. **Connect Power BI to Gold layer** — discover the Gold lakehouse SQL endpoint, create a Direct Lake semantic model, create a report with visuals on the Gold summary table (see [Gold Layer → Power BI Consumption](#gold-layer--power-bi-consumption))
+9. **Create pipeline** to orchestrate the Bronze → Silver → Gold flow for recurring execution
 
 ### Explicit Override: Single Workspace
 
@@ -186,6 +146,8 @@ When a user requests data ingestion into the Bronze layer, guide LLM to:
 
 ## Silver Layer — Transformation Patterns
 
+> **Transformation engine choice** — the patterns below use Spark notebooks (Lakehouse). If the Silver layer is a **Fabric Warehouse** and the logic is SQL-expressible, the `dbt-authoring-cli` skill is an alternative that gives versioned models, lineage, and tests. Use Spark for PySpark/Delta-heavy work; use dbt for declarative SQL transformations into a Warehouse.
+
 When a user requests Bronze-to-Silver transformation, guide LLM to:
 
 - **Quality rules**: Deduplicate on natural/composite key, filter invalid ranges, handle nulls (drop required, fill optional), validate logical constraints
@@ -196,6 +158,8 @@ When a user requests Bronze-to-Silver transformation, guide LLM to:
 ---
 
 ## Gold Layer — Aggregation Patterns
+
+> **Warehouse Gold layer?** If the Gold layer is a Fabric Warehouse, the dimensional models and aggregates below can also be built with the `dbt-authoring-cli` skill (dbt Core in Fabric) instead of Spark notebooks — preferred when the team wants SQL-first models with lineage and tests.
 
 When a user requests Gold analytics tables, guide LLM to generate:
 
@@ -259,7 +223,7 @@ Build a semantic model on top of the Gold lakehouse, using DirectLake.
    ```sql
    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'nyc_taxi_daily_summary'
    ```
-3. **Create a semantic model** — use the [semantic-model-authoring](../semantic-model-authoring/SKILL.md) skill for semantic model creation and TMDL deployment. Create via `POST /v1/workspaces/{workspaceId}/items` with `type: "SemanticModel"` then deploy definition via `updateDefinition` using TMDL format (see [ITEM-DEFINITIONS-CORE.md § SemanticModel](../../common/ITEM-DEFINITIONS-CORE.md#semanticmodel)):
+3. **Create a semantic model** — use the [powerbi-authoring-cli](../powerbi-authoring-cli/SKILL.md) skill for semantic model creation and TMDL deployment. Create via `POST /v1/workspaces/{workspaceId}/items` with `type: "SemanticModel"` then deploy definition via `updateDefinition` using TMDL format (see [ITEM-DEFINITIONS-CORE.md § SemanticModel](../../common/ITEM-DEFINITIONS-CORE.md#semanticmodel)):
    - The model must reference the Gold lakehouse SQL endpoint as its data source
    - Define a table mapping to the Gold summary table (e.g., `nyc_taxi_daily_summary`)
    - Use **Direct Lake** mode — this connects directly to Delta tables in OneLake without data import
@@ -268,7 +232,7 @@ Build a semantic model on top of the Gold lakehouse, using DirectLake.
    - Reference the semantic model created in step 3 via `definition.pbir`
    - Define at least one page with visuals on the Gold summary table
    - Suggested visuals: line chart (daily trend), card (KPI totals), bar chart (by category), table (detail view)
-5. **Verify end-to-end** — use the `semantic-model-consumption` skill to run DAX queries against the semantic model and confirm data flows from Gold tables through to the report
+5. **Verify end-to-end** — use the `powerbi-consumption-cli` skill to run DAX queries against the semantic model and confirm data flows from Gold tables through to the report
 
 ### Principles
 
@@ -276,8 +240,8 @@ Build a semantic model on top of the Gold lakehouse, using DirectLake.
 - **Wait for SQL endpoint provisioning** — status must be `Success` before connecting; newly created lakehouses may take minutes to provision
 - **Prefer Direct Lake mode** — avoids data duplication; semantic model reads directly from OneLake Delta tables
 - **Match table/column names exactly** — the semantic model table definition must use the exact Delta table and column names from the Gold lakehouse
-- **For semantic model authoring** (TMDL, refresh, permissions), cross-reference the [semantic-model-authoring](../semantic-model-authoring/SKILL.md) skill
-- **For DAX query validation**, cross-reference the [semantic-model-consumption](../semantic-model-consumption/SKILL.md) skill
+- **For semantic model authoring** (TMDL, refresh, permissions), cross-reference the [powerbi-authoring-cli](../powerbi-authoring-cli/SKILL.md) skill
+- **For DAX query validation**, cross-reference the [powerbi-consumption-cli](../powerbi-consumption-cli/SKILL.md) skill
 
 ---
 

--- a/skills/sqldw-authoring-cli/SKILL.md
+++ b/skills/sqldw-authoring-cli/SKILL.md
@@ -261,6 +261,7 @@ For CLI-specific issues: [COMMON-CLI.md](../../common/COMMON-CLI.md) Gotchas & T
 - **`-Q`** (non-interactive exit) for agentic use.
 - **`-F vertical`** for exploration of wide tables.
 - **Env vars** (`FABRIC_SERVER`, `FABRIC_DB`) for script reuse.
+- **`dbt-authoring-cli` skill for versioned, multi-model SQL transformations** — when building a maintainable set of SQL transformation models (Silver→Gold, dimensional models) with lineage, dependency ordering, and built-in tests, consider a DataBuildToolJob (dbt Core in Fabric) instead of hand-written stored-procedure ETL. This skill (raw `sqlcmd` T-SQL) remains the right choice for ad-hoc DDL/DML, ingestion (COPY INTO), and one-off operations.
 
 ### TROUBLESHOOTING
 


### PR DESCRIPTION
## Summary

Adds two source-independent CLI skills for Microsoft Fabric **dbt jobs** (DataBuildToolJob), plus cross-skill references. All facts were verified hands-on by building and running a working dbt job end-to-end against the live Fabric API.

### New skills
- **`dbt-authoring-cli`** - create, configure, update, and run dbt jobs.
- **`dbt-consumption-cli`** - list, inspect, monitor, and trigger dbt job runs.

### Verified corrections (vs. the public docs / naive assumptions)
- Content part is **`dbt-content.json`** on the live API (docs say `dbtjob-content.json`) - discover dynamically via `getDefinition`.
- DataWarehouse profile uses the **nested** `properties.typeProperties` shape with `workspaceId` + `artifactId` + **`endPoint`**; the flat doc shape fails at runtime with "data source type is not supported".
- Create via `POST .../dataBuildToolJobs` (name + description); the generic `/items` path returns `InvalidDefinitionFormat`.
- Trigger runs with **`jobType=Execute`** (other values return 400).
- `updateDefinition` **replaces all parts** - always resend content + every `Code/dbt/*` model file + `.platform`, or model files silently disappear.
- Fabric Warehouse T-SQL limits (no `nvarchar` -> `CAST(... AS VARCHAR(n))`), OneLake DFS upload, and cross-workspace/cross-database patterns documented.

### Cross-skill awareness
- `e2e-medallion-architecture`: note dbt as an option for SQL-first Warehouse Silver/Gold layers.
- `sqldw-authoring-cli`: consider dbt for versioned, multi-model SQL transformations.
- `common/ITEM-DEFINITIONS-CORE.md`: corrected the `DataBuildToolJob` part-name mapping.

All skills are **source-independent** (generic placeholders, no dataset specifics).

> Note: only the canonical `skills/` + `common/` sources are changed here; the `plugins/` bundles are build-generated and intentionally left for the maintainers' build step.