### PR TITLE
Add dbt-authoring-cli and dbt-consumption-cli skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "fabric-collection",
   "metadata": {
     "description": "Microsoft Skills for Fabric collection for GitHub Copilot CLI",
-    "version": "0.3.5"
+    "version": "0.3.6"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "fabric-skills",
       "source": "./plugins/fabric-skills",
       "description": "Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -42,7 +42,9 @@
         "./skills/pipeline-migration",
         "./skills/synapse-migration",
         "./skills/hdinsight-migration",
-        "./skills/e2e-medallion-architecture"
+        "./skills/e2e-medallion-architecture",
+        "./skills/dbt-authoring-cli",
+        "./skills/dbt-consumption-cli"
       ],
       "agents": [
         "./agents/FabricAdmin.agent.md",
@@ -78,7 +80,7 @@
       "name": "skills-for-fabric",
       "source": "./plugins/fabric-skills",
       "description": "[DEPRECATED ALIAS of fabric-skills@fabric-collection \u2014 pre-0.3.0 users only; new installs should use fabric-skills.] Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -107,7 +109,9 @@
         "./skills/pipeline-migration",
         "./skills/synapse-migration",
         "./skills/hdinsight-migration",
-        "./skills/e2e-medallion-architecture"
+        "./skills/e2e-medallion-architecture",
+        "./skills/dbt-authoring-cli",
+        "./skills/dbt-consumption-cli"
       ],
       "agents": [
         "./agents/FabricAdmin.agent.md",
@@ -143,7 +147,7 @@
       "name": "fabric-authoring",
       "source": "./plugins/fabric-authoring",
       "description": "Developer skills for authoring Microsoft Skills for Fabric solutions - SDKs, APIs, automation scripts, CI/CD",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/sqldw-authoring-cli",
@@ -155,7 +159,8 @@
         "./skills/dataflows-authoring-cli",
         "./skills/dataflows-save-as-authoring-cli",
         "./skills/fabriciq-ontology-authoring-cli",
-        "./skills/e2e-medallion-architecture"
+        "./skills/e2e-medallion-architecture",
+        "./skills/dbt-authoring-cli"
       ],
       "agents": [
         "./agents/FabricAdmin.agent.md",
@@ -179,7 +184,7 @@
       "name": "fabric-consumption",
       "source": "./plugins/fabric-consumption",
       "description": "Consumer skills for interactive Microsoft Skills for Fabric operations - queries, exploration, monitoring",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -191,7 +196,8 @@
         "./skills/activator-consumption-cli",
         "./skills/dataflows-consumption-cli",
         "./skills/search-consumption-cli",
-        "./skills/fabriciq-ontology-consumption-cli"
+        "./skills/fabriciq-ontology-consumption-cli",
+        "./skills/dbt-consumption-cli"
       ],
       "agents": [
         "./agents/FabricAdmin.agent.md",
@@ -222,7 +228,7 @@
       "name": "fabric-operations",
       "source": "./plugins/fabric-operations",
       "description": "Operations skills for diagnosing Microsoft Fabric performance and health - system views, multi-step investigation workflows",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/mlv-operations-cli",
@@ -250,7 +256,7 @@
       "name": "powerbi-authoring",
       "source": "./plugins/powerbi-authoring",
       "description": "Developer skills for authoring Microsoft Power BI solutions.",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-authoring",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "fabric-collection",
   "metadata": {
     "description": "Microsoft Skills for Fabric collection for GitHub Copilot CLI",
-    "version": "0.3.5"
+    "version": "0.3.6"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "fabric-skills",
       "source": "./plugins/fabric-skills",
       "description": "Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -42,7 +42,9 @@
         "./skills/pipeline-migration",
         "./skills/synapse-migration",
         "./skills/hdinsight-migration",
-        "./skills/e2e-medallion-architecture"
+        "./skills/e2e-medallion-architecture",
+        "./skills/dbt-authoring-cli",
+        "./skills/dbt-consumption-cli"
       ],
       "agents": [
         "./agents/FabricAdmin.agent.md",
@@ -78,7 +80,7 @@
       "name": "skills-for-fabric",
       "source": "./plugins/fabric-skills",
       "description": "[DEPRECATED ALIAS of fabric-skills@fabric-collection \u2014 pre-0.3.0 users only; new installs should use fabric-skills.] Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -107,7 +109,9 @@
         "./skills/pipeline-migration",
         "./skills/synapse-migration",
         "./skills/hdinsight-migration",
-        "./skills/e2e-medallion-architecture"
+        "./skills/e2e-medallion-architecture",
+        "./skills/dbt-authoring-cli",
+        "./skills/dbt-consumption-cli"
       ],
       "agents": [
         "./agents/FabricAdmin.agent.md",
@@ -143,7 +147,7 @@
       "name": "fabric-authoring",
       "source": "./plugins/fabric-authoring",
       "description": "Developer skills for authoring Microsoft Skills for Fabric solutions - SDKs, APIs, automation scripts, CI/CD",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/sqldw-authoring-cli",
@@ -155,7 +159,8 @@
         "./skills/dataflows-authoring-cli",
         "./skills/dataflows-save-as-authoring-cli",
         "./skills/fabriciq-ontology-authoring-cli",
-        "./skills/e2e-medallion-architecture"
+        "./skills/e2e-medallion-architecture",
+        "./skills/dbt-authoring-cli"
       ],
       "agents": [
         "./agents/FabricAdmin.agent.md",
@@ -179,7 +184,7 @@
       "name": "fabric-consumption",
       "source": "./plugins/fabric-consumption",
       "description": "Consumer skills for interactive Microsoft Skills for Fabric operations - queries, exploration, monitoring",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -191,7 +196,8 @@
         "./skills/activator-consumption-cli",
         "./skills/dataflows-consumption-cli",
         "./skills/search-consumption-cli",
-        "./skills/fabriciq-ontology-consumption-cli"
+        "./skills/fabriciq-ontology-consumption-cli",
+        "./skills/dbt-consumption-cli"
       ],
       "agents": [
         "./agents/FabricAdmin.agent.md",
@@ -222,7 +228,7 @@
       "name": "fabric-operations",
       "source": "./plugins/fabric-operations",
       "description": "Operations skills for diagnosing Microsoft Fabric performance and health - system views, multi-step investigation workflows",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/mlv-operations-cli",
@@ -250,7 +256,7 @@
       "name": "powerbi-authoring",
       "source": "./plugins/powerbi-authoring",
       "description": "Developer skills for authoring Microsoft Power BI solutions.",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-authoring",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 User-facing changes for the public Microsoft Fabric Skills release.
 
+## [0.3.6] - 2026-07-01
+
+### Added
+- **New skills `dbt-authoring-cli` and `dbt-consumption-cli`** — dbt (data build tool) job support from the CLI. `dbt-authoring-cli` creates, configures, updates, deploys, and runs Fabric `DataBuildToolJob` items via `az rest`, and generates dbt Core 1.9 SQL for the supported adapters (Fabric Warehouse, Azure SQL Database, PostgreSQL, Snowflake). It packs a local project into `Code/dbt/*` definition parts with **read-modify-write** (so `updateDefinition` never drops files), binds targets **by connection GUID** (no credentials in config — the golden rule), discovers the config-part name (`dbt[\w-]*content\.json`, which differs live vs docs), and connects a job to an existing **GitHub repository** as a run-only source (`GitHubSourceControl` connection from a classic PAT held only in the connection). `dbt-consumption-cli` lists dbt jobs, decodes their configuration and `Code/dbt/*` project files (incl. `schema.yml`), reviews run history and `failureReason`, and triggers/monitors runs — read-only. Adds a shared `common/DBT-CORE.md` (execution model, supportability matrix, per-adapter SQL, project structure, security rule) and per-skill `references/` with copy/paste `az rest` recipes. A Preview & Confirm gate precedes any write or run.
+
 ## [0.3.5] - 2026-06-25
 
 ### Added

--- a/common/DBT-CORE.md
+++ b/common/DBT-CORE.md
@@ -1,0 +1,147 @@
+# DBT-CORE.md — dbt Job Model, Adapters & Project Reference
+
+Shared reference for the dbt (data build tool) skills. Covers the Fabric dbt job execution model,
+the item-definition structure, the supportability matrix, per-adapter SQL generation for dbt Core
+1.9, and dbt project layout. The consumption skill links here for the execution model; the authoring
+skill links here for SQL generation and project structure.
+
+## Table of contents
+- [Execution model](#execution-model)
+- [Supportability matrix](#supportability-matrix)
+- [Adapter SQL](#adapter-sql)
+- [Project structure](#project-structure)
+- [Security: never write credentials](#security-never-write-credentials)
+
+---
+
+## Execution model
+
+- A dbt job is a Fabric item of type **`DataBuildToolJob`** (preview).
+- Its **definition** is a list of base64 parts:
+  - the **config part** — `dbt-content.json` on the live API / `dbtjob-content.json` in docs;
+    holds `project`, `profile`, and `command` settings. **Discover the name** from `getDefinition`
+    (regex `dbt[\w-]*content\.json`) — do not hardcode.
+  - **`Code/dbt/...`** — the dbt project files (`dbt_project.yml`, `models/*.sql`, `schema.yml`,
+    `seeds/`, `snapshots/`), one part per file. (Absent for GitHub-sourced jobs.)
+  - **`.platform`** — item metadata.
+- `updateDefinition` **replaces the whole part list** → every change is read-modify-write.
+- Runs are triggered with `POST .../items/{id}/jobs/instances?jobType=Execute` and polled to a
+  terminal status (`Completed`/`Failed`/`Cancelled`/`Deduped`).
+
+### Config part (`ContentDetails`) shape
+```jsonc
+{
+  "project": {
+    "projectType": "OneLake",              // "OneLake" | "Lakehouse" | "GitHubSourceControl"
+    "folderPath": "dbt"
+  },
+  "profile": {
+    "profileType": "DataWarehouse",        // DataWarehouse | SqlServer | PostgreSql | Snowflake
+    "schema": "gold",
+    // bind by GUID — either an external connection or workspace/artifact of the warehouse:
+    "connectionSettings": {
+      "name": "MyWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": {
+          "workspaceId": "<ws-guid>", "artifactId": "<warehouse-guid>",
+          "endPoint": "<name>.datawarehouse.fabric.microsoft.com"
+        }
+      }
+    }
+    // or: "externalReferences": { "connection": "<connection-guid>" }
+  },
+  "command": { "operation": "build", "arguments": { "threads": 4, "failFast": true } }
+}
+```
+`operation` ∈ `run | build | show | seed | compile | test | snapshot`. Command arguments:
+`select`, `exclude`, `fullRefresh`, `failFast`, `threads`, `selectorName`.
+
+---
+
+## Supportability matrix
+
+dbt Job Runtime **v1.0**, dbt Core **1.9**, Python **3.12**. Generate Core-1.9 SQL for all four.
+
+| Target | Adapter (pip) | Adapter version | `profiles.yml` type | `profileType` |
+|---|---|---|---|---|
+| Fabric Warehouse | `dbt-fabric` | 1.9.0 | `fabric` | `DataWarehouse` |
+| PostgreSQL | `dbt-postgres` | 1.9.0 | `postgres` | `PostgreSql` |
+| Snowflake | `dbt-snowflake` | 1.9.0 | `snowflake` | `Snowflake` |
+| Azure SQL Database | `dbt-sqlserver` | 1.8.5 | `sqlserver` | `SqlServer` |
+
+Azure SQL pins adapter **1.8.5** (Core-1.9-only features like `microbatch` may be unavailable there —
+prefer `delete+insert`/`merge`). Adapters evolve; verify edge cases at https://docs.getdbt.com.
+
+---
+
+## Adapter SQL
+
+dbt mechanics are shared: models are `SELECT`s, dependencies use `{{ ref() }}`/`{{ source() }}`,
+materialization comes from `{{ config() }}`, incremental models use `is_incremental()`. Only the
+**dialect** and **supported strategies** differ.
+
+**Incremental strategy support:**
+
+| Strategy | Fabric DW | Azure SQL (1.8.5) | PostgreSQL | Snowflake |
+|---|---|---|---|---|
+| `append` | ✅ | ✅ | ✅ | ✅ |
+| `delete+insert` | ✅ | ✅ | ✅ (default) | ✅ |
+| `merge` | ⚠️ verify | ✅ | ✅ (PG 15+) | ✅ (default) |
+| `insert_overwrite` | ❌ | ❌ | ❌ | ✅ |
+| `microbatch` (1.9) | ⚠️ verify | ⚠️ likely no | ✅ | ✅ |
+
+**Fabric Warehouse (`dbt-fabric`)** — restricted T-SQL. Use `varchar`/`char` (UTF-8),
+`int/bigint`, `decimal(p,s)`, `float`, `bit`, `date`, `time`, `datetime2`, `uniqueidentifier`,
+`varbinary`. **Avoid** `nvarchar`/`ntext`/`text`, `datetime`/`smalldatetime`, `money`, `xml`,
+`geography`. No enforced constraints/identity. `table` builds via CTAS. Incremental: `append` /
+`delete+insert`; treat `merge`/`microbatch` as "verify".
+
+**Azure SQL / SQL Server (`dbt-sqlserver`)** — full T-SQL: `nvarchar`, `datetime2`, `MERGE`,
+enforced constraints. Incremental: `append`/`delete+insert`/`merge`. Avoid relying on `microbatch`.
+
+**PostgreSQL (`dbt-postgres`)** — `text`/`varchar`, `numeric`, `boolean`, `timestamptz`, `jsonb`,
+`||` concat. Incremental: `append`/`delete+insert`(default)/`merge`(PG15+)/`microbatch`.
+
+**Snowflake (`dbt-snowflake`)** — `varchar`/`number`/`variant`/`timestamp_ntz`; `qualify`, `::`
+casts, `transient`, `cluster_by`. Incremental: `merge`(default)/`append`/`delete+insert`/
+`insert_overwrite`/`microbatch`.
+
+**Porting checklist:** switch `profiles.yml` type + `profileType`; re-map types (classic Fabric
+fixes: `nvarchar`→`varchar`, `datetime`→`datetime2`, `money`→`decimal(19,4)`); confirm the
+incremental strategy is supported (downgrade to `delete+insert` when unsure); translate dialect
+functions (`||` vs `+` vs `concat`, `qualify`, `iff`); re-validate.
+
+---
+
+## Project structure
+
+Standard dbt layout (Core 1.9):
+```text
+<project>/
+├── dbt_project.yml     # name, profile, model-paths, per-folder materialization defaults
+├── profiles.yml        # ADAPTER TYPE + env_var() placeholders only — NO secrets
+├── models/
+│   ├── staging/        # 1:1 with sources, usually views
+│   ├── marts/          # business entities, usually tables/incremental
+│   └── schema.yml      # sources, model docs, tests (this is the data-model schema)
+├── seeds/              # optional CSV reference data
+└── snapshots/          # optional SCD-2 (YAML snapshots in 1.9)
+```
+- Pin the project: `require-dbt-version: [">=1.9.0", "<1.10.0"]`.
+- `schema.yml` uses the Core-1.9 `data_tests:` key; built-ins: `not_null`, `unique`,
+  `accepted_values`, `relationships`. Parse it first when updating a project.
+- Core 1.9 features: `microbatch` incremental strategy, YAML snapshots, `dbt_valid_to_current`.
+
+---
+
+## Security: never write credentials
+
+The Fabric **Connection** object holds every secret; the dbt job references targets **by connection
+GUID**. Therefore:
+- `dbt-content.json` binds via `externalReferences.connection` or `typeProperties.{workspaceId,
+  artifactId}` — never a username/password/account/host secret/connection string.
+- `profiles.yml` (needed only for local `dbt parse`/`compile`) uses `{{ env_var('DBT_...') }}` for
+  every sensitive field, left unset in the file.
+- GitHub sourcing: the classic **PAT** lives only in the `GitHubSourceControl` connection, never in
+  a file. If it rotates, update the connection.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/skills-for-fabric",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "AI coding assistant skills for Microsoft Fabric developers and consumers",
   "repository": {
     "type": "git",

--- a/plugins/fabric-authoring/common/DBT-CORE.md
+++ b/plugins/fabric-authoring/common/DBT-CORE.md
@@ -1,0 +1,147 @@
+# DBT-CORE.md — dbt Job Model, Adapters & Project Reference
+
+Shared reference for the dbt (data build tool) skills. Covers the Fabric dbt job execution model,
+the item-definition structure, the supportability matrix, per-adapter SQL generation for dbt Core
+1.9, and dbt project layout. The consumption skill links here for the execution model; the authoring
+skill links here for SQL generation and project structure.
+
+## Table of contents
+- [Execution model](#execution-model)
+- [Supportability matrix](#supportability-matrix)
+- [Adapter SQL](#adapter-sql)
+- [Project structure](#project-structure)
+- [Security: never write credentials](#security-never-write-credentials)
+
+---
+
+## Execution model
+
+- A dbt job is a Fabric item of type **`DataBuildToolJob`** (preview).
+- Its **definition** is a list of base64 parts:
+  - the **config part** — `dbt-content.json` on the live API / `dbtjob-content.json` in docs;
+    holds `project`, `profile`, and `command` settings. **Discover the name** from `getDefinition`
+    (regex `dbt[\w-]*content\.json`) — do not hardcode.
+  - **`Code/dbt/...`** — the dbt project files (`dbt_project.yml`, `models/*.sql`, `schema.yml`,
+    `seeds/`, `snapshots/`), one part per file. (Absent for GitHub-sourced jobs.)
+  - **`.platform`** — item metadata.
+- `updateDefinition` **replaces the whole part list** → every change is read-modify-write.
+- Runs are triggered with `POST .../items/{id}/jobs/instances?jobType=Execute` and polled to a
+  terminal status (`Completed`/`Failed`/`Cancelled`/`Deduped`).
+
+### Config part (`ContentDetails`) shape
+```jsonc
+{
+  "project": {
+    "projectType": "OneLake",              // "OneLake" | "Lakehouse" | "GitHubSourceControl"
+    "folderPath": "dbt"
+  },
+  "profile": {
+    "profileType": "DataWarehouse",        // DataWarehouse | SqlServer | PostgreSql | Snowflake
+    "schema": "gold",
+    // bind by GUID — either an external connection or workspace/artifact of the warehouse:
+    "connectionSettings": {
+      "name": "MyWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": {
+          "workspaceId": "<ws-guid>", "artifactId": "<warehouse-guid>",
+          "endPoint": "<name>.datawarehouse.fabric.microsoft.com"
+        }
+      }
+    }
+    // or: "externalReferences": { "connection": "<connection-guid>" }
+  },
+  "command": { "operation": "build", "arguments": { "threads": 4, "failFast": true } }
+}
+```
+`operation` ∈ `run | build | show | seed | compile | test | snapshot`. Command arguments:
+`select`, `exclude`, `fullRefresh`, `failFast`, `threads`, `selectorName`.
+
+---
+
+## Supportability matrix
+
+dbt Job Runtime **v1.0**, dbt Core **1.9**, Python **3.12**. Generate Core-1.9 SQL for all four.
+
+| Target | Adapter (pip) | Adapter version | `profiles.yml` type | `profileType` |
+|---|---|---|---|---|
+| Fabric Warehouse | `dbt-fabric` | 1.9.0 | `fabric` | `DataWarehouse` |
+| PostgreSQL | `dbt-postgres` | 1.9.0 | `postgres` | `PostgreSql` |
+| Snowflake | `dbt-snowflake` | 1.9.0 | `snowflake` | `Snowflake` |
+| Azure SQL Database | `dbt-sqlserver` | 1.8.5 | `sqlserver` | `SqlServer` |
+
+Azure SQL pins adapter **1.8.5** (Core-1.9-only features like `microbatch` may be unavailable there —
+prefer `delete+insert`/`merge`). Adapters evolve; verify edge cases at https://docs.getdbt.com.
+
+---
+
+## Adapter SQL
+
+dbt mechanics are shared: models are `SELECT`s, dependencies use `{{ ref() }}`/`{{ source() }}`,
+materialization comes from `{{ config() }}`, incremental models use `is_incremental()`. Only the
+**dialect** and **supported strategies** differ.
+
+**Incremental strategy support:**
+
+| Strategy | Fabric DW | Azure SQL (1.8.5) | PostgreSQL | Snowflake |
+|---|---|---|---|---|
+| `append` | ✅ | ✅ | ✅ | ✅ |
+| `delete+insert` | ✅ | ✅ | ✅ (default) | ✅ |
+| `merge` | ⚠️ verify | ✅ | ✅ (PG 15+) | ✅ (default) |
+| `insert_overwrite` | ❌ | ❌ | ❌ | ✅ |
+| `microbatch` (1.9) | ⚠️ verify | ⚠️ likely no | ✅ | ✅ |
+
+**Fabric Warehouse (`dbt-fabric`)** — restricted T-SQL. Use `varchar`/`char` (UTF-8),
+`int/bigint`, `decimal(p,s)`, `float`, `bit`, `date`, `time`, `datetime2`, `uniqueidentifier`,
+`varbinary`. **Avoid** `nvarchar`/`ntext`/`text`, `datetime`/`smalldatetime`, `money`, `xml`,
+`geography`. No enforced constraints/identity. `table` builds via CTAS. Incremental: `append` /
+`delete+insert`; treat `merge`/`microbatch` as "verify".
+
+**Azure SQL / SQL Server (`dbt-sqlserver`)** — full T-SQL: `nvarchar`, `datetime2`, `MERGE`,
+enforced constraints. Incremental: `append`/`delete+insert`/`merge`. Avoid relying on `microbatch`.
+
+**PostgreSQL (`dbt-postgres`)** — `text`/`varchar`, `numeric`, `boolean`, `timestamptz`, `jsonb`,
+`||` concat. Incremental: `append`/`delete+insert`(default)/`merge`(PG15+)/`microbatch`.
+
+**Snowflake (`dbt-snowflake`)** — `varchar`/`number`/`variant`/`timestamp_ntz`; `qualify`, `::`
+casts, `transient`, `cluster_by`. Incremental: `merge`(default)/`append`/`delete+insert`/
+`insert_overwrite`/`microbatch`.
+
+**Porting checklist:** switch `profiles.yml` type + `profileType`; re-map types (classic Fabric
+fixes: `nvarchar`→`varchar`, `datetime`→`datetime2`, `money`→`decimal(19,4)`); confirm the
+incremental strategy is supported (downgrade to `delete+insert` when unsure); translate dialect
+functions (`||` vs `+` vs `concat`, `qualify`, `iff`); re-validate.
+
+---
+
+## Project structure
+
+Standard dbt layout (Core 1.9):
+```text
+<project>/
+├── dbt_project.yml     # name, profile, model-paths, per-folder materialization defaults
+├── profiles.yml        # ADAPTER TYPE + env_var() placeholders only — NO secrets
+├── models/
+│   ├── staging/        # 1:1 with sources, usually views
+│   ├── marts/          # business entities, usually tables/incremental
+│   └── schema.yml      # sources, model docs, tests (this is the data-model schema)
+├── seeds/              # optional CSV reference data
+└── snapshots/          # optional SCD-2 (YAML snapshots in 1.9)
+```
+- Pin the project: `require-dbt-version: [">=1.9.0", "<1.10.0"]`.
+- `schema.yml` uses the Core-1.9 `data_tests:` key; built-ins: `not_null`, `unique`,
+  `accepted_values`, `relationships`. Parse it first when updating a project.
+- Core 1.9 features: `microbatch` incremental strategy, YAML snapshots, `dbt_valid_to_current`.
+
+---
+
+## Security: never write credentials
+
+The Fabric **Connection** object holds every secret; the dbt job references targets **by connection
+GUID**. Therefore:
+- `dbt-content.json` binds via `externalReferences.connection` or `typeProperties.{workspaceId,
+  artifactId}` — never a username/password/account/host secret/connection string.
+- `profiles.yml` (needed only for local `dbt parse`/`compile`) uses `{{ env_var('DBT_...') }}` for
+  every sensitive field, left unset in the file.
+- GitHub sourcing: the classic **PAT** lives only in the `GitHubSourceControl` connection, never in
+  a file. If it rotates, update the connection.

--- a/plugins/fabric-authoring/skills/dbt-authoring-cli/SKILL.md
+++ b/plugins/fabric-authoring/skills/dbt-authoring-cli/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: dbt-authoring-cli
+description: >
+  Create, configure, update, deploy, and run dbt (data build tool) jobs (DataBuildToolJob) in
+  Microsoft Fabric via `az rest`, and generate dbt Core 1.9 SQL models for the supported adapters
+  (Fabric Warehouse, Azure SQL Database, PostgreSQL, Snowflake).
+  Use when the user wants to:
+    1. Create or configure a Fabric dbt job (connection, schema, run command)
+    2. Generate or port dbt models (.sql) / schema.yml / dbt_project.yml for a specific adapter
+    3. Deploy a local dbt project into a job (Code/dbt/* definition parts) with read-modify-write
+    4. Add tests, sources, incremental logic, or snapshots to a dbt project
+    5. Connect a dbt job to an existing GitHub repository as the code source (run-only)
+    6. Trigger a dbt run (build/run/test/seed/snapshot/compile) and monitor it
+  Triggers: "create dbt job", "set up dbt in Fabric", "make a dbt model for my Fabric warehouse",
+  "port this dbt model to Snowflake", "add an incremental model", "deploy dbt project",
+  "update my dbt job", "connect dbt job to github", "run dbt build in Fabric", "dbt authoring"
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+> **CRITICAL NOTES**
+> 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering.
+> 2. To find the item details (including its ID) from workspace ID, item type (`DataBuildToolJob`), and item name: list all items of that type in that workspace and, then, use JMESPath filtering.
+> 3. **Never write credentials into config.** A dbt job binds its target and its GitHub source **by connection GUID**; the secret lives in the Fabric Connection object. No password, account, token, or connection string ever goes into `dbtjob-content.json`, `profiles.yml`, or any project file.
+> 4. **`updateDefinition` replaces the entire part list.** Read-modify-write every time (getDefinition → keep all existing parts → change what you need → updateDefinition) or you will delete the project files.
+
+# dbt-authoring-cli — Author, Deploy & Run Fabric dbt Jobs via CLI
+
+## Table of Contents
+
+| Task | Reference | Notes |
+|---|---|---|
+| Finding Workspaces and Items in Fabric | [COMMON-CLI.md § Finding Workspaces and Items in Fabric](../../common/COMMON-CLI.md#finding-workspaces-and-items-in-fabric) | **Mandatory** — *READ link first* [resolve workspace/item IDs; use `type=DataBuildToolJob`] |
+| Fabric Topology & Key Concepts | [COMMON-CORE.md § Fabric Topology & Key Concepts](../../common/COMMON-CORE.md#fabric-topology--key-concepts) | |
+| Environment URLs | [COMMON-CORE.md § Environment URLs](../../common/COMMON-CORE.md#environment-urls) | |
+| Authentication & Token Acquisition | [COMMON-CORE.md § Authentication & Token Acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition) | Wrong audience = 401; use `https://api.fabric.microsoft.com` |
+| Core Control-Plane REST APIs | [COMMON-CORE.md § Core Control-Plane REST APIs](../../common/COMMON-CORE.md#core-control-plane-rest-apis) | List Items, Item Creation, definition APIs |
+| Long-Running Operations (LRO) | [COMMON-CORE.md § Long-Running Operations (LRO)](../../common/COMMON-CORE.md#long-running-operations-lro) | Create/getDefinition/updateDefinition/run are LROs |
+| Item Definitions envelope | [ITEM-DEFINITIONS-CORE.md § Definition Envelope](../../common/ITEM-DEFINITIONS-CORE.md#definition-envelope) | Base64 parts, `.platform` file |
+| Fabric Control-Plane API via `az rest` | [COMMON-CLI.md § Fabric Control-Plane API via az rest](../../common/COMMON-CLI.md#fabric-control-plane-api-via-az-rest) | **Always pass `--resource https://api.fabric.microsoft.com`** |
+| Long-Running Operations (LRO) Pattern | [COMMON-CLI.md § Long-Running Operations (LRO) Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern) | Poll `Location` / `operations/{id}` |
+| dbt job execution model & definition | [DBT-CORE.md § Execution model](../../common/DBT-CORE.md#execution-model) | Item type, `Code/dbt/*` parts, content part name, connection binding |
+| Supportability matrix (adapters) | [DBT-CORE.md § Supportability matrix](../../common/DBT-CORE.md#supportability-matrix) | dbt Core 1.9; adapter versions & profileType per target |
+| Adapter SQL generation | [DBT-CORE.md § Adapter SQL](../../common/DBT-CORE.md#adapter-sql) | Types, materializations, incremental strategies, porting |
+| dbt project structure | [DBT-CORE.md § Project structure](../../common/DBT-CORE.md#project-structure) | dbt_project.yml, profiles.yml (no secrets), schema.yml, 1.9 features |
+| Authoring recipes (`az rest`) | [authoring-recipes.md](references/authoring-recipes.md) | Create job, deploy project, set config, run — copy/paste `az rest` |
+| GitHub source (run-only) | [authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source) | Create GitHubSourceControl connection + bind job to repo/branch |
+| Tool Stack | [SKILL.md § Tool Stack](#tool-stack) | |
+| Authoring Scope | [SKILL.md § Authoring Scope](#authoring-scope) | |
+| Core Workflow | [SKILL.md § Core Workflow](#core-workflow) | Create → generate SQL → deploy → configure → run |
+| Preview & Confirm (writes) | [SKILL.md § Preview & Confirm](#preview--confirm) | **Human-in-the-loop before any write/run** |
+| Must / Prefer / Avoid | [SKILL.md § Must / Prefer / Avoid](#must--prefer--avoid) | |
+| Examples | [SKILL.md § Examples](#examples) | |
+| Agent Integration Notes | [SKILL.md § Agent Integration Notes](#agent-integration-notes) | |
+
+---
+
+## Tool Stack
+
+| Tool | Purpose | Install |
+|---|---|---|
+| **az cli** | Fabric control-plane REST + item definition + run via `az rest` | `winget install Microsoft.AzureCLI` |
+| **jq** | JSON processing / decoding base64 definition parts | `winget install jqlang.jq` |
+| **base64** | Encode project files into definition parts (coreutils / built-in) | preinstalled on Linux/macOS |
+
+Authenticate once (see [COMMON-CLI.md § Authentication Recipes](../../common/COMMON-CLI.md#authentication-recipes)):
+
+```bash
+az login
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+```
+
+---
+
+## Authoring Scope
+
+| Operation | Endpoint (via `az rest`, `--resource $RES`) |
+|---|---|
+| Create dbt job | `POST $API/workspaces/{ws}/dataBuildToolJobs` |
+| List dbt jobs | `GET  $API/workspaces/{ws}/items?type=DataBuildToolJob` |
+| Get definition (all parts) | `POST $API/workspaces/{ws}/items/{id}/getDefinition` |
+| Update definition (RMW) | `POST $API/workspaces/{ws}/items/{id}/updateDefinition` |
+| Trigger run | `POST $API/workspaces/{ws}/items/{id}/jobs/instances?jobType=Execute` |
+| Create GitHub connection | `POST $API/connections` (type `GitHubSourceControl`) |
+
+The dbt **project files** ship inside the definition as parts under `Code/dbt/*`; the **config**
+part (`dbt-content.json` / `dbtjob-content.json`) holds project/profile/command settings. See
+[DBT-CORE.md](../../common/DBT-CORE.md) for the full model.
+
+---
+
+## Core Workflow
+
+For a new, in-Fabric dbt job:
+
+1. **Confirm intent** — target adapter (Fabric DW / Azure SQL / PostgreSQL / Snowflake), what the
+   models should do, and the target connection/schema. If ambiguous, ask (see *Preview & Confirm*).
+2. **Generate the project** — `dbt_project.yml`, `models/*.sql`, `schema.yml`, seeds. Write
+   Core-1.9 SQL for the chosen adapter using [DBT-CORE.md § Adapter SQL](../../common/DBT-CORE.md#adapter-sql).
+   Keep `profiles.yml` secret-free (`env_var()` placeholders only).
+3. **Create the job** and **deploy** the project into `Code/dbt/*`
+   ([authoring-recipes.md](references/authoring-recipes.md)).
+4. **Set the config** — bind the warehouse **by connection GUID**, set schema and run command.
+5. **Run** and confirm the instance reaches `Completed` (never treat a 202 as success).
+
+To use an existing **GitHub** repo instead of storing files in Fabric, skip steps 2–3 and follow
+[authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source) — these jobs
+are **run-only** (edit models in GitHub).
+
+To **update an existing** job's models, delegate discovery to **dbt-consumption-cli** (decode the
+definition + parse `schema.yml`), then redeploy with read-modify-write.
+
+---
+
+## Preview & Confirm
+
+Writes and runs have side effects (they create items, overwrite definitions, and execute SQL against
+a warehouse), so treat them like any irreversible operation:
+
+- If the request is ambiguous (no adapter, no target, "set up my dbt job"), **ask first** — offer
+  the concrete options rather than inferring.
+- Before `updateDefinition` or a run, **show the plan**: which job, which parts change, the resolved
+  `dbt-content.json` (connection GUID + schema + command), and the operation. Proceed on explicit
+  confirmation.
+- Before `updateDefinition`, **always** `getDefinition` first and preserve every existing part —
+  a partial part list deletes the project files.
+
+---
+
+## Must / Prefer / Avoid
+
+### Must
+- Bind targets **by connection GUID** (`externalReferences.connection` or workspace/artifact GUIDs).
+  Never put a credential in any file. For GitHub sourcing, the classic PAT lives only in the
+  `GitHubSourceControl` connection.
+- Read-modify-write for every `updateDefinition` (preserve `Code/dbt/*` + `.platform`).
+- **Discover** the config-part name from `getDefinition` (`dbt[\w-]*content\.json`) — it differs by
+  API version (`dbt-content.json` live vs `dbtjob-content.json` in docs).
+- Poll LROs / run instances to a terminal state before reporting success.
+
+### Prefer
+- `dbt build` as the default command (models + tests + seeds + snapshots).
+- `delete+insert` incremental strategy for portability; upgrade to `merge`/`microbatch` only where
+  the adapter supports it (see [DBT-CORE.md](../../common/DBT-CORE.md#adapter-sql)).
+- Fabric-Warehouse-safe types (`varchar` not `nvarchar`, `datetime2` not `datetime`, `decimal` not
+  `money`).
+
+### Avoid
+- Hand-building `updateDefinition` with a partial part list (drops files).
+- Hardcoding three-part table names in models — use `{{ ref() }}` / `{{ source() }}`.
+- Writing `profiles.yml` with real host/user/password — use `env_var()` placeholders.
+- Deploying `Code/dbt/*` to a GitHub-connected (run-only) job — edit in the repo instead.
+
+---
+
+## Examples
+
+### Example 1 — New Fabric DW job, deploy + run
+See [authoring-recipes.md § End-to-end](references/authoring-recipes.md#end-to-end): create the job,
+`base64`-pack `./my_dbt_project` into `Code/dbt/*`, set `profileType=DataWarehouse` bound to the
+warehouse GUID + schema `gold`, `operation=build`, then trigger and poll a run.
+
+### Example 2 — Generate an incremental model for Fabric DW
+```sql
+{{ config(materialized='incremental', incremental_strategy='delete+insert', unique_key='order_id') }}
+select
+    cast(order_id as bigint)      as order_id,
+    cast(amount   as decimal(19,4)) as amount,   -- not money
+    cast(status   as varchar(50)) as status      -- not nvarchar
+from {{ ref('stg_orders') }}
+{% if is_incremental() %}
+where order_date > (select max(order_date) from {{ this }})
+{% endif %}
+```
+
+### Example 3 — Connect a job to a GitHub repo (run-only)
+See [authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source): create a
+`GitHubSourceControl` connection from a classic PAT, bind the job's project to that connection +
+branch (profile/command unchanged), then run.
+
+---
+
+## Agent Integration Notes
+
+- This skill covers **authoring** — create/configure/update/deploy/run dbt jobs and generate SQL.
+- For **read-only** discovery, run-history, and monitoring, delegate to **dbt-consumption-cli**.
+- For end-to-end lakehouse patterns, see **e2e-medallion-architecture**; for warehouse T-SQL, see
+  **sqldw-authoring-cli**.
+- All writes require a Contributor workspace role and read/write on the target warehouse/connection.

--- a/plugins/fabric-authoring/skills/dbt-authoring-cli/references/authoring-recipes.md
+++ b/plugins/fabric-authoring/skills/dbt-authoring-cli/references/authoring-recipes.md
@@ -1,0 +1,186 @@
+# Authoring Recipes — `az rest` for Fabric dbt Jobs
+
+Copy/paste `az rest` recipes for the full dbt job lifecycle. All calls pass
+`--resource https://api.fabric.microsoft.com`. Assumes:
+
+```bash
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+WS="<workspace-id>"
+```
+
+See [DBT-CORE.md](../../../common/DBT-CORE.md) for the definition model and the no-secrets rule. Confirm writes with
+the user first (see SKILL.md § Preview & Confirm).
+
+## Create a dbt job
+
+```bash
+JOB_ID=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/dataBuildToolJobs" \
+  --headers "Content-Type=application/json" \
+  --body '{"displayName":"Sales dbt job","description":"Builds sales marts"}' \
+  --query "id" -o tsv)
+echo "Job: $JOB_ID"
+```
+
+## Discover the config-part name (never hardcode)
+
+```bash
+# getDefinition (LRO — poll Location if 202; see COMMON-CLI.md § LRO Pattern)
+DEF=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/getDefinition")
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+CONTENT_PART="${CONTENT_PART:-dbt-content.json}"     # default for a brand-new job
+echo "Config part: $CONTENT_PART"
+```
+
+## Deploy a local project into `Code/dbt/*` (read-modify-write)
+
+`updateDefinition` replaces the whole part list, so rebuild it from the **existing** parts plus your
+files. This packs everything under `./my_dbt_project` as `Code/dbt/<relpath>` and keeps any config /
+`.platform` part already present.
+
+```bash
+ROOT="./my_dbt_project"
+
+# Start from existing parts EXCEPT the project files we're about to replace.
+PARTS=$(echo "$DEF" | jq '[.definition.parts[] | select(.path | startswith("Code/dbt/") | not)]')
+
+# Add each project file as a Code/dbt/* part.
+while IFS= read -r f; do
+  rel="${f#"$ROOT"/}"
+  b64=$(base64 -w0 < "$f" 2>/dev/null || base64 < "$f" | tr -d '\n')   # macOS has no -w0
+  PARTS=$(echo "$PARTS" | jq --arg p "Code/dbt/$rel" --arg pl "$b64" \
+    '. + [{path:$p, payload:$pl, payloadType:"InlineBase64"}]')
+done < <(find "$ROOT" -type f -not -path '*/target/*' -not -path '*/.git/*')
+
+az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/updateDefinition" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --argjson parts "$PARTS" '{definition:{parts:$parts}}')"
+```
+
+## Set the config part (connection GUID + schema + command)
+
+Binds a **Fabric Warehouse** by workspace/artifact GUID. For Postgres/Snowflake/SQL Server, replace
+`connectionSettings` with `"externalReferences": {"connection":"<conn-guid>"}` and set `profileType`
+accordingly (`PostgreSql`/`Snowflake`/`SqlServer`). No credentials appear anywhere.
+
+```bash
+WH_ID="<warehouse-item-id>"
+WH_FQDN=$(az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$WH_ID" --query "properties.connectionString" -o tsv)
+
+cat > /tmp/dbt-content.json << EOF
+{
+  "project": { "projectType": "OneLake", "folderPath": "dbt" },
+  "profile": {
+    "profileType": "DataWarehouse",
+    "schema": "gold",
+    "connectionSettings": {
+      "name": "SalesWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": { "workspaceId": "$WS", "artifactId": "$WH_ID", "endPoint": "$WH_FQDN" }
+      }
+    }
+  },
+  "command": { "operation": "build", "arguments": { "threads": 4, "failFast": true } }
+}
+EOF
+
+# RMW: keep all existing parts, replace only the config part.
+CONTENT_B64=$(base64 -w0 < /tmp/dbt-content.json 2>/dev/null || base64 < /tmp/dbt-content.json | tr -d '\n')
+PARTS=$(echo "$DEF" | jq --arg cp "$CONTENT_PART" \
+  '[.definition.parts[] | select(.path != $cp)]')
+PARTS=$(echo "$PARTS" | jq --arg cp "$CONTENT_PART" --arg pl "$CONTENT_B64" \
+  '. + [{path:$cp, payload:$pl, payloadType:"InlineBase64"}]')
+
+az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/updateDefinition" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --argjson parts "$PARTS" '{definition:{parts:$parts}}')"
+```
+
+## Trigger a run and monitor
+
+```bash
+RUN_LOCATION=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances?jobType=Execute" \
+  --headers "Content-Length=0" --output none --include-response-headers 2>&1 \
+  | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+while true; do
+  RUN=$(az rest --method GET --resource "$RES" --url "$RUN_LOCATION")
+  STATUS=$(echo "$RUN" | jq -r '.status')
+  echo "Status: $STATUS"
+  [[ "$STATUS" =~ ^(Completed|Failed|Cancelled|Deduped)$ ]] && break
+  sleep 15
+done
+[[ "$STATUS" == "Failed" ]] && echo "$RUN" | jq '.failureReason'
+```
+
+## End-to-end
+
+Create → deploy `Code/dbt/*` → set config → run, in order: run the four blocks above with the same
+`$JOB_ID` and `$DEF` (re-fetch `$DEF` with getDefinition before each RMW so you always start from the
+current parts).
+
+---
+
+## GitHub source
+
+Connect a job to an existing GitHub repo instead of storing files in Fabric. **Run-only** — you can't
+edit models in Fabric; commit to the repo and Fabric pulls on the next run. The classic PAT lives
+only in the connection.
+
+### 1) Create the GitHub source-control connection (PAT from env)
+
+```bash
+# Read the PAT from the environment so it never appears in shell history / files.
+read -rs GITHUB_PAT    # or: export GITHUB_PAT before running
+
+CONN_ID=$(az rest --method POST --resource "$RES" --url "$API/connections" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --arg url 'https://github.com/<owner>/<repo>' --arg pat "$GITHUB_PAT" '{
+    connectivityType:"ShareableCloud",
+    displayName:"MyGitHubPAT",
+    connectionDetails:{ type:"GitHubSourceControl", creationMethod:"GitHubSourceControl.Contents",
+      parameters:[{dataType:"Text", name:"url", value:$url}] },
+    credentialDetails:{ credentials:{ credentialType:"Key", key:$pat } }
+  }')" \
+  --query "id" -o tsv)
+echo "GitHub connection: $CONN_ID"
+```
+
+Response `connectionDetails.type` is `GitHubSourceControl`. Omitting the repo in `parameters.url`
+scopes the connection to all repos the PAT can read.
+
+### 2) Bind the dbt job to the GitHub source
+
+Project points at the GitHub connection + branch; **profile and command stay the normal warehouse
+binding** (a GitHub-sourced job still has an adapter + warehouse + schema). Push with `updateDefinition`.
+
+> The git-source `project` block below is **inferred** (the portal writes it inside an iframe that
+> can't be captured) — verify against your tenant. If rejected, capture a working job's definition
+> with dbt-consumption-cli and copy the exact `project` shape.
+
+```jsonc
+{
+  "project": {
+    "projectType": "GitHubSourceControl",
+    "connectionSettings": {
+      "type": "GitHubSourceControl",
+      "properties": { "connection": "<github-connection-guid>", "branch": "main", "rootFolder": "" }
+    }
+  },
+  "profile": { "profileType": "DataWarehouse", "schema": "jaffle_shop",
+    "connectionSettings": { "name": "jaffle_shop_dw", "properties": { "type":"DataWarehouse",
+      "typeProperties": { "workspaceId":"<ws>", "artifactId":"<warehouse>", "endPoint":"<fqdn>" } } } },
+  "command": { "operation": "build", "arguments": { "threads": 4 } }
+}
+```
+
+### 3) Run
+
+Identical to any dbt job — see [Trigger a run and monitor](#trigger-a-run-and-monitor).

--- a/plugins/fabric-consumption/common/DBT-CORE.md
+++ b/plugins/fabric-consumption/common/DBT-CORE.md
@@ -1,0 +1,147 @@
+# DBT-CORE.md — dbt Job Model, Adapters & Project Reference
+
+Shared reference for the dbt (data build tool) skills. Covers the Fabric dbt job execution model,
+the item-definition structure, the supportability matrix, per-adapter SQL generation for dbt Core
+1.9, and dbt project layout. The consumption skill links here for the execution model; the authoring
+skill links here for SQL generation and project structure.
+
+## Table of contents
+- [Execution model](#execution-model)
+- [Supportability matrix](#supportability-matrix)
+- [Adapter SQL](#adapter-sql)
+- [Project structure](#project-structure)
+- [Security: never write credentials](#security-never-write-credentials)
+
+---
+
+## Execution model
+
+- A dbt job is a Fabric item of type **`DataBuildToolJob`** (preview).
+- Its **definition** is a list of base64 parts:
+  - the **config part** — `dbt-content.json` on the live API / `dbtjob-content.json` in docs;
+    holds `project`, `profile`, and `command` settings. **Discover the name** from `getDefinition`
+    (regex `dbt[\w-]*content\.json`) — do not hardcode.
+  - **`Code/dbt/...`** — the dbt project files (`dbt_project.yml`, `models/*.sql`, `schema.yml`,
+    `seeds/`, `snapshots/`), one part per file. (Absent for GitHub-sourced jobs.)
+  - **`.platform`** — item metadata.
+- `updateDefinition` **replaces the whole part list** → every change is read-modify-write.
+- Runs are triggered with `POST .../items/{id}/jobs/instances?jobType=Execute` and polled to a
+  terminal status (`Completed`/`Failed`/`Cancelled`/`Deduped`).
+
+### Config part (`ContentDetails`) shape
+```jsonc
+{
+  "project": {
+    "projectType": "OneLake",              // "OneLake" | "Lakehouse" | "GitHubSourceControl"
+    "folderPath": "dbt"
+  },
+  "profile": {
+    "profileType": "DataWarehouse",        // DataWarehouse | SqlServer | PostgreSql | Snowflake
+    "schema": "gold",
+    // bind by GUID — either an external connection or workspace/artifact of the warehouse:
+    "connectionSettings": {
+      "name": "MyWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": {
+          "workspaceId": "<ws-guid>", "artifactId": "<warehouse-guid>",
+          "endPoint": "<name>.datawarehouse.fabric.microsoft.com"
+        }
+      }
+    }
+    // or: "externalReferences": { "connection": "<connection-guid>" }
+  },
+  "command": { "operation": "build", "arguments": { "threads": 4, "failFast": true } }
+}
+```
+`operation` ∈ `run | build | show | seed | compile | test | snapshot`. Command arguments:
+`select`, `exclude`, `fullRefresh`, `failFast`, `threads`, `selectorName`.
+
+---
+
+## Supportability matrix
+
+dbt Job Runtime **v1.0**, dbt Core **1.9**, Python **3.12**. Generate Core-1.9 SQL for all four.
+
+| Target | Adapter (pip) | Adapter version | `profiles.yml` type | `profileType` |
+|---|---|---|---|---|
+| Fabric Warehouse | `dbt-fabric` | 1.9.0 | `fabric` | `DataWarehouse` |
+| PostgreSQL | `dbt-postgres` | 1.9.0 | `postgres` | `PostgreSql` |
+| Snowflake | `dbt-snowflake` | 1.9.0 | `snowflake` | `Snowflake` |
+| Azure SQL Database | `dbt-sqlserver` | 1.8.5 | `sqlserver` | `SqlServer` |
+
+Azure SQL pins adapter **1.8.5** (Core-1.9-only features like `microbatch` may be unavailable there —
+prefer `delete+insert`/`merge`). Adapters evolve; verify edge cases at https://docs.getdbt.com.
+
+---
+
+## Adapter SQL
+
+dbt mechanics are shared: models are `SELECT`s, dependencies use `{{ ref() }}`/`{{ source() }}`,
+materialization comes from `{{ config() }}`, incremental models use `is_incremental()`. Only the
+**dialect** and **supported strategies** differ.
+
+**Incremental strategy support:**
+
+| Strategy | Fabric DW | Azure SQL (1.8.5) | PostgreSQL | Snowflake |
+|---|---|---|---|---|
+| `append` | ✅ | ✅ | ✅ | ✅ |
+| `delete+insert` | ✅ | ✅ | ✅ (default) | ✅ |
+| `merge` | ⚠️ verify | ✅ | ✅ (PG 15+) | ✅ (default) |
+| `insert_overwrite` | ❌ | ❌ | ❌ | ✅ |
+| `microbatch` (1.9) | ⚠️ verify | ⚠️ likely no | ✅ | ✅ |
+
+**Fabric Warehouse (`dbt-fabric`)** — restricted T-SQL. Use `varchar`/`char` (UTF-8),
+`int/bigint`, `decimal(p,s)`, `float`, `bit`, `date`, `time`, `datetime2`, `uniqueidentifier`,
+`varbinary`. **Avoid** `nvarchar`/`ntext`/`text`, `datetime`/`smalldatetime`, `money`, `xml`,
+`geography`. No enforced constraints/identity. `table` builds via CTAS. Incremental: `append` /
+`delete+insert`; treat `merge`/`microbatch` as "verify".
+
+**Azure SQL / SQL Server (`dbt-sqlserver`)** — full T-SQL: `nvarchar`, `datetime2`, `MERGE`,
+enforced constraints. Incremental: `append`/`delete+insert`/`merge`. Avoid relying on `microbatch`.
+
+**PostgreSQL (`dbt-postgres`)** — `text`/`varchar`, `numeric`, `boolean`, `timestamptz`, `jsonb`,
+`||` concat. Incremental: `append`/`delete+insert`(default)/`merge`(PG15+)/`microbatch`.
+
+**Snowflake (`dbt-snowflake`)** — `varchar`/`number`/`variant`/`timestamp_ntz`; `qualify`, `::`
+casts, `transient`, `cluster_by`. Incremental: `merge`(default)/`append`/`delete+insert`/
+`insert_overwrite`/`microbatch`.
+
+**Porting checklist:** switch `profiles.yml` type + `profileType`; re-map types (classic Fabric
+fixes: `nvarchar`→`varchar`, `datetime`→`datetime2`, `money`→`decimal(19,4)`); confirm the
+incremental strategy is supported (downgrade to `delete+insert` when unsure); translate dialect
+functions (`||` vs `+` vs `concat`, `qualify`, `iff`); re-validate.
+
+---
+
+## Project structure
+
+Standard dbt layout (Core 1.9):
+```text
+<project>/
+├── dbt_project.yml     # name, profile, model-paths, per-folder materialization defaults
+├── profiles.yml        # ADAPTER TYPE + env_var() placeholders only — NO secrets
+├── models/
+│   ├── staging/        # 1:1 with sources, usually views
+│   ├── marts/          # business entities, usually tables/incremental
+│   └── schema.yml      # sources, model docs, tests (this is the data-model schema)
+├── seeds/              # optional CSV reference data
+└── snapshots/          # optional SCD-2 (YAML snapshots in 1.9)
+```
+- Pin the project: `require-dbt-version: [">=1.9.0", "<1.10.0"]`.
+- `schema.yml` uses the Core-1.9 `data_tests:` key; built-ins: `not_null`, `unique`,
+  `accepted_values`, `relationships`. Parse it first when updating a project.
+- Core 1.9 features: `microbatch` incremental strategy, YAML snapshots, `dbt_valid_to_current`.
+
+---
+
+## Security: never write credentials
+
+The Fabric **Connection** object holds every secret; the dbt job references targets **by connection
+GUID**. Therefore:
+- `dbt-content.json` binds via `externalReferences.connection` or `typeProperties.{workspaceId,
+  artifactId}` — never a username/password/account/host secret/connection string.
+- `profiles.yml` (needed only for local `dbt parse`/`compile`) uses `{{ env_var('DBT_...') }}` for
+  every sensitive field, left unset in the file.
+- GitHub sourcing: the classic **PAT** lives only in the `GitHubSourceControl` connection, never in
+  a file. If it rotates, update the connection.

--- a/plugins/fabric-consumption/skills/dbt-consumption-cli/SKILL.md
+++ b/plugins/fabric-consumption/skills/dbt-consumption-cli/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dbt-consumption-cli
+description: >
+  Discover, inspect, and monitor Fabric dbt jobs (DataBuildToolJob) via `az rest` — read-only and
+  run-focused operations. List dbt jobs, decode their configuration and project files from the item
+  definition, review model schema (schema.yml), trigger runs, and inspect run history and failures.
+  Use when the user wants to:
+    1. List the dbt jobs in a workspace
+    2. Inspect a dbt job's adapter, schema, connection, and run command
+    3. See which project files (models, schema.yml) ship with a job
+    4. Trigger a dbt run and monitor it, or review run history / failure reasons
+    5. Compare dbt command/profile settings across jobs (governance)
+  Triggers: "list dbt jobs", "inspect dbt job", "show dbt config", "dbt run history",
+  "why did my dbt job fail", "monitor dbt run", "which models are in my dbt job", "dbt consumption"
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+> **CRITICAL NOTES**
+> 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering.
+> 2. To find dbt jobs: list items with `type=DataBuildToolJob`, then filter by `displayName`.
+> 3. **Decode before inspecting** — definition parts are base64; the config-part name varies by API version (discover it via `dbt[\w-]*content\.json`).
+
+# dbt-consumption-cli — Inspect & Monitor Fabric dbt Jobs via CLI
+
+## Table of Contents
+
+| Task | Reference | Notes |
+|---|---|---|
+| Finding Workspaces and Items in Fabric | [COMMON-CLI.md § Finding Workspaces and Items in Fabric](../../common/COMMON-CLI.md#finding-workspaces-and-items-in-fabric) | **Mandatory** — *READ link first* [use `type=DataBuildToolJob`] |
+| Authentication & Token Acquisition | [COMMON-CORE.md § Authentication & Token Acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition) | Wrong audience = 401 |
+| Core Control-Plane REST APIs | [COMMON-CORE.md § Core Control-Plane REST APIs](../../common/COMMON-CORE.md#core-control-plane-rest-apis) | List Items, getDefinition |
+| Long-Running Operations (LRO) | [COMMON-CORE.md § Long-Running Operations (LRO)](../../common/COMMON-CORE.md#long-running-operations-lro) | getDefinition can be a 202 LRO |
+| Fabric Control-Plane API via `az rest` | [COMMON-CLI.md § Fabric Control-Plane API via az rest](../../common/COMMON-CLI.md#fabric-control-plane-api-via-az-rest) | **Always pass `--resource https://api.fabric.microsoft.com`** |
+| Long-Running Operations (LRO) Pattern | [COMMON-CLI.md § Long-Running Operations (LRO) Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern) | Poll `Location` |
+| dbt job execution model & definition | [DBT-CORE.md § Execution model](../../common/DBT-CORE.md#execution-model) | Item type, `Code/dbt/*` parts, config-part name |
+| Adapter reference | [DBT-CORE.md § Supportability matrix](../../common/DBT-CORE.md#supportability-matrix) | Interpreting `profileType` |
+| Inspect & monitor recipes (`az rest`) | [inspect-recipes.md](references/inspect-recipes.md) | List, decode config, list Code/dbt parts, run history |
+| Discovery Scope | [SKILL.md § Discovery Scope](#discovery-scope) | |
+| Must / Prefer / Avoid | [SKILL.md § Must / Prefer / Avoid](#must--prefer--avoid) | |
+| Troubleshooting | [SKILL.md § Troubleshooting](#troubleshooting) | |
+| Agent Integration Notes | [SKILL.md § Agent Integration Notes](#agent-integration-notes) | |
+
+---
+
+## Discovery Scope
+
+| Operation | Endpoint (via `az rest`, `--resource https://api.fabric.microsoft.com`) |
+|---|---|
+| List dbt jobs | `GET  /v1/workspaces/{ws}/items?type=DataBuildToolJob` |
+| Get item | `GET  /v1/workspaces/{ws}/dataBuildToolJobs/{id}` |
+| Get definition (decode) | `POST /v1/workspaces/{ws}/items/{id}/getDefinition` |
+| Run history | `GET  /v1/workspaces/{ws}/items/{id}/jobs/instances` |
+| Trigger run | `POST /v1/workspaces/{ws}/items/{id}/jobs/instances?jobType=Execute` |
+
+All read-only except triggering a run. See [inspect-recipes.md](references/inspect-recipes.md) for
+copy/paste commands, and [DBT-CORE.md](../../common/DBT-CORE.md) for the definition model.
+
+---
+
+## Must / Prefer / Avoid
+
+### Must
+- Use `type=DataBuildToolJob` when listing (not `dbtJob`).
+- **Discover** the config-part name from `getDefinition` (`dbt[\w-]*content\.json`) before decoding.
+- Decode base64 parts before inspecting; handle `getDefinition` 202 by polling `Location`.
+
+### Prefer
+- Inspect a job's config + `schema.yml` **before** triggering a run or handing off to authoring.
+- Filter run history by status/time; read `failureReason` on failures.
+- `jq` / JMESPath for compact diagnostics.
+
+### Avoid
+- Assuming the config-part name (`dbt-content.json` vs `dbtjob-content.json`).
+- Editing anything here — this skill is read-only. For changes, delegate to **dbt-authoring-cli**.
+- Polling runs without a backoff.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Empty job list | Wrong item type filter | Use `type=DataBuildToolJob` |
+| 401 on API calls | Wrong/expired token | Re-login; keep `--resource https://api.fabric.microsoft.com` |
+| Missing content part | Hardcoded part name | Discover via `getDefinition` regex `dbt.?content\.json` |
+| No `Code/dbt/*` parts | GitHub-sourced (run-only) job | Code lives in GitHub; inspect the repo, not the definition |
+| 400 on run trigger | Wrong `jobType` | Use `jobType=Execute` |
+
+---
+
+## Agent Integration Notes
+
+- This skill is **read-only + run** — discover, inspect, monitor. It never edits a job.
+- For create/configure/update/deploy and SQL generation, delegate to **dbt-authoring-cli**.
+- Inspecting `schema.yml` here is the first step of the authoring skill's update workflow.

--- a/plugins/fabric-consumption/skills/dbt-consumption-cli/references/inspect-recipes.md
+++ b/plugins/fabric-consumption/skills/dbt-consumption-cli/references/inspect-recipes.md
@@ -1,0 +1,98 @@
+# Inspect & Monitor Recipes — `az rest` for Fabric dbt Jobs
+
+Read-only (plus run) recipes. All calls pass `--resource https://api.fabric.microsoft.com`. Assumes:
+
+```bash
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+WS="<workspace-id>"
+```
+
+See [DBT-CORE.md](../../../common/DBT-CORE.md) for the definition model.
+
+## 1) List dbt jobs in a workspace
+
+```bash
+az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items?type=DataBuildToolJob" \
+  --query "value[].{name:displayName, id:id, description:description}" -o table
+```
+
+## 2) Decode a job's configuration (adapter, schema, command)
+
+```bash
+JOB_ID="<dbt-job-id>"
+DEF=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/getDefinition")     # poll Location if 202
+
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+echo "$DEF" | jq -r --arg p "$CONTENT_PART" \
+  '.definition.parts[] | select(.path==$p) | .payload' | base64 -d | jq '{
+    projectType: .project.projectType,
+    adapter:     .profile.profileType,
+    schema:      .profile.schema,
+    operation:   .command.operation,
+    select:      .command.arguments.select,
+    threads:     .command.arguments.threads,
+    failFast:    .command.arguments.failFast
+  }'
+```
+
+## 3) List the project files shipped with the job
+
+```bash
+echo "$DEF" | jq -r '.definition.parts[].path | select(startswith("Code/dbt/"))'
+```
+
+No `Code/dbt/*` parts usually means the job is **GitHub-sourced** (run-only) — the code lives in the
+repo, not the definition. Check `project.projectType` from step 2.
+
+## 4) Read a specific model or schema.yml (understand the data model)
+
+```bash
+# Decode schema.yml — the source of truth for the model's columns and tests.
+echo "$DEF" | jq -r '.definition.parts[] | select(.path|endswith("schema.yml")) | .payload' \
+  | base64 -d
+
+# Decode a specific model
+echo "$DEF" | jq -r '.definition.parts[] | select(.path=="Code/dbt/models/marts/fct_orders.sql") | .payload' \
+  | base64 -d
+```
+
+## 5) Run history and failure diagnostics
+
+```bash
+az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances" \
+  --query "value[].{status:status, start:startTimeUtc, end:endTimeUtc, error:failureReason}" -o table
+```
+
+## 6) Trigger a run and monitor
+
+```bash
+RUN_LOCATION=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances?jobType=Execute" \
+  --headers "Content-Length=0" --output none --include-response-headers 2>&1 \
+  | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+while true; do
+  RUN=$(az rest --method GET --resource "$RES" --url "$RUN_LOCATION")
+  STATUS=$(echo "$RUN" | jq -r '.status'); echo "Status: $STATUS"
+  [[ "$STATUS" =~ ^(Completed|Failed|Cancelled|Deduped)$ ]] && break
+  sleep 15
+done
+[[ "$STATUS" == "Failed" ]] && echo "$RUN" | jq '.failureReason'
+```
+
+## 7) Compare dbt commands across jobs (governance)
+
+```bash
+for ID in $(az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items?type=DataBuildToolJob" --query "value[].id" -o tsv); do
+  echo "==== $ID ===="
+  D=$(az rest --method POST --resource "$RES" --url "$API/workspaces/$WS/items/$ID/getDefinition")
+  CP=$(echo "$D" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+  echo "$D" | jq -r --arg p "$CP" '.definition.parts[] | select(.path==$p) | .payload' \
+    | base64 -d | jq '{adapter:.profile.profileType, operation:.command.operation, select:.command.arguments.select}'
+done
+```

--- a/plugins/fabric-skills/common/DBT-CORE.md
+++ b/plugins/fabric-skills/common/DBT-CORE.md
@@ -1,0 +1,147 @@
+# DBT-CORE.md — dbt Job Model, Adapters & Project Reference
+
+Shared reference for the dbt (data build tool) skills. Covers the Fabric dbt job execution model,
+the item-definition structure, the supportability matrix, per-adapter SQL generation for dbt Core
+1.9, and dbt project layout. The consumption skill links here for the execution model; the authoring
+skill links here for SQL generation and project structure.
+
+## Table of contents
+- [Execution model](#execution-model)
+- [Supportability matrix](#supportability-matrix)
+- [Adapter SQL](#adapter-sql)
+- [Project structure](#project-structure)
+- [Security: never write credentials](#security-never-write-credentials)
+
+---
+
+## Execution model
+
+- A dbt job is a Fabric item of type **`DataBuildToolJob`** (preview).
+- Its **definition** is a list of base64 parts:
+  - the **config part** — `dbt-content.json` on the live API / `dbtjob-content.json` in docs;
+    holds `project`, `profile`, and `command` settings. **Discover the name** from `getDefinition`
+    (regex `dbt[\w-]*content\.json`) — do not hardcode.
+  - **`Code/dbt/...`** — the dbt project files (`dbt_project.yml`, `models/*.sql`, `schema.yml`,
+    `seeds/`, `snapshots/`), one part per file. (Absent for GitHub-sourced jobs.)
+  - **`.platform`** — item metadata.
+- `updateDefinition` **replaces the whole part list** → every change is read-modify-write.
+- Runs are triggered with `POST .../items/{id}/jobs/instances?jobType=Execute` and polled to a
+  terminal status (`Completed`/`Failed`/`Cancelled`/`Deduped`).
+
+### Config part (`ContentDetails`) shape
+```jsonc
+{
+  "project": {
+    "projectType": "OneLake",              // "OneLake" | "Lakehouse" | "GitHubSourceControl"
+    "folderPath": "dbt"
+  },
+  "profile": {
+    "profileType": "DataWarehouse",        // DataWarehouse | SqlServer | PostgreSql | Snowflake
+    "schema": "gold",
+    // bind by GUID — either an external connection or workspace/artifact of the warehouse:
+    "connectionSettings": {
+      "name": "MyWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": {
+          "workspaceId": "<ws-guid>", "artifactId": "<warehouse-guid>",
+          "endPoint": "<name>.datawarehouse.fabric.microsoft.com"
+        }
+      }
+    }
+    // or: "externalReferences": { "connection": "<connection-guid>" }
+  },
+  "command": { "operation": "build", "arguments": { "threads": 4, "failFast": true } }
+}
+```
+`operation` ∈ `run | build | show | seed | compile | test | snapshot`. Command arguments:
+`select`, `exclude`, `fullRefresh`, `failFast`, `threads`, `selectorName`.
+
+---
+
+## Supportability matrix
+
+dbt Job Runtime **v1.0**, dbt Core **1.9**, Python **3.12**. Generate Core-1.9 SQL for all four.
+
+| Target | Adapter (pip) | Adapter version | `profiles.yml` type | `profileType` |
+|---|---|---|---|---|
+| Fabric Warehouse | `dbt-fabric` | 1.9.0 | `fabric` | `DataWarehouse` |
+| PostgreSQL | `dbt-postgres` | 1.9.0 | `postgres` | `PostgreSql` |
+| Snowflake | `dbt-snowflake` | 1.9.0 | `snowflake` | `Snowflake` |
+| Azure SQL Database | `dbt-sqlserver` | 1.8.5 | `sqlserver` | `SqlServer` |
+
+Azure SQL pins adapter **1.8.5** (Core-1.9-only features like `microbatch` may be unavailable there —
+prefer `delete+insert`/`merge`). Adapters evolve; verify edge cases at https://docs.getdbt.com.
+
+---
+
+## Adapter SQL
+
+dbt mechanics are shared: models are `SELECT`s, dependencies use `{{ ref() }}`/`{{ source() }}`,
+materialization comes from `{{ config() }}`, incremental models use `is_incremental()`. Only the
+**dialect** and **supported strategies** differ.
+
+**Incremental strategy support:**
+
+| Strategy | Fabric DW | Azure SQL (1.8.5) | PostgreSQL | Snowflake |
+|---|---|---|---|---|
+| `append` | ✅ | ✅ | ✅ | ✅ |
+| `delete+insert` | ✅ | ✅ | ✅ (default) | ✅ |
+| `merge` | ⚠️ verify | ✅ | ✅ (PG 15+) | ✅ (default) |
+| `insert_overwrite` | ❌ | ❌ | ❌ | ✅ |
+| `microbatch` (1.9) | ⚠️ verify | ⚠️ likely no | ✅ | ✅ |
+
+**Fabric Warehouse (`dbt-fabric`)** — restricted T-SQL. Use `varchar`/`char` (UTF-8),
+`int/bigint`, `decimal(p,s)`, `float`, `bit`, `date`, `time`, `datetime2`, `uniqueidentifier`,
+`varbinary`. **Avoid** `nvarchar`/`ntext`/`text`, `datetime`/`smalldatetime`, `money`, `xml`,
+`geography`. No enforced constraints/identity. `table` builds via CTAS. Incremental: `append` /
+`delete+insert`; treat `merge`/`microbatch` as "verify".
+
+**Azure SQL / SQL Server (`dbt-sqlserver`)** — full T-SQL: `nvarchar`, `datetime2`, `MERGE`,
+enforced constraints. Incremental: `append`/`delete+insert`/`merge`. Avoid relying on `microbatch`.
+
+**PostgreSQL (`dbt-postgres`)** — `text`/`varchar`, `numeric`, `boolean`, `timestamptz`, `jsonb`,
+`||` concat. Incremental: `append`/`delete+insert`(default)/`merge`(PG15+)/`microbatch`.
+
+**Snowflake (`dbt-snowflake`)** — `varchar`/`number`/`variant`/`timestamp_ntz`; `qualify`, `::`
+casts, `transient`, `cluster_by`. Incremental: `merge`(default)/`append`/`delete+insert`/
+`insert_overwrite`/`microbatch`.
+
+**Porting checklist:** switch `profiles.yml` type + `profileType`; re-map types (classic Fabric
+fixes: `nvarchar`→`varchar`, `datetime`→`datetime2`, `money`→`decimal(19,4)`); confirm the
+incremental strategy is supported (downgrade to `delete+insert` when unsure); translate dialect
+functions (`||` vs `+` vs `concat`, `qualify`, `iff`); re-validate.
+
+---
+
+## Project structure
+
+Standard dbt layout (Core 1.9):
+```text
+<project>/
+├── dbt_project.yml     # name, profile, model-paths, per-folder materialization defaults
+├── profiles.yml        # ADAPTER TYPE + env_var() placeholders only — NO secrets
+├── models/
+│   ├── staging/        # 1:1 with sources, usually views
+│   ├── marts/          # business entities, usually tables/incremental
+│   └── schema.yml      # sources, model docs, tests (this is the data-model schema)
+├── seeds/              # optional CSV reference data
+└── snapshots/          # optional SCD-2 (YAML snapshots in 1.9)
+```
+- Pin the project: `require-dbt-version: [">=1.9.0", "<1.10.0"]`.
+- `schema.yml` uses the Core-1.9 `data_tests:` key; built-ins: `not_null`, `unique`,
+  `accepted_values`, `relationships`. Parse it first when updating a project.
+- Core 1.9 features: `microbatch` incremental strategy, YAML snapshots, `dbt_valid_to_current`.
+
+---
+
+## Security: never write credentials
+
+The Fabric **Connection** object holds every secret; the dbt job references targets **by connection
+GUID**. Therefore:
+- `dbt-content.json` binds via `externalReferences.connection` or `typeProperties.{workspaceId,
+  artifactId}` — never a username/password/account/host secret/connection string.
+- `profiles.yml` (needed only for local `dbt parse`/`compile`) uses `{{ env_var('DBT_...') }}` for
+  every sensitive field, left unset in the file.
+- GitHub sourcing: the classic **PAT** lives only in the `GitHubSourceControl` connection, never in
+  a file. If it rotates, update the connection.

--- a/plugins/fabric-skills/skills/dbt-authoring-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/dbt-authoring-cli/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: dbt-authoring-cli
+description: >
+  Create, configure, update, deploy, and run dbt (data build tool) jobs (DataBuildToolJob) in
+  Microsoft Fabric via `az rest`, and generate dbt Core 1.9 SQL models for the supported adapters
+  (Fabric Warehouse, Azure SQL Database, PostgreSQL, Snowflake).
+  Use when the user wants to:
+    1. Create or configure a Fabric dbt job (connection, schema, run command)
+    2. Generate or port dbt models (.sql) / schema.yml / dbt_project.yml for a specific adapter
+    3. Deploy a local dbt project into a job (Code/dbt/* definition parts) with read-modify-write
+    4. Add tests, sources, incremental logic, or snapshots to a dbt project
+    5. Connect a dbt job to an existing GitHub repository as the code source (run-only)
+    6. Trigger a dbt run (build/run/test/seed/snapshot/compile) and monitor it
+  Triggers: "create dbt job", "set up dbt in Fabric", "make a dbt model for my Fabric warehouse",
+  "port this dbt model to Snowflake", "add an incremental model", "deploy dbt project",
+  "update my dbt job", "connect dbt job to github", "run dbt build in Fabric", "dbt authoring"
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+> **CRITICAL NOTES**
+> 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering.
+> 2. To find the item details (including its ID) from workspace ID, item type (`DataBuildToolJob`), and item name: list all items of that type in that workspace and, then, use JMESPath filtering.
+> 3. **Never write credentials into config.** A dbt job binds its target and its GitHub source **by connection GUID**; the secret lives in the Fabric Connection object. No password, account, token, or connection string ever goes into `dbtjob-content.json`, `profiles.yml`, or any project file.
+> 4. **`updateDefinition` replaces the entire part list.** Read-modify-write every time (getDefinition → keep all existing parts → change what you need → updateDefinition) or you will delete the project files.
+
+# dbt-authoring-cli — Author, Deploy & Run Fabric dbt Jobs via CLI
+
+## Table of Contents
+
+| Task | Reference | Notes |
+|---|---|---|
+| Finding Workspaces and Items in Fabric | [COMMON-CLI.md § Finding Workspaces and Items in Fabric](../../common/COMMON-CLI.md#finding-workspaces-and-items-in-fabric) | **Mandatory** — *READ link first* [resolve workspace/item IDs; use `type=DataBuildToolJob`] |
+| Fabric Topology & Key Concepts | [COMMON-CORE.md § Fabric Topology & Key Concepts](../../common/COMMON-CORE.md#fabric-topology--key-concepts) | |
+| Environment URLs | [COMMON-CORE.md § Environment URLs](../../common/COMMON-CORE.md#environment-urls) | |
+| Authentication & Token Acquisition | [COMMON-CORE.md § Authentication & Token Acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition) | Wrong audience = 401; use `https://api.fabric.microsoft.com` |
+| Core Control-Plane REST APIs | [COMMON-CORE.md § Core Control-Plane REST APIs](../../common/COMMON-CORE.md#core-control-plane-rest-apis) | List Items, Item Creation, definition APIs |
+| Long-Running Operations (LRO) | [COMMON-CORE.md § Long-Running Operations (LRO)](../../common/COMMON-CORE.md#long-running-operations-lro) | Create/getDefinition/updateDefinition/run are LROs |
+| Item Definitions envelope | [ITEM-DEFINITIONS-CORE.md § Definition Envelope](../../common/ITEM-DEFINITIONS-CORE.md#definition-envelope) | Base64 parts, `.platform` file |
+| Fabric Control-Plane API via `az rest` | [COMMON-CLI.md § Fabric Control-Plane API via az rest](../../common/COMMON-CLI.md#fabric-control-plane-api-via-az-rest) | **Always pass `--resource https://api.fabric.microsoft.com`** |
+| Long-Running Operations (LRO) Pattern | [COMMON-CLI.md § Long-Running Operations (LRO) Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern) | Poll `Location` / `operations/{id}` |
+| dbt job execution model & definition | [DBT-CORE.md § Execution model](../../common/DBT-CORE.md#execution-model) | Item type, `Code/dbt/*` parts, content part name, connection binding |
+| Supportability matrix (adapters) | [DBT-CORE.md § Supportability matrix](../../common/DBT-CORE.md#supportability-matrix) | dbt Core 1.9; adapter versions & profileType per target |
+| Adapter SQL generation | [DBT-CORE.md § Adapter SQL](../../common/DBT-CORE.md#adapter-sql) | Types, materializations, incremental strategies, porting |
+| dbt project structure | [DBT-CORE.md § Project structure](../../common/DBT-CORE.md#project-structure) | dbt_project.yml, profiles.yml (no secrets), schema.yml, 1.9 features |
+| Authoring recipes (`az rest`) | [authoring-recipes.md](references/authoring-recipes.md) | Create job, deploy project, set config, run — copy/paste `az rest` |
+| GitHub source (run-only) | [authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source) | Create GitHubSourceControl connection + bind job to repo/branch |
+| Tool Stack | [SKILL.md § Tool Stack](#tool-stack) | |
+| Authoring Scope | [SKILL.md § Authoring Scope](#authoring-scope) | |
+| Core Workflow | [SKILL.md § Core Workflow](#core-workflow) | Create → generate SQL → deploy → configure → run |
+| Preview & Confirm (writes) | [SKILL.md § Preview & Confirm](#preview--confirm) | **Human-in-the-loop before any write/run** |
+| Must / Prefer / Avoid | [SKILL.md § Must / Prefer / Avoid](#must--prefer--avoid) | |
+| Examples | [SKILL.md § Examples](#examples) | |
+| Agent Integration Notes | [SKILL.md § Agent Integration Notes](#agent-integration-notes) | |
+
+---
+
+## Tool Stack
+
+| Tool | Purpose | Install |
+|---|---|---|
+| **az cli** | Fabric control-plane REST + item definition + run via `az rest` | `winget install Microsoft.AzureCLI` |
+| **jq** | JSON processing / decoding base64 definition parts | `winget install jqlang.jq` |
+| **base64** | Encode project files into definition parts (coreutils / built-in) | preinstalled on Linux/macOS |
+
+Authenticate once (see [COMMON-CLI.md § Authentication Recipes](../../common/COMMON-CLI.md#authentication-recipes)):
+
+```bash
+az login
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+```
+
+---
+
+## Authoring Scope
+
+| Operation | Endpoint (via `az rest`, `--resource $RES`) |
+|---|---|
+| Create dbt job | `POST $API/workspaces/{ws}/dataBuildToolJobs` |
+| List dbt jobs | `GET  $API/workspaces/{ws}/items?type=DataBuildToolJob` |
+| Get definition (all parts) | `POST $API/workspaces/{ws}/items/{id}/getDefinition` |
+| Update definition (RMW) | `POST $API/workspaces/{ws}/items/{id}/updateDefinition` |
+| Trigger run | `POST $API/workspaces/{ws}/items/{id}/jobs/instances?jobType=Execute` |
+| Create GitHub connection | `POST $API/connections` (type `GitHubSourceControl`) |
+
+The dbt **project files** ship inside the definition as parts under `Code/dbt/*`; the **config**
+part (`dbt-content.json` / `dbtjob-content.json`) holds project/profile/command settings. See
+[DBT-CORE.md](../../common/DBT-CORE.md) for the full model.
+
+---
+
+## Core Workflow
+
+For a new, in-Fabric dbt job:
+
+1. **Confirm intent** — target adapter (Fabric DW / Azure SQL / PostgreSQL / Snowflake), what the
+   models should do, and the target connection/schema. If ambiguous, ask (see *Preview & Confirm*).
+2. **Generate the project** — `dbt_project.yml`, `models/*.sql`, `schema.yml`, seeds. Write
+   Core-1.9 SQL for the chosen adapter using [DBT-CORE.md § Adapter SQL](../../common/DBT-CORE.md#adapter-sql).
+   Keep `profiles.yml` secret-free (`env_var()` placeholders only).
+3. **Create the job** and **deploy** the project into `Code/dbt/*`
+   ([authoring-recipes.md](references/authoring-recipes.md)).
+4. **Set the config** — bind the warehouse **by connection GUID**, set schema and run command.
+5. **Run** and confirm the instance reaches `Completed` (never treat a 202 as success).
+
+To use an existing **GitHub** repo instead of storing files in Fabric, skip steps 2–3 and follow
+[authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source) — these jobs
+are **run-only** (edit models in GitHub).
+
+To **update an existing** job's models, delegate discovery to **dbt-consumption-cli** (decode the
+definition + parse `schema.yml`), then redeploy with read-modify-write.
+
+---
+
+## Preview & Confirm
+
+Writes and runs have side effects (they create items, overwrite definitions, and execute SQL against
+a warehouse), so treat them like any irreversible operation:
+
+- If the request is ambiguous (no adapter, no target, "set up my dbt job"), **ask first** — offer
+  the concrete options rather than inferring.
+- Before `updateDefinition` or a run, **show the plan**: which job, which parts change, the resolved
+  `dbt-content.json` (connection GUID + schema + command), and the operation. Proceed on explicit
+  confirmation.
+- Before `updateDefinition`, **always** `getDefinition` first and preserve every existing part —
+  a partial part list deletes the project files.
+
+---
+
+## Must / Prefer / Avoid
+
+### Must
+- Bind targets **by connection GUID** (`externalReferences.connection` or workspace/artifact GUIDs).
+  Never put a credential in any file. For GitHub sourcing, the classic PAT lives only in the
+  `GitHubSourceControl` connection.
+- Read-modify-write for every `updateDefinition` (preserve `Code/dbt/*` + `.platform`).
+- **Discover** the config-part name from `getDefinition` (`dbt[\w-]*content\.json`) — it differs by
+  API version (`dbt-content.json` live vs `dbtjob-content.json` in docs).
+- Poll LROs / run instances to a terminal state before reporting success.
+
+### Prefer
+- `dbt build` as the default command (models + tests + seeds + snapshots).
+- `delete+insert` incremental strategy for portability; upgrade to `merge`/`microbatch` only where
+  the adapter supports it (see [DBT-CORE.md](../../common/DBT-CORE.md#adapter-sql)).
+- Fabric-Warehouse-safe types (`varchar` not `nvarchar`, `datetime2` not `datetime`, `decimal` not
+  `money`).
+
+### Avoid
+- Hand-building `updateDefinition` with a partial part list (drops files).
+- Hardcoding three-part table names in models — use `{{ ref() }}` / `{{ source() }}`.
+- Writing `profiles.yml` with real host/user/password — use `env_var()` placeholders.
+- Deploying `Code/dbt/*` to a GitHub-connected (run-only) job — edit in the repo instead.
+
+---
+
+## Examples
+
+### Example 1 — New Fabric DW job, deploy + run
+See [authoring-recipes.md § End-to-end](references/authoring-recipes.md#end-to-end): create the job,
+`base64`-pack `./my_dbt_project` into `Code/dbt/*`, set `profileType=DataWarehouse` bound to the
+warehouse GUID + schema `gold`, `operation=build`, then trigger and poll a run.
+
+### Example 2 — Generate an incremental model for Fabric DW
+```sql
+{{ config(materialized='incremental', incremental_strategy='delete+insert', unique_key='order_id') }}
+select
+    cast(order_id as bigint)      as order_id,
+    cast(amount   as decimal(19,4)) as amount,   -- not money
+    cast(status   as varchar(50)) as status      -- not nvarchar
+from {{ ref('stg_orders') }}
+{% if is_incremental() %}
+where order_date > (select max(order_date) from {{ this }})
+{% endif %}
+```
+
+### Example 3 — Connect a job to a GitHub repo (run-only)
+See [authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source): create a
+`GitHubSourceControl` connection from a classic PAT, bind the job's project to that connection +
+branch (profile/command unchanged), then run.
+
+---
+
+## Agent Integration Notes
+
+- This skill covers **authoring** — create/configure/update/deploy/run dbt jobs and generate SQL.
+- For **read-only** discovery, run-history, and monitoring, delegate to **dbt-consumption-cli**.
+- For end-to-end lakehouse patterns, see **e2e-medallion-architecture**; for warehouse T-SQL, see
+  **sqldw-authoring-cli**.
+- All writes require a Contributor workspace role and read/write on the target warehouse/connection.

--- a/plugins/fabric-skills/skills/dbt-authoring-cli/references/authoring-recipes.md
+++ b/plugins/fabric-skills/skills/dbt-authoring-cli/references/authoring-recipes.md
@@ -1,0 +1,186 @@
+# Authoring Recipes — `az rest` for Fabric dbt Jobs
+
+Copy/paste `az rest` recipes for the full dbt job lifecycle. All calls pass
+`--resource https://api.fabric.microsoft.com`. Assumes:
+
+```bash
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+WS="<workspace-id>"
+```
+
+See [DBT-CORE.md](../../../common/DBT-CORE.md) for the definition model and the no-secrets rule. Confirm writes with
+the user first (see SKILL.md § Preview & Confirm).
+
+## Create a dbt job
+
+```bash
+JOB_ID=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/dataBuildToolJobs" \
+  --headers "Content-Type=application/json" \
+  --body '{"displayName":"Sales dbt job","description":"Builds sales marts"}' \
+  --query "id" -o tsv)
+echo "Job: $JOB_ID"
+```
+
+## Discover the config-part name (never hardcode)
+
+```bash
+# getDefinition (LRO — poll Location if 202; see COMMON-CLI.md § LRO Pattern)
+DEF=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/getDefinition")
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+CONTENT_PART="${CONTENT_PART:-dbt-content.json}"     # default for a brand-new job
+echo "Config part: $CONTENT_PART"
+```
+
+## Deploy a local project into `Code/dbt/*` (read-modify-write)
+
+`updateDefinition` replaces the whole part list, so rebuild it from the **existing** parts plus your
+files. This packs everything under `./my_dbt_project` as `Code/dbt/<relpath>` and keeps any config /
+`.platform` part already present.
+
+```bash
+ROOT="./my_dbt_project"
+
+# Start from existing parts EXCEPT the project files we're about to replace.
+PARTS=$(echo "$DEF" | jq '[.definition.parts[] | select(.path | startswith("Code/dbt/") | not)]')
+
+# Add each project file as a Code/dbt/* part.
+while IFS= read -r f; do
+  rel="${f#"$ROOT"/}"
+  b64=$(base64 -w0 < "$f" 2>/dev/null || base64 < "$f" | tr -d '\n')   # macOS has no -w0
+  PARTS=$(echo "$PARTS" | jq --arg p "Code/dbt/$rel" --arg pl "$b64" \
+    '. + [{path:$p, payload:$pl, payloadType:"InlineBase64"}]')
+done < <(find "$ROOT" -type f -not -path '*/target/*' -not -path '*/.git/*')
+
+az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/updateDefinition" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --argjson parts "$PARTS" '{definition:{parts:$parts}}')"
+```
+
+## Set the config part (connection GUID + schema + command)
+
+Binds a **Fabric Warehouse** by workspace/artifact GUID. For Postgres/Snowflake/SQL Server, replace
+`connectionSettings` with `"externalReferences": {"connection":"<conn-guid>"}` and set `profileType`
+accordingly (`PostgreSql`/`Snowflake`/`SqlServer`). No credentials appear anywhere.
+
+```bash
+WH_ID="<warehouse-item-id>"
+WH_FQDN=$(az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$WH_ID" --query "properties.connectionString" -o tsv)
+
+cat > /tmp/dbt-content.json << EOF
+{
+  "project": { "projectType": "OneLake", "folderPath": "dbt" },
+  "profile": {
+    "profileType": "DataWarehouse",
+    "schema": "gold",
+    "connectionSettings": {
+      "name": "SalesWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": { "workspaceId": "$WS", "artifactId": "$WH_ID", "endPoint": "$WH_FQDN" }
+      }
+    }
+  },
+  "command": { "operation": "build", "arguments": { "threads": 4, "failFast": true } }
+}
+EOF
+
+# RMW: keep all existing parts, replace only the config part.
+CONTENT_B64=$(base64 -w0 < /tmp/dbt-content.json 2>/dev/null || base64 < /tmp/dbt-content.json | tr -d '\n')
+PARTS=$(echo "$DEF" | jq --arg cp "$CONTENT_PART" \
+  '[.definition.parts[] | select(.path != $cp)]')
+PARTS=$(echo "$PARTS" | jq --arg cp "$CONTENT_PART" --arg pl "$CONTENT_B64" \
+  '. + [{path:$cp, payload:$pl, payloadType:"InlineBase64"}]')
+
+az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/updateDefinition" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --argjson parts "$PARTS" '{definition:{parts:$parts}}')"
+```
+
+## Trigger a run and monitor
+
+```bash
+RUN_LOCATION=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances?jobType=Execute" \
+  --headers "Content-Length=0" --output none --include-response-headers 2>&1 \
+  | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+while true; do
+  RUN=$(az rest --method GET --resource "$RES" --url "$RUN_LOCATION")
+  STATUS=$(echo "$RUN" | jq -r '.status')
+  echo "Status: $STATUS"
+  [[ "$STATUS" =~ ^(Completed|Failed|Cancelled|Deduped)$ ]] && break
+  sleep 15
+done
+[[ "$STATUS" == "Failed" ]] && echo "$RUN" | jq '.failureReason'
+```
+
+## End-to-end
+
+Create → deploy `Code/dbt/*` → set config → run, in order: run the four blocks above with the same
+`$JOB_ID` and `$DEF` (re-fetch `$DEF` with getDefinition before each RMW so you always start from the
+current parts).
+
+---
+
+## GitHub source
+
+Connect a job to an existing GitHub repo instead of storing files in Fabric. **Run-only** — you can't
+edit models in Fabric; commit to the repo and Fabric pulls on the next run. The classic PAT lives
+only in the connection.
+
+### 1) Create the GitHub source-control connection (PAT from env)
+
+```bash
+# Read the PAT from the environment so it never appears in shell history / files.
+read -rs GITHUB_PAT    # or: export GITHUB_PAT before running
+
+CONN_ID=$(az rest --method POST --resource "$RES" --url "$API/connections" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --arg url 'https://github.com/<owner>/<repo>' --arg pat "$GITHUB_PAT" '{
+    connectivityType:"ShareableCloud",
+    displayName:"MyGitHubPAT",
+    connectionDetails:{ type:"GitHubSourceControl", creationMethod:"GitHubSourceControl.Contents",
+      parameters:[{dataType:"Text", name:"url", value:$url}] },
+    credentialDetails:{ credentials:{ credentialType:"Key", key:$pat } }
+  }')" \
+  --query "id" -o tsv)
+echo "GitHub connection: $CONN_ID"
+```
+
+Response `connectionDetails.type` is `GitHubSourceControl`. Omitting the repo in `parameters.url`
+scopes the connection to all repos the PAT can read.
+
+### 2) Bind the dbt job to the GitHub source
+
+Project points at the GitHub connection + branch; **profile and command stay the normal warehouse
+binding** (a GitHub-sourced job still has an adapter + warehouse + schema). Push with `updateDefinition`.
+
+> The git-source `project` block below is **inferred** (the portal writes it inside an iframe that
+> can't be captured) — verify against your tenant. If rejected, capture a working job's definition
+> with dbt-consumption-cli and copy the exact `project` shape.
+
+```jsonc
+{
+  "project": {
+    "projectType": "GitHubSourceControl",
+    "connectionSettings": {
+      "type": "GitHubSourceControl",
+      "properties": { "connection": "<github-connection-guid>", "branch": "main", "rootFolder": "" }
+    }
+  },
+  "profile": { "profileType": "DataWarehouse", "schema": "jaffle_shop",
+    "connectionSettings": { "name": "jaffle_shop_dw", "properties": { "type":"DataWarehouse",
+      "typeProperties": { "workspaceId":"<ws>", "artifactId":"<warehouse>", "endPoint":"<fqdn>" } } } },
+  "command": { "operation": "build", "arguments": { "threads": 4 } }
+}
+```
+
+### 3) Run
+
+Identical to any dbt job — see [Trigger a run and monitor](#trigger-a-run-and-monitor).

--- a/plugins/fabric-skills/skills/dbt-consumption-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/dbt-consumption-cli/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dbt-consumption-cli
+description: >
+  Discover, inspect, and monitor Fabric dbt jobs (DataBuildToolJob) via `az rest` — read-only and
+  run-focused operations. List dbt jobs, decode their configuration and project files from the item
+  definition, review model schema (schema.yml), trigger runs, and inspect run history and failures.
+  Use when the user wants to:
+    1. List the dbt jobs in a workspace
+    2. Inspect a dbt job's adapter, schema, connection, and run command
+    3. See which project files (models, schema.yml) ship with a job
+    4. Trigger a dbt run and monitor it, or review run history / failure reasons
+    5. Compare dbt command/profile settings across jobs (governance)
+  Triggers: "list dbt jobs", "inspect dbt job", "show dbt config", "dbt run history",
+  "why did my dbt job fail", "monitor dbt run", "which models are in my dbt job", "dbt consumption"
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+> **CRITICAL NOTES**
+> 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering.
+> 2. To find dbt jobs: list items with `type=DataBuildToolJob`, then filter by `displayName`.
+> 3. **Decode before inspecting** — definition parts are base64; the config-part name varies by API version (discover it via `dbt[\w-]*content\.json`).
+
+# dbt-consumption-cli — Inspect & Monitor Fabric dbt Jobs via CLI
+
+## Table of Contents
+
+| Task | Reference | Notes |
+|---|---|---|
+| Finding Workspaces and Items in Fabric | [COMMON-CLI.md § Finding Workspaces and Items in Fabric](../../common/COMMON-CLI.md#finding-workspaces-and-items-in-fabric) | **Mandatory** — *READ link first* [use `type=DataBuildToolJob`] |
+| Authentication & Token Acquisition | [COMMON-CORE.md § Authentication & Token Acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition) | Wrong audience = 401 |
+| Core Control-Plane REST APIs | [COMMON-CORE.md § Core Control-Plane REST APIs](../../common/COMMON-CORE.md#core-control-plane-rest-apis) | List Items, getDefinition |
+| Long-Running Operations (LRO) | [COMMON-CORE.md § Long-Running Operations (LRO)](../../common/COMMON-CORE.md#long-running-operations-lro) | getDefinition can be a 202 LRO |
+| Fabric Control-Plane API via `az rest` | [COMMON-CLI.md § Fabric Control-Plane API via az rest](../../common/COMMON-CLI.md#fabric-control-plane-api-via-az-rest) | **Always pass `--resource https://api.fabric.microsoft.com`** |
+| Long-Running Operations (LRO) Pattern | [COMMON-CLI.md § Long-Running Operations (LRO) Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern) | Poll `Location` |
+| dbt job execution model & definition | [DBT-CORE.md § Execution model](../../common/DBT-CORE.md#execution-model) | Item type, `Code/dbt/*` parts, config-part name |
+| Adapter reference | [DBT-CORE.md § Supportability matrix](../../common/DBT-CORE.md#supportability-matrix) | Interpreting `profileType` |
+| Inspect & monitor recipes (`az rest`) | [inspect-recipes.md](references/inspect-recipes.md) | List, decode config, list Code/dbt parts, run history |
+| Discovery Scope | [SKILL.md § Discovery Scope](#discovery-scope) | |
+| Must / Prefer / Avoid | [SKILL.md § Must / Prefer / Avoid](#must--prefer--avoid) | |
+| Troubleshooting | [SKILL.md § Troubleshooting](#troubleshooting) | |
+| Agent Integration Notes | [SKILL.md § Agent Integration Notes](#agent-integration-notes) | |
+
+---
+
+## Discovery Scope
+
+| Operation | Endpoint (via `az rest`, `--resource https://api.fabric.microsoft.com`) |
+|---|---|
+| List dbt jobs | `GET  /v1/workspaces/{ws}/items?type=DataBuildToolJob` |
+| Get item | `GET  /v1/workspaces/{ws}/dataBuildToolJobs/{id}` |
+| Get definition (decode) | `POST /v1/workspaces/{ws}/items/{id}/getDefinition` |
+| Run history | `GET  /v1/workspaces/{ws}/items/{id}/jobs/instances` |
+| Trigger run | `POST /v1/workspaces/{ws}/items/{id}/jobs/instances?jobType=Execute` |
+
+All read-only except triggering a run. See [inspect-recipes.md](references/inspect-recipes.md) for
+copy/paste commands, and [DBT-CORE.md](../../common/DBT-CORE.md) for the definition model.
+
+---
+
+## Must / Prefer / Avoid
+
+### Must
+- Use `type=DataBuildToolJob` when listing (not `dbtJob`).
+- **Discover** the config-part name from `getDefinition` (`dbt[\w-]*content\.json`) before decoding.
+- Decode base64 parts before inspecting; handle `getDefinition` 202 by polling `Location`.
+
+### Prefer
+- Inspect a job's config + `schema.yml` **before** triggering a run or handing off to authoring.
+- Filter run history by status/time; read `failureReason` on failures.
+- `jq` / JMESPath for compact diagnostics.
+
+### Avoid
+- Assuming the config-part name (`dbt-content.json` vs `dbtjob-content.json`).
+- Editing anything here — this skill is read-only. For changes, delegate to **dbt-authoring-cli**.
+- Polling runs without a backoff.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Empty job list | Wrong item type filter | Use `type=DataBuildToolJob` |
+| 401 on API calls | Wrong/expired token | Re-login; keep `--resource https://api.fabric.microsoft.com` |
+| Missing content part | Hardcoded part name | Discover via `getDefinition` regex `dbt.?content\.json` |
+| No `Code/dbt/*` parts | GitHub-sourced (run-only) job | Code lives in GitHub; inspect the repo, not the definition |
+| 400 on run trigger | Wrong `jobType` | Use `jobType=Execute` |
+
+---
+
+## Agent Integration Notes
+
+- This skill is **read-only + run** — discover, inspect, monitor. It never edits a job.
+- For create/configure/update/deploy and SQL generation, delegate to **dbt-authoring-cli**.
+- Inspecting `schema.yml` here is the first step of the authoring skill's update workflow.

--- a/plugins/fabric-skills/skills/dbt-consumption-cli/references/inspect-recipes.md
+++ b/plugins/fabric-skills/skills/dbt-consumption-cli/references/inspect-recipes.md
@@ -1,0 +1,98 @@
+# Inspect & Monitor Recipes — `az rest` for Fabric dbt Jobs
+
+Read-only (plus run) recipes. All calls pass `--resource https://api.fabric.microsoft.com`. Assumes:
+
+```bash
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+WS="<workspace-id>"
+```
+
+See [DBT-CORE.md](../../../common/DBT-CORE.md) for the definition model.
+
+## 1) List dbt jobs in a workspace
+
+```bash
+az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items?type=DataBuildToolJob" \
+  --query "value[].{name:displayName, id:id, description:description}" -o table
+```
+
+## 2) Decode a job's configuration (adapter, schema, command)
+
+```bash
+JOB_ID="<dbt-job-id>"
+DEF=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/getDefinition")     # poll Location if 202
+
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+echo "$DEF" | jq -r --arg p "$CONTENT_PART" \
+  '.definition.parts[] | select(.path==$p) | .payload' | base64 -d | jq '{
+    projectType: .project.projectType,
+    adapter:     .profile.profileType,
+    schema:      .profile.schema,
+    operation:   .command.operation,
+    select:      .command.arguments.select,
+    threads:     .command.arguments.threads,
+    failFast:    .command.arguments.failFast
+  }'
+```
+
+## 3) List the project files shipped with the job
+
+```bash
+echo "$DEF" | jq -r '.definition.parts[].path | select(startswith("Code/dbt/"))'
+```
+
+No `Code/dbt/*` parts usually means the job is **GitHub-sourced** (run-only) — the code lives in the
+repo, not the definition. Check `project.projectType` from step 2.
+
+## 4) Read a specific model or schema.yml (understand the data model)
+
+```bash
+# Decode schema.yml — the source of truth for the model's columns and tests.
+echo "$DEF" | jq -r '.definition.parts[] | select(.path|endswith("schema.yml")) | .payload' \
+  | base64 -d
+
+# Decode a specific model
+echo "$DEF" | jq -r '.definition.parts[] | select(.path=="Code/dbt/models/marts/fct_orders.sql") | .payload' \
+  | base64 -d
+```
+
+## 5) Run history and failure diagnostics
+
+```bash
+az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances" \
+  --query "value[].{status:status, start:startTimeUtc, end:endTimeUtc, error:failureReason}" -o table
+```
+
+## 6) Trigger a run and monitor
+
+```bash
+RUN_LOCATION=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances?jobType=Execute" \
+  --headers "Content-Length=0" --output none --include-response-headers 2>&1 \
+  | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+while true; do
+  RUN=$(az rest --method GET --resource "$RES" --url "$RUN_LOCATION")
+  STATUS=$(echo "$RUN" | jq -r '.status'); echo "Status: $STATUS"
+  [[ "$STATUS" =~ ^(Completed|Failed|Cancelled|Deduped)$ ]] && break
+  sleep 15
+done
+[[ "$STATUS" == "Failed" ]] && echo "$RUN" | jq '.failureReason'
+```
+
+## 7) Compare dbt commands across jobs (governance)
+
+```bash
+for ID in $(az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items?type=DataBuildToolJob" --query "value[].id" -o tsv); do
+  echo "==== $ID ===="
+  D=$(az rest --method POST --resource "$RES" --url "$API/workspaces/$WS/items/$ID/getDefinition")
+  CP=$(echo "$D" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+  echo "$D" | jq -r --arg p "$CP" '.definition.parts[] | select(.path==$p) | .payload' \
+    | base64 -d | jq '{adapter:.profile.profileType, operation:.command.operation, select:.command.arguments.select}'
+done
+```

--- a/skills/dbt-authoring-cli/SKILL.md
+++ b/skills/dbt-authoring-cli/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: dbt-authoring-cli
+description: >
+  Create, configure, update, deploy, and run dbt (data build tool) jobs (DataBuildToolJob) in
+  Microsoft Fabric via `az rest`, and generate dbt Core 1.9 SQL models for the supported adapters
+  (Fabric Warehouse, Azure SQL Database, PostgreSQL, Snowflake).
+  Use when the user wants to:
+    1. Create or configure a Fabric dbt job (connection, schema, run command)
+    2. Generate or port dbt models (.sql) / schema.yml / dbt_project.yml for a specific adapter
+    3. Deploy a local dbt project into a job (Code/dbt/* definition parts) with read-modify-write
+    4. Add tests, sources, incremental logic, or snapshots to a dbt project
+    5. Connect a dbt job to an existing GitHub repository as the code source (run-only)
+    6. Trigger a dbt run (build/run/test/seed/snapshot/compile) and monitor it
+  Triggers: "create dbt job", "set up dbt in Fabric", "make a dbt model for my Fabric warehouse",
+  "port this dbt model to Snowflake", "add an incremental model", "deploy dbt project",
+  "update my dbt job", "connect dbt job to github", "run dbt build in Fabric", "dbt authoring"
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+> **CRITICAL NOTES**
+> 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering.
+> 2. To find the item details (including its ID) from workspace ID, item type (`DataBuildToolJob`), and item name: list all items of that type in that workspace and, then, use JMESPath filtering.
+> 3. **Never write credentials into config.** A dbt job binds its target and its GitHub source **by connection GUID**; the secret lives in the Fabric Connection object. No password, account, token, or connection string ever goes into `dbtjob-content.json`, `profiles.yml`, or any project file.
+> 4. **`updateDefinition` replaces the entire part list.** Read-modify-write every time (getDefinition → keep all existing parts → change what you need → updateDefinition) or you will delete the project files.
+
+# dbt-authoring-cli — Author, Deploy & Run Fabric dbt Jobs via CLI
+
+## Table of Contents
+
+| Task | Reference | Notes |
+|---|---|---|
+| Finding Workspaces and Items in Fabric | [COMMON-CLI.md § Finding Workspaces and Items in Fabric](../../common/COMMON-CLI.md#finding-workspaces-and-items-in-fabric) | **Mandatory** — *READ link first* [resolve workspace/item IDs; use `type=DataBuildToolJob`] |
+| Fabric Topology & Key Concepts | [COMMON-CORE.md § Fabric Topology & Key Concepts](../../common/COMMON-CORE.md#fabric-topology--key-concepts) | |
+| Environment URLs | [COMMON-CORE.md § Environment URLs](../../common/COMMON-CORE.md#environment-urls) | |
+| Authentication & Token Acquisition | [COMMON-CORE.md § Authentication & Token Acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition) | Wrong audience = 401; use `https://api.fabric.microsoft.com` |
+| Core Control-Plane REST APIs | [COMMON-CORE.md § Core Control-Plane REST APIs](../../common/COMMON-CORE.md#core-control-plane-rest-apis) | List Items, Item Creation, definition APIs |
+| Long-Running Operations (LRO) | [COMMON-CORE.md § Long-Running Operations (LRO)](../../common/COMMON-CORE.md#long-running-operations-lro) | Create/getDefinition/updateDefinition/run are LROs |
+| Item Definitions envelope | [ITEM-DEFINITIONS-CORE.md § Definition Envelope](../../common/ITEM-DEFINITIONS-CORE.md#definition-envelope) | Base64 parts, `.platform` file |
+| Fabric Control-Plane API via `az rest` | [COMMON-CLI.md § Fabric Control-Plane API via az rest](../../common/COMMON-CLI.md#fabric-control-plane-api-via-az-rest) | **Always pass `--resource https://api.fabric.microsoft.com`** |
+| Long-Running Operations (LRO) Pattern | [COMMON-CLI.md § Long-Running Operations (LRO) Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern) | Poll `Location` / `operations/{id}` |
+| dbt job execution model & definition | [DBT-CORE.md § Execution model](../../common/DBT-CORE.md#execution-model) | Item type, `Code/dbt/*` parts, content part name, connection binding |
+| Supportability matrix (adapters) | [DBT-CORE.md § Supportability matrix](../../common/DBT-CORE.md#supportability-matrix) | dbt Core 1.9; adapter versions & profileType per target |
+| Adapter SQL generation | [DBT-CORE.md § Adapter SQL](../../common/DBT-CORE.md#adapter-sql) | Types, materializations, incremental strategies, porting |
+| dbt project structure | [DBT-CORE.md § Project structure](../../common/DBT-CORE.md#project-structure) | dbt_project.yml, profiles.yml (no secrets), schema.yml, 1.9 features |
+| Authoring recipes (`az rest`) | [authoring-recipes.md](references/authoring-recipes.md) | Create job, deploy project, set config, run — copy/paste `az rest` |
+| GitHub source (run-only) | [authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source) | Create GitHubSourceControl connection + bind job to repo/branch |
+| Tool Stack | [SKILL.md § Tool Stack](#tool-stack) | |
+| Authoring Scope | [SKILL.md § Authoring Scope](#authoring-scope) | |
+| Core Workflow | [SKILL.md § Core Workflow](#core-workflow) | Create → generate SQL → deploy → configure → run |
+| Preview & Confirm (writes) | [SKILL.md § Preview & Confirm](#preview--confirm) | **Human-in-the-loop before any write/run** |
+| Must / Prefer / Avoid | [SKILL.md § Must / Prefer / Avoid](#must--prefer--avoid) | |
+| Examples | [SKILL.md § Examples](#examples) | |
+| Agent Integration Notes | [SKILL.md § Agent Integration Notes](#agent-integration-notes) | |
+
+---
+
+## Tool Stack
+
+| Tool | Purpose | Install |
+|---|---|---|
+| **az cli** | Fabric control-plane REST + item definition + run via `az rest` | `winget install Microsoft.AzureCLI` |
+| **jq** | JSON processing / decoding base64 definition parts | `winget install jqlang.jq` |
+| **base64** | Encode project files into definition parts (coreutils / built-in) | preinstalled on Linux/macOS |
+
+Authenticate once (see [COMMON-CLI.md § Authentication Recipes](../../common/COMMON-CLI.md#authentication-recipes)):
+
+```bash
+az login
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+```
+
+---
+
+## Authoring Scope
+
+| Operation | Endpoint (via `az rest`, `--resource $RES`) |
+|---|---|
+| Create dbt job | `POST $API/workspaces/{ws}/dataBuildToolJobs` |
+| List dbt jobs | `GET  $API/workspaces/{ws}/items?type=DataBuildToolJob` |
+| Get definition (all parts) | `POST $API/workspaces/{ws}/items/{id}/getDefinition` |
+| Update definition (RMW) | `POST $API/workspaces/{ws}/items/{id}/updateDefinition` |
+| Trigger run | `POST $API/workspaces/{ws}/items/{id}/jobs/instances?jobType=Execute` |
+| Create GitHub connection | `POST $API/connections` (type `GitHubSourceControl`) |
+
+The dbt **project files** ship inside the definition as parts under `Code/dbt/*`; the **config**
+part (`dbt-content.json` / `dbtjob-content.json`) holds project/profile/command settings. See
+[DBT-CORE.md](../../common/DBT-CORE.md) for the full model.
+
+---
+
+## Core Workflow
+
+For a new, in-Fabric dbt job:
+
+1. **Confirm intent** — target adapter (Fabric DW / Azure SQL / PostgreSQL / Snowflake), what the
+   models should do, and the target connection/schema. If ambiguous, ask (see *Preview & Confirm*).
+2. **Generate the project** — `dbt_project.yml`, `models/*.sql`, `schema.yml`, seeds. Write
+   Core-1.9 SQL for the chosen adapter using [DBT-CORE.md § Adapter SQL](../../common/DBT-CORE.md#adapter-sql).
+   Keep `profiles.yml` secret-free (`env_var()` placeholders only).
+3. **Create the job** and **deploy** the project into `Code/dbt/*`
+   ([authoring-recipes.md](references/authoring-recipes.md)).
+4. **Set the config** — bind the warehouse **by connection GUID**, set schema and run command.
+5. **Run** and confirm the instance reaches `Completed` (never treat a 202 as success).
+
+To use an existing **GitHub** repo instead of storing files in Fabric, skip steps 2–3 and follow
+[authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source) — these jobs
+are **run-only** (edit models in GitHub).
+
+To **update an existing** job's models, delegate discovery to **dbt-consumption-cli** (decode the
+definition + parse `schema.yml`), then redeploy with read-modify-write.
+
+---
+
+## Preview & Confirm
+
+Writes and runs have side effects (they create items, overwrite definitions, and execute SQL against
+a warehouse), so treat them like any irreversible operation:
+
+- If the request is ambiguous (no adapter, no target, "set up my dbt job"), **ask first** — offer
+  the concrete options rather than inferring.
+- Before `updateDefinition` or a run, **show the plan**: which job, which parts change, the resolved
+  `dbt-content.json` (connection GUID + schema + command), and the operation. Proceed on explicit
+  confirmation.
+- Before `updateDefinition`, **always** `getDefinition` first and preserve every existing part —
+  a partial part list deletes the project files.
+
+---
+
+## Must / Prefer / Avoid
+
+### Must
+- Bind targets **by connection GUID** (`externalReferences.connection` or workspace/artifact GUIDs).
+  Never put a credential in any file. For GitHub sourcing, the classic PAT lives only in the
+  `GitHubSourceControl` connection.
+- Read-modify-write for every `updateDefinition` (preserve `Code/dbt/*` + `.platform`).
+- **Discover** the config-part name from `getDefinition` (`dbt[\w-]*content\.json`) — it differs by
+  API version (`dbt-content.json` live vs `dbtjob-content.json` in docs).
+- Poll LROs / run instances to a terminal state before reporting success.
+
+### Prefer
+- `dbt build` as the default command (models + tests + seeds + snapshots).
+- `delete+insert` incremental strategy for portability; upgrade to `merge`/`microbatch` only where
+  the adapter supports it (see [DBT-CORE.md](../../common/DBT-CORE.md#adapter-sql)).
+- Fabric-Warehouse-safe types (`varchar` not `nvarchar`, `datetime2` not `datetime`, `decimal` not
+  `money`).
+
+### Avoid
+- Hand-building `updateDefinition` with a partial part list (drops files).
+- Hardcoding three-part table names in models — use `{{ ref() }}` / `{{ source() }}`.
+- Writing `profiles.yml` with real host/user/password — use `env_var()` placeholders.
+- Deploying `Code/dbt/*` to a GitHub-connected (run-only) job — edit in the repo instead.
+
+---
+
+## Examples
+
+### Example 1 — New Fabric DW job, deploy + run
+See [authoring-recipes.md § End-to-end](references/authoring-recipes.md#end-to-end): create the job,
+`base64`-pack `./my_dbt_project` into `Code/dbt/*`, set `profileType=DataWarehouse` bound to the
+warehouse GUID + schema `gold`, `operation=build`, then trigger and poll a run.
+
+### Example 2 — Generate an incremental model for Fabric DW
+```sql
+{{ config(materialized='incremental', incremental_strategy='delete+insert', unique_key='order_id') }}
+select
+    cast(order_id as bigint)      as order_id,
+    cast(amount   as decimal(19,4)) as amount,   -- not money
+    cast(status   as varchar(50)) as status      -- not nvarchar
+from {{ ref('stg_orders') }}
+{% if is_incremental() %}
+where order_date > (select max(order_date) from {{ this }})
+{% endif %}
+```
+
+### Example 3 — Connect a job to a GitHub repo (run-only)
+See [authoring-recipes.md § GitHub source](references/authoring-recipes.md#github-source): create a
+`GitHubSourceControl` connection from a classic PAT, bind the job's project to that connection +
+branch (profile/command unchanged), then run.
+
+---
+
+## Agent Integration Notes
+
+- This skill covers **authoring** — create/configure/update/deploy/run dbt jobs and generate SQL.
+- For **read-only** discovery, run-history, and monitoring, delegate to **dbt-consumption-cli**.
+- For end-to-end lakehouse patterns, see **e2e-medallion-architecture**; for warehouse T-SQL, see
+  **sqldw-authoring-cli**.
+- All writes require a Contributor workspace role and read/write on the target warehouse/connection.

--- a/skills/dbt-authoring-cli/references/authoring-recipes.md
+++ b/skills/dbt-authoring-cli/references/authoring-recipes.md
@@ -1,0 +1,186 @@
+# Authoring Recipes — `az rest` for Fabric dbt Jobs
+
+Copy/paste `az rest` recipes for the full dbt job lifecycle. All calls pass
+`--resource https://api.fabric.microsoft.com`. Assumes:
+
+```bash
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+WS="<workspace-id>"
+```
+
+See [DBT-CORE.md](../../../common/DBT-CORE.md) for the definition model and the no-secrets rule. Confirm writes with
+the user first (see SKILL.md § Preview & Confirm).
+
+## Create a dbt job
+
+```bash
+JOB_ID=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/dataBuildToolJobs" \
+  --headers "Content-Type=application/json" \
+  --body '{"displayName":"Sales dbt job","description":"Builds sales marts"}' \
+  --query "id" -o tsv)
+echo "Job: $JOB_ID"
+```
+
+## Discover the config-part name (never hardcode)
+
+```bash
+# getDefinition (LRO — poll Location if 202; see COMMON-CLI.md § LRO Pattern)
+DEF=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/getDefinition")
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+CONTENT_PART="${CONTENT_PART:-dbt-content.json}"     # default for a brand-new job
+echo "Config part: $CONTENT_PART"
+```
+
+## Deploy a local project into `Code/dbt/*` (read-modify-write)
+
+`updateDefinition` replaces the whole part list, so rebuild it from the **existing** parts plus your
+files. This packs everything under `./my_dbt_project` as `Code/dbt/<relpath>` and keeps any config /
+`.platform` part already present.
+
+```bash
+ROOT="./my_dbt_project"
+
+# Start from existing parts EXCEPT the project files we're about to replace.
+PARTS=$(echo "$DEF" | jq '[.definition.parts[] | select(.path | startswith("Code/dbt/") | not)]')
+
+# Add each project file as a Code/dbt/* part.
+while IFS= read -r f; do
+  rel="${f#"$ROOT"/}"
+  b64=$(base64 -w0 < "$f" 2>/dev/null || base64 < "$f" | tr -d '\n')   # macOS has no -w0
+  PARTS=$(echo "$PARTS" | jq --arg p "Code/dbt/$rel" --arg pl "$b64" \
+    '. + [{path:$p, payload:$pl, payloadType:"InlineBase64"}]')
+done < <(find "$ROOT" -type f -not -path '*/target/*' -not -path '*/.git/*')
+
+az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/updateDefinition" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --argjson parts "$PARTS" '{definition:{parts:$parts}}')"
+```
+
+## Set the config part (connection GUID + schema + command)
+
+Binds a **Fabric Warehouse** by workspace/artifact GUID. For Postgres/Snowflake/SQL Server, replace
+`connectionSettings` with `"externalReferences": {"connection":"<conn-guid>"}` and set `profileType`
+accordingly (`PostgreSql`/`Snowflake`/`SqlServer`). No credentials appear anywhere.
+
+```bash
+WH_ID="<warehouse-item-id>"
+WH_FQDN=$(az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$WH_ID" --query "properties.connectionString" -o tsv)
+
+cat > /tmp/dbt-content.json << EOF
+{
+  "project": { "projectType": "OneLake", "folderPath": "dbt" },
+  "profile": {
+    "profileType": "DataWarehouse",
+    "schema": "gold",
+    "connectionSettings": {
+      "name": "SalesWarehouse",
+      "properties": {
+        "type": "DataWarehouse",
+        "typeProperties": { "workspaceId": "$WS", "artifactId": "$WH_ID", "endPoint": "$WH_FQDN" }
+      }
+    }
+  },
+  "command": { "operation": "build", "arguments": { "threads": 4, "failFast": true } }
+}
+EOF
+
+# RMW: keep all existing parts, replace only the config part.
+CONTENT_B64=$(base64 -w0 < /tmp/dbt-content.json 2>/dev/null || base64 < /tmp/dbt-content.json | tr -d '\n')
+PARTS=$(echo "$DEF" | jq --arg cp "$CONTENT_PART" \
+  '[.definition.parts[] | select(.path != $cp)]')
+PARTS=$(echo "$PARTS" | jq --arg cp "$CONTENT_PART" --arg pl "$CONTENT_B64" \
+  '. + [{path:$cp, payload:$pl, payloadType:"InlineBase64"}]')
+
+az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/updateDefinition" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --argjson parts "$PARTS" '{definition:{parts:$parts}}')"
+```
+
+## Trigger a run and monitor
+
+```bash
+RUN_LOCATION=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances?jobType=Execute" \
+  --headers "Content-Length=0" --output none --include-response-headers 2>&1 \
+  | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+while true; do
+  RUN=$(az rest --method GET --resource "$RES" --url "$RUN_LOCATION")
+  STATUS=$(echo "$RUN" | jq -r '.status')
+  echo "Status: $STATUS"
+  [[ "$STATUS" =~ ^(Completed|Failed|Cancelled|Deduped)$ ]] && break
+  sleep 15
+done
+[[ "$STATUS" == "Failed" ]] && echo "$RUN" | jq '.failureReason'
+```
+
+## End-to-end
+
+Create → deploy `Code/dbt/*` → set config → run, in order: run the four blocks above with the same
+`$JOB_ID` and `$DEF` (re-fetch `$DEF` with getDefinition before each RMW so you always start from the
+current parts).
+
+---
+
+## GitHub source
+
+Connect a job to an existing GitHub repo instead of storing files in Fabric. **Run-only** — you can't
+edit models in Fabric; commit to the repo and Fabric pulls on the next run. The classic PAT lives
+only in the connection.
+
+### 1) Create the GitHub source-control connection (PAT from env)
+
+```bash
+# Read the PAT from the environment so it never appears in shell history / files.
+read -rs GITHUB_PAT    # or: export GITHUB_PAT before running
+
+CONN_ID=$(az rest --method POST --resource "$RES" --url "$API/connections" \
+  --headers "Content-Type=application/json" \
+  --body "$(jq -n --arg url 'https://github.com/<owner>/<repo>' --arg pat "$GITHUB_PAT" '{
+    connectivityType:"ShareableCloud",
+    displayName:"MyGitHubPAT",
+    connectionDetails:{ type:"GitHubSourceControl", creationMethod:"GitHubSourceControl.Contents",
+      parameters:[{dataType:"Text", name:"url", value:$url}] },
+    credentialDetails:{ credentials:{ credentialType:"Key", key:$pat } }
+  }')" \
+  --query "id" -o tsv)
+echo "GitHub connection: $CONN_ID"
+```
+
+Response `connectionDetails.type` is `GitHubSourceControl`. Omitting the repo in `parameters.url`
+scopes the connection to all repos the PAT can read.
+
+### 2) Bind the dbt job to the GitHub source
+
+Project points at the GitHub connection + branch; **profile and command stay the normal warehouse
+binding** (a GitHub-sourced job still has an adapter + warehouse + schema). Push with `updateDefinition`.
+
+> The git-source `project` block below is **inferred** (the portal writes it inside an iframe that
+> can't be captured) — verify against your tenant. If rejected, capture a working job's definition
+> with dbt-consumption-cli and copy the exact `project` shape.
+
+```jsonc
+{
+  "project": {
+    "projectType": "GitHubSourceControl",
+    "connectionSettings": {
+      "type": "GitHubSourceControl",
+      "properties": { "connection": "<github-connection-guid>", "branch": "main", "rootFolder": "" }
+    }
+  },
+  "profile": { "profileType": "DataWarehouse", "schema": "jaffle_shop",
+    "connectionSettings": { "name": "jaffle_shop_dw", "properties": { "type":"DataWarehouse",
+      "typeProperties": { "workspaceId":"<ws>", "artifactId":"<warehouse>", "endPoint":"<fqdn>" } } } },
+  "command": { "operation": "build", "arguments": { "threads": 4 } }
+}
+```
+
+### 3) Run
+
+Identical to any dbt job — see [Trigger a run and monitor](#trigger-a-run-and-monitor).

--- a/skills/dbt-consumption-cli/SKILL.md
+++ b/skills/dbt-consumption-cli/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: dbt-consumption-cli
+description: >
+  Discover, inspect, and monitor Fabric dbt jobs (DataBuildToolJob) via `az rest` — read-only and
+  run-focused operations. List dbt jobs, decode their configuration and project files from the item
+  definition, review model schema (schema.yml), trigger runs, and inspect run history and failures.
+  Use when the user wants to:
+    1. List the dbt jobs in a workspace
+    2. Inspect a dbt job's adapter, schema, connection, and run command
+    3. See which project files (models, schema.yml) ship with a job
+    4. Trigger a dbt run and monitor it, or review run history / failure reasons
+    5. Compare dbt command/profile settings across jobs (governance)
+  Triggers: "list dbt jobs", "inspect dbt job", "show dbt config", "dbt run history",
+  "why did my dbt job fail", "monitor dbt run", "which models are in my dbt job", "dbt consumption"
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+> **CRITICAL NOTES**
+> 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering.
+> 2. To find dbt jobs: list items with `type=DataBuildToolJob`, then filter by `displayName`.
+> 3. **Decode before inspecting** — definition parts are base64; the config-part name varies by API version (discover it via `dbt[\w-]*content\.json`).
+
+# dbt-consumption-cli — Inspect & Monitor Fabric dbt Jobs via CLI
+
+## Table of Contents
+
+| Task | Reference | Notes |
+|---|---|---|
+| Finding Workspaces and Items in Fabric | [COMMON-CLI.md § Finding Workspaces and Items in Fabric](../../common/COMMON-CLI.md#finding-workspaces-and-items-in-fabric) | **Mandatory** — *READ link first* [use `type=DataBuildToolJob`] |
+| Authentication & Token Acquisition | [COMMON-CORE.md § Authentication & Token Acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition) | Wrong audience = 401 |
+| Core Control-Plane REST APIs | [COMMON-CORE.md § Core Control-Plane REST APIs](../../common/COMMON-CORE.md#core-control-plane-rest-apis) | List Items, getDefinition |
+| Long-Running Operations (LRO) | [COMMON-CORE.md § Long-Running Operations (LRO)](../../common/COMMON-CORE.md#long-running-operations-lro) | getDefinition can be a 202 LRO |
+| Fabric Control-Plane API via `az rest` | [COMMON-CLI.md § Fabric Control-Plane API via az rest](../../common/COMMON-CLI.md#fabric-control-plane-api-via-az-rest) | **Always pass `--resource https://api.fabric.microsoft.com`** |
+| Long-Running Operations (LRO) Pattern | [COMMON-CLI.md § Long-Running Operations (LRO) Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern) | Poll `Location` |
+| dbt job execution model & definition | [DBT-CORE.md § Execution model](../../common/DBT-CORE.md#execution-model) | Item type, `Code/dbt/*` parts, config-part name |
+| Adapter reference | [DBT-CORE.md § Supportability matrix](../../common/DBT-CORE.md#supportability-matrix) | Interpreting `profileType` |
+| Inspect & monitor recipes (`az rest`) | [inspect-recipes.md](references/inspect-recipes.md) | List, decode config, list Code/dbt parts, run history |
+| Discovery Scope | [SKILL.md § Discovery Scope](#discovery-scope) | |
+| Must / Prefer / Avoid | [SKILL.md § Must / Prefer / Avoid](#must--prefer--avoid) | |
+| Troubleshooting | [SKILL.md § Troubleshooting](#troubleshooting) | |
+| Agent Integration Notes | [SKILL.md § Agent Integration Notes](#agent-integration-notes) | |
+
+---
+
+## Discovery Scope
+
+| Operation | Endpoint (via `az rest`, `--resource https://api.fabric.microsoft.com`) |
+|---|---|
+| List dbt jobs | `GET  /v1/workspaces/{ws}/items?type=DataBuildToolJob` |
+| Get item | `GET  /v1/workspaces/{ws}/dataBuildToolJobs/{id}` |
+| Get definition (decode) | `POST /v1/workspaces/{ws}/items/{id}/getDefinition` |
+| Run history | `GET  /v1/workspaces/{ws}/items/{id}/jobs/instances` |
+| Trigger run | `POST /v1/workspaces/{ws}/items/{id}/jobs/instances?jobType=Execute` |
+
+All read-only except triggering a run. See [inspect-recipes.md](references/inspect-recipes.md) for
+copy/paste commands, and [DBT-CORE.md](../../common/DBT-CORE.md) for the definition model.
+
+---
+
+## Must / Prefer / Avoid
+
+### Must
+- Use `type=DataBuildToolJob` when listing (not `dbtJob`).
+- **Discover** the config-part name from `getDefinition` (`dbt[\w-]*content\.json`) before decoding.
+- Decode base64 parts before inspecting; handle `getDefinition` 202 by polling `Location`.
+
+### Prefer
+- Inspect a job's config + `schema.yml` **before** triggering a run or handing off to authoring.
+- Filter run history by status/time; read `failureReason` on failures.
+- `jq` / JMESPath for compact diagnostics.
+
+### Avoid
+- Assuming the config-part name (`dbt-content.json` vs `dbtjob-content.json`).
+- Editing anything here — this skill is read-only. For changes, delegate to **dbt-authoring-cli**.
+- Polling runs without a backoff.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Empty job list | Wrong item type filter | Use `type=DataBuildToolJob` |
+| 401 on API calls | Wrong/expired token | Re-login; keep `--resource https://api.fabric.microsoft.com` |
+| Missing content part | Hardcoded part name | Discover via `getDefinition` regex `dbt.?content\.json` |
+| No `Code/dbt/*` parts | GitHub-sourced (run-only) job | Code lives in GitHub; inspect the repo, not the definition |
+| 400 on run trigger | Wrong `jobType` | Use `jobType=Execute` |
+
+---
+
+## Agent Integration Notes
+
+- This skill is **read-only + run** — discover, inspect, monitor. It never edits a job.
+- For create/configure/update/deploy and SQL generation, delegate to **dbt-authoring-cli**.
+- Inspecting `schema.yml` here is the first step of the authoring skill's update workflow.

--- a/skills/dbt-consumption-cli/references/inspect-recipes.md
+++ b/skills/dbt-consumption-cli/references/inspect-recipes.md
@@ -1,0 +1,98 @@
+# Inspect & Monitor Recipes — `az rest` for Fabric dbt Jobs
+
+Read-only (plus run) recipes. All calls pass `--resource https://api.fabric.microsoft.com`. Assumes:
+
+```bash
+API="https://api.fabric.microsoft.com/v1"
+RES="https://api.fabric.microsoft.com"
+WS="<workspace-id>"
+```
+
+See [DBT-CORE.md](../../../common/DBT-CORE.md) for the definition model.
+
+## 1) List dbt jobs in a workspace
+
+```bash
+az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items?type=DataBuildToolJob" \
+  --query "value[].{name:displayName, id:id, description:description}" -o table
+```
+
+## 2) Decode a job's configuration (adapter, schema, command)
+
+```bash
+JOB_ID="<dbt-job-id>"
+DEF=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/getDefinition")     # poll Location if 202
+
+CONTENT_PART=$(echo "$DEF" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+echo "$DEF" | jq -r --arg p "$CONTENT_PART" \
+  '.definition.parts[] | select(.path==$p) | .payload' | base64 -d | jq '{
+    projectType: .project.projectType,
+    adapter:     .profile.profileType,
+    schema:      .profile.schema,
+    operation:   .command.operation,
+    select:      .command.arguments.select,
+    threads:     .command.arguments.threads,
+    failFast:    .command.arguments.failFast
+  }'
+```
+
+## 3) List the project files shipped with the job
+
+```bash
+echo "$DEF" | jq -r '.definition.parts[].path | select(startswith("Code/dbt/"))'
+```
+
+No `Code/dbt/*` parts usually means the job is **GitHub-sourced** (run-only) — the code lives in the
+repo, not the definition. Check `project.projectType` from step 2.
+
+## 4) Read a specific model or schema.yml (understand the data model)
+
+```bash
+# Decode schema.yml — the source of truth for the model's columns and tests.
+echo "$DEF" | jq -r '.definition.parts[] | select(.path|endswith("schema.yml")) | .payload' \
+  | base64 -d
+
+# Decode a specific model
+echo "$DEF" | jq -r '.definition.parts[] | select(.path=="Code/dbt/models/marts/fct_orders.sql") | .payload' \
+  | base64 -d
+```
+
+## 5) Run history and failure diagnostics
+
+```bash
+az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances" \
+  --query "value[].{status:status, start:startTimeUtc, end:endTimeUtc, error:failureReason}" -o table
+```
+
+## 6) Trigger a run and monitor
+
+```bash
+RUN_LOCATION=$(az rest --method POST --resource "$RES" \
+  --url "$API/workspaces/$WS/items/$JOB_ID/jobs/instances?jobType=Execute" \
+  --headers "Content-Length=0" --output none --include-response-headers 2>&1 \
+  | grep -i "^location:" | awk '{print $2}' | tr -d '\r')
+
+while true; do
+  RUN=$(az rest --method GET --resource "$RES" --url "$RUN_LOCATION")
+  STATUS=$(echo "$RUN" | jq -r '.status'); echo "Status: $STATUS"
+  [[ "$STATUS" =~ ^(Completed|Failed|Cancelled|Deduped)$ ]] && break
+  sleep 15
+done
+[[ "$STATUS" == "Failed" ]] && echo "$RUN" | jq '.failureReason'
+```
+
+## 7) Compare dbt commands across jobs (governance)
+
+```bash
+for ID in $(az rest --method GET --resource "$RES" \
+  --url "$API/workspaces/$WS/items?type=DataBuildToolJob" --query "value[].id" -o tsv); do
+  echo "==== $ID ===="
+  D=$(az rest --method POST --resource "$RES" --url "$API/workspaces/$WS/items/$ID/getDefinition")
+  CP=$(echo "$D" | jq -r '.definition.parts[].path | select(test("dbt.?content\\.json"))')
+  echo "$D" | jq -r --arg p "$CP" '.definition.parts[] | select(.path==$p) | .payload' \
+    | base64 -d | jq '{adapter:.profile.profileType, operation:.command.operation, select:.command.arguments.select}'
+done
+```


### PR DESCRIPTION
New skills for creating, deploying, and running Fabric dbt jobs (DataBuildToolJob) and generating dbt Core 1.9 SQL for Fabric Warehouse, Azure SQL, PostgreSQL and Snowflake. Includes shared common/DBT-CORE.md, az rest recipe references, GitHub run-only source support, connection-GUID-only (no credentials) binding, and read-modify-write definition updates. Registered in both marketplace manifests (fabric-skills / fabric-authoring / fabric-consumption), version 0.3.5 -> 0.3.6, CHANGELOG entry.