### PR TITLE
Fix broken references found in repo audit

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -90,7 +90,7 @@ Developers use REST APIs to manage artifacts, then protocol-specific connections
 ### Power BI / FabricIQ
 - Consumption skill: `skills/semantic-model-consumption/SKILL.md` — raw DAX queries via MCP ExecuteQuery
 - FabricIQ skill: `skills/fabriciq/SKILL.md` — multi-step Power BI analysis (discover, inspect, resolve, generate, execute)
-- ⚠️ **MANDATORY**: Before calling any FabricIQ MCP tool, read `skills/fabriciq/SKILL.md` in full (see [`agents/FabricIQ.agent.md` § Pre-Flight](../agents/FabricIQ.agent.md#pre-flight--mandatory-skill-reading)).
+- ⚠️ **MANDATORY**: Before calling any FabricIQ MCP tool, read `skills/fabriciq/SKILL.md` in full (see [`agents/FabricIQ.agent.md` § Pre-Flight](agents/FabricIQ.agent.md#pre-flight--mandatory-skill-reading)).
 
 ### Fabric IQ / Ontology (preview)
 - Use the Fabric item-definition REST API (Create / Get / Update Item Definition) with `InlineBase64` parts

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,10 +2,3 @@
 # https://github.com/gitleaks/gitleaks#configuration
 
 title = "skills-for-fabric Gitleaks Config"
-
-# Allowlist paths containing test fixtures with fake secrets
-[allowlist]
-  description = "Allowlist for test files with fake/mock secrets"
-  paths = [
-    '''tests/redteam/test_prompt_injection\.py''',
-  ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Fabric REST APIs: https://learn.microsoft.com/en-us/rest/api/fabric/articles/
 ### Power BI / FabricIQ
 - Consumption skill: `skills/semantic-model-consumption/SKILL.md` — raw DAX queries against semantic models via MCP ExecuteQuery tool
 - FabricIQ skill: `skills/fabriciq/SKILL.md` — multi-step Power BI data analysis (discover, inspect, resolve, generate, execute)
-- ⚠️ **MANDATORY**: Before calling any FabricIQ MCP tool, read `skills/fabriciq/SKILL.md` in full (see [`agents/FabricIQ.agent.md` § Pre-Flight](../agents/FabricIQ.agent.md#pre-flight--mandatory-skill-reading)).
+- ⚠️ **MANDATORY**: Before calling any FabricIQ MCP tool, read `skills/fabriciq/SKILL.md` in full (see [`agents/FabricIQ.agent.md` § Pre-Flight](agents/FabricIQ.agent.md#pre-flight--mandatory-skill-reading)).
 
 ### Fabric IQ / Ontology (preview)
 - Authoring skill: `skills/fabriciq-ontology-authoring-cli/SKILL.md` — define entity types, properties (incl. timeseries), relationship types, and bind them to lakehouse/Eventhouse tables via the item-definition REST API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ https://learn.microsoft.com/en-us/rest/api/fabric/articles/
   - Authoring skill: `skills/semantic-model-authoring/SKILL.md` — semantic model authoring
   - Consumption skill: `skills/semantic-model-consumption/SKILL.md` — raw DAX queries against semantic models via MCP ExecuteQuery tool
   - FabricIQ skill: `skills/fabriciq/SKILL.md` — multi-step Power BI data analysis (discover, inspect, resolve, generate, execute)
-  - ⚠️ **MANDATORY**: Before calling any FabricIQ MCP tool, read `skills/fabriciq/SKILL.md` in full (see [`agents/FabricIQ.agent.md` § Pre-Flight](../agents/FabricIQ.agent.md#pre-flight--mandatory-skill-reading)).
+  - ⚠️ **MANDATORY**: Before calling any FabricIQ MCP tool, read `skills/fabriciq/SKILL.md` in full (see [`agents/FabricIQ.agent.md` § Pre-Flight](agents/FabricIQ.agent.md#pre-flight--mandatory-skill-reading)).
 - **Power BI Reports**: PBIR/PBIP report projects, visual design, Desktop validation, and Fabric report item management
   - Docs: https://learn.microsoft.com/en-us/power-bi/developer/projects/projects-report
   - Skill docs: https://aka.ms/Report_Authoring_skill_LearnDocs

--- a/package.json
+++ b/package.json
@@ -30,10 +30,6 @@
     "mcp-setup/**"
   ],
   "scripts": {
-    "postinstall": "node -e \"console.log('\\n✅ Skills for Fabric installed. Use the GitHub Copilot CLI plugin marketplace, or copy the relevant skills/ folder into your AI tool configuration.\\n')\"",
-    "report:coverage-gaps": "python tests/coverage_gap_report.py",
-    "test": "pytest",
-    "test:semantic": "pytest -m semantic",
-    "test:integration": "pytest -m integration"
+    "postinstall": "node -e \"console.log('\\n✅ Skills for Fabric installed. Use the GitHub Copilot CLI plugin marketplace, or copy the relevant skills/ folder into your AI tool configuration.\\n')\""
   }
 }

--- a/plugins/fabric-authoring/skills/spark-authoring-cli/resources/notebook-api-operations.md
+++ b/plugins/fabric-authoring/skills/spark-authoring-cli/resources/notebook-api-operations.md
@@ -4,7 +4,6 @@ Principles and decision guidance for reading and updating Fabric notebook conten
 Use this guide when the task requires modifying an **existing** notebook in a Fabric workspace
 (e.g., adding new columns, updating SQL logic, changing cell code).
 
-> **Local file authoring?** See [local-development.md](local-development.md) instead.
 > This guide covers **service-mode** operations that require a workspace ID and a Fabric token.
 
 ---

--- a/plugins/fabric-operations/skills/spark-operations-cli/references/diagnostic-workflow.md
+++ b/plugins/fabric-operations/skills/spark-operations-cli/references/diagnostic-workflow.md
@@ -85,7 +85,7 @@ This skill provides two diagnostic tiers. Always start with **Tier 1**. Escalate
 Uses Fabric Spark Monitoring REST APIs (via `az rest`) to pull session data, failed jobs, slowest stages, Spark Advisor findings, and driver logs. Fast; no download; no active session required.
 
 **Workflow:**
-1. **Find the session** — List Livy sessions for the notebook/SJD (see [Monitoring Workflow](../../common/SPARK-MONITORING-CORE.md#diagnostic-workflow-using-monitoring-apis))
+1. **Find the session** — List Livy sessions for the notebook/SJD (see [Monitoring Workflow](../../../common/SPARK-MONITORING-CORE.md#diagnostic-workflow-using-monitoring-apis))
 2. **Check Advisor** — Query the Spark Advisor API for automated root-cause detection
 3. **Failure analysis** — If job failed, inspect failed jobs/stages, read driver/executor logs
 4. **Performance analysis** — Check stage metrics, executor utilization, resource usage

--- a/plugins/fabric-operations/skills/spark-operations-cli/references/jobinsight-api.md
+++ b/plugins/fabric-operations/skills/spark-operations-cli/references/jobinsight-api.md
@@ -135,7 +135,7 @@ Since JobInsight is Scala-only and cluster-bound, the recommended automation pat
      --url "https://api.fabric.microsoft.com/v1/workspaces/$workspaceId/items/$notebookId/jobs/RunNotebook/instances" \
      --body '{"executionData": {"parameters": {"workspaceId": "...", "livyId": "...", "targetDir": "..."}}}'
    ```
-3. Poll the Location header for completion (see [COMMON-CLI.md § LRO Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern))
+3. Poll the Location header for completion (see [COMMON-CLI.md § LRO Pattern](../../../common/COMMON-CLI.md#long-running-operations-lro-pattern))
 
 ---
 

--- a/plugins/fabric-skills/skills/spark-authoring-cli/resources/notebook-api-operations.md
+++ b/plugins/fabric-skills/skills/spark-authoring-cli/resources/notebook-api-operations.md
@@ -4,7 +4,6 @@ Principles and decision guidance for reading and updating Fabric notebook conten
 Use this guide when the task requires modifying an **existing** notebook in a Fabric workspace
 (e.g., adding new columns, updating SQL logic, changing cell code).
 
-> **Local file authoring?** See [local-development.md](local-development.md) instead.
 > This guide covers **service-mode** operations that require a workspace ID and a Fabric token.
 
 ---

--- a/plugins/fabric-skills/skills/spark-operations-cli/references/diagnostic-workflow.md
+++ b/plugins/fabric-skills/skills/spark-operations-cli/references/diagnostic-workflow.md
@@ -85,7 +85,7 @@ This skill provides two diagnostic tiers. Always start with **Tier 1**. Escalate
 Uses Fabric Spark Monitoring REST APIs (via `az rest`) to pull session data, failed jobs, slowest stages, Spark Advisor findings, and driver logs. Fast; no download; no active session required.
 
 **Workflow:**
-1. **Find the session** — List Livy sessions for the notebook/SJD (see [Monitoring Workflow](../../common/SPARK-MONITORING-CORE.md#diagnostic-workflow-using-monitoring-apis))
+1. **Find the session** — List Livy sessions for the notebook/SJD (see [Monitoring Workflow](../../../common/SPARK-MONITORING-CORE.md#diagnostic-workflow-using-monitoring-apis))
 2. **Check Advisor** — Query the Spark Advisor API for automated root-cause detection
 3. **Failure analysis** — If job failed, inspect failed jobs/stages, read driver/executor logs
 4. **Performance analysis** — Check stage metrics, executor utilization, resource usage

--- a/plugins/fabric-skills/skills/spark-operations-cli/references/jobinsight-api.md
+++ b/plugins/fabric-skills/skills/spark-operations-cli/references/jobinsight-api.md
@@ -135,7 +135,7 @@ Since JobInsight is Scala-only and cluster-bound, the recommended automation pat
      --url "https://api.fabric.microsoft.com/v1/workspaces/$workspaceId/items/$notebookId/jobs/RunNotebook/instances" \
      --body '{"executionData": {"parameters": {"workspaceId": "...", "livyId": "...", "targetDir": "..."}}}'
    ```
-3. Poll the Location header for completion (see [COMMON-CLI.md § LRO Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern))
+3. Poll the Location header for completion (see [COMMON-CLI.md § LRO Pattern](../../../common/COMMON-CLI.md#long-running-operations-lro-pattern))
 
 ---
 

--- a/skills/spark-authoring-cli/resources/notebook-api-operations.md
+++ b/skills/spark-authoring-cli/resources/notebook-api-operations.md
@@ -4,7 +4,6 @@ Principles and decision guidance for reading and updating Fabric notebook conten
 Use this guide when the task requires modifying an **existing** notebook in a Fabric workspace
 (e.g., adding new columns, updating SQL logic, changing cell code).
 
-> **Local file authoring?** See [local-development.md](local-development.md) instead.
 > This guide covers **service-mode** operations that require a workspace ID and a Fabric token.
 
 ---

--- a/skills/spark-operations-cli/references/diagnostic-workflow.md
+++ b/skills/spark-operations-cli/references/diagnostic-workflow.md
@@ -85,7 +85,7 @@ This skill provides two diagnostic tiers. Always start with **Tier 1**. Escalate
 Uses Fabric Spark Monitoring REST APIs (via `az rest`) to pull session data, failed jobs, slowest stages, Spark Advisor findings, and driver logs. Fast; no download; no active session required.
 
 **Workflow:**
-1. **Find the session** — List Livy sessions for the notebook/SJD (see [Monitoring Workflow](../../common/SPARK-MONITORING-CORE.md#diagnostic-workflow-using-monitoring-apis))
+1. **Find the session** — List Livy sessions for the notebook/SJD (see [Monitoring Workflow](../../../common/SPARK-MONITORING-CORE.md#diagnostic-workflow-using-monitoring-apis))
 2. **Check Advisor** — Query the Spark Advisor API for automated root-cause detection
 3. **Failure analysis** — If job failed, inspect failed jobs/stages, read driver/executor logs
 4. **Performance analysis** — Check stage metrics, executor utilization, resource usage

--- a/skills/spark-operations-cli/references/jobinsight-api.md
+++ b/skills/spark-operations-cli/references/jobinsight-api.md
@@ -135,7 +135,7 @@ Since JobInsight is Scala-only and cluster-bound, the recommended automation pat
      --url "https://api.fabric.microsoft.com/v1/workspaces/$workspaceId/items/$notebookId/jobs/RunNotebook/instances" \
      --body '{"executionData": {"parameters": {"workspaceId": "...", "livyId": "...", "targetDir": "..."}}}'
    ```
-3. Poll the Location header for completion (see [COMMON-CLI.md § LRO Pattern](../../common/COMMON-CLI.md#long-running-operations-lro-pattern))
+3. Poll the Location header for completion (see [COMMON-CLI.md § LRO Pattern](../../../common/COMMON-CLI.md#long-running-operations-lro-pattern))
 
 ---
 


### PR DESCRIPTION
Fixes items 1–4 of #56 (repo audit findings). The remaining items in that issue need maintainer decisions and are not touched here.

## Changes

1. **Remove dead link to nonexistent `local-development.md`** in `spark-authoring-cli/resources/notebook-api-operations.md` — the target file does not exist anywhere in the repo. Applied to all 3 copies (root, `fabric-skills`, `fabric-authoring`).
2. **Correct wrong-depth `../../common/` links to `../../../common/`** in `spark-operations-cli/references/diagnostic-workflow.md` and `jobinsight-api.md` — from the `references/` subfolder, two levels up resolves to the nonexistent `skills/common/`. Applied to all 3 copies (root, `fabric-skills`, `fabric-operations`). The other reference files in this skill already use the correct path.
3. **Fix `../agents/FabricIQ.agent.md` link** in `CLAUDE.md`, `AGENTS.md`, and `.cursorrules` — these files are at the repo root, so `../` pointed outside the repository.
4. **Remove stale `tests/` references** — the four `package.json` scripts (`test`, `test:semantic`, `test:integration`, `report:coverage-gaps`) and the sole `.gitleaks.toml` allowlist entry reference a `tests/` directory that is not part of this public repo, so `npm test` fails for anyone who runs it. `postinstall` is kept.

## Verification

- Zero occurrences of `local-development.md` remain repo-wide; zero wrong-depth `common/` links remain in `spark-operations-cli`.
- `package.json` parses cleanly after the script removals.
- All duplicated skill files remain byte-identical between root `skills/` and every `plugins/*/skills/` copy (hash-verified), preserving the repo's zero-drift invariant.

Note: since releases sync from an internal repo, these fixes may need to be applied upstream as well — happy for this PR to be superseded by an internal fix if that's the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
