### PR TITLE
fix(powerbi-authoring): work around unsigned macOS binary in powerbi-…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -277,7 +277,7 @@
           "command": "npx",
           "args": [
             "-y",
-            "@microsoft/powerbi-modeling-mcp@latest",
+            "@microsoft/powerbi-modeling-mcp@0.5.0-beta.11",
             "--start"
           ],
           "tools": [

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -277,7 +277,7 @@
           "command": "npx",
           "args": [
             "-y",
-            "@microsoft/powerbi-modeling-mcp@latest",
+            "@microsoft/powerbi-modeling-mcp@0.5.0-beta.11",
             "--start"
           ],
           "tools": [

--- a/plugins/fabric-authoring/skills/semantic-model-authoring/SKILL.md
+++ b/plugins/fabric-authoring/skills/semantic-model-authoring/SKILL.md
@@ -392,6 +392,7 @@ If any check fails, fix the issue and re-run validation.
 | Symptom                              | Fix                                                                                                                   |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | MCP connection failure               | Fall back to TMDL editing (see Tool Selection Priority). Inform the user about the fallback.                          |
+| MCP connect timeout on macOS (`timed out after 60000ms`) | The `powerbi-modeling-mcp` native macOS binary ships unsigned; macOS kills it with SIGKILL (exit 137) before the stdio handshake completes. Ad-hoc sign the downloaded binary, then restart the client: `find "$HOME/.npm/_npx" -path '*powerbi-modeling-mcp-*/dist/powerbi-modeling-mcp' -type f \| while read -r b; do xattr -dr com.apple.quarantine "$b" 2>/dev/null; codesign --force --sign - "$b"; done` |
 | TMDL validation errors               | Read error details, fix syntax, re-validate. Load [tmdl-guidelines.md](./references/tmdl-guidelines.md).              |
 | `403 Forbidden` / `identity None`    | User needs Contributor+ role - stop immediately. Do not retry.                                                        |
 | `401 Unauthorized`                   | Wrong `--resource` audience or missing permissions to the item. Check [semantic-model-rest-api.md](./references/semantic-model-rest-api.md). |

--- a/plugins/fabric-skills/skills/semantic-model-authoring/SKILL.md
+++ b/plugins/fabric-skills/skills/semantic-model-authoring/SKILL.md
@@ -392,6 +392,7 @@ If any check fails, fix the issue and re-run validation.
 | Symptom                              | Fix                                                                                                                   |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | MCP connection failure               | Fall back to TMDL editing (see Tool Selection Priority). Inform the user about the fallback.                          |
+| MCP connect timeout on macOS (`timed out after 60000ms`) | The `powerbi-modeling-mcp` native macOS binary ships unsigned; macOS kills it with SIGKILL (exit 137) before the stdio handshake completes. Ad-hoc sign the downloaded binary, then restart the client: `find "$HOME/.npm/_npx" -path '*powerbi-modeling-mcp-*/dist/powerbi-modeling-mcp' -type f \| while read -r b; do xattr -dr com.apple.quarantine "$b" 2>/dev/null; codesign --force --sign - "$b"; done` |
 | TMDL validation errors               | Read error details, fix syntax, re-validate. Load [tmdl-guidelines.md](./references/tmdl-guidelines.md).              |
 | `403 Forbidden` / `identity None`    | User needs Contributor+ role - stop immediately. Do not retry.                                                        |
 | `401 Unauthorized`                   | Wrong `--resource` audience or missing permissions to the item. Check [semantic-model-rest-api.md](./references/semantic-model-rest-api.md). |

--- a/plugins/powerbi-authoring/.github/plugin/plugin.json
+++ b/plugins/powerbi-authoring/.github/plugin/plugin.json
@@ -31,7 +31,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@microsoft/powerbi-modeling-mcp@latest",
+        "@microsoft/powerbi-modeling-mcp@0.5.0-beta.11",
         "--start"
       ],
       "tools": [

--- a/plugins/powerbi-authoring/.mcp.json
+++ b/plugins/powerbi-authoring/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@microsoft/powerbi-modeling-mcp@latest",
+        "@microsoft/powerbi-modeling-mcp@0.5.0-beta.11",
         "--start"
       ],
       "tools": [

--- a/plugins/powerbi-authoring/skills/semantic-model-authoring/SKILL.md
+++ b/plugins/powerbi-authoring/skills/semantic-model-authoring/SKILL.md
@@ -392,6 +392,7 @@ If any check fails, fix the issue and re-run validation.
 | Symptom                              | Fix                                                                                                                   |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | MCP connection failure               | Fall back to TMDL editing (see Tool Selection Priority). Inform the user about the fallback.                          |
+| MCP connect timeout on macOS (`timed out after 60000ms`) | The `powerbi-modeling-mcp` native macOS binary ships unsigned; macOS kills it with SIGKILL (exit 137) before the stdio handshake completes. Ad-hoc sign the downloaded binary, then restart the client: `find "$HOME/.npm/_npx" -path '*powerbi-modeling-mcp-*/dist/powerbi-modeling-mcp' -type f \| while read -r b; do xattr -dr com.apple.quarantine "$b" 2>/dev/null; codesign --force --sign - "$b"; done` |
 | TMDL validation errors               | Read error details, fix syntax, re-validate. Load [tmdl-guidelines.md](./references/tmdl-guidelines.md).              |
 | `403 Forbidden` / `identity None`    | User needs Contributor+ role - stop immediately. Do not retry.                                                        |
 | `401 Unauthorized`                   | Wrong `--resource` audience or missing permissions to the item. Check [semantic-model-rest-api.md](./references/semantic-model-rest-api.md). |

--- a/skills/semantic-model-authoring/SKILL.md
+++ b/skills/semantic-model-authoring/SKILL.md
@@ -392,6 +392,7 @@ If any check fails, fix the issue and re-run validation.
 | Symptom                              | Fix                                                                                                                   |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | MCP connection failure               | Fall back to TMDL editing (see Tool Selection Priority). Inform the user about the fallback.                          |
+| MCP connect timeout on macOS (`timed out after 60000ms`) | The `powerbi-modeling-mcp` native macOS binary ships unsigned; macOS kills it with SIGKILL (exit 137) before the stdio handshake completes. Ad-hoc sign the downloaded binary, then restart the client: `find "$HOME/.npm/_npx" -path '*powerbi-modeling-mcp-*/dist/powerbi-modeling-mcp' -type f \| while read -r b; do xattr -dr com.apple.quarantine "$b" 2>/dev/null; codesign --force --sign - "$b"; done` |
 | TMDL validation errors               | Read error details, fix syntax, re-validate. Load [tmdl-guidelines.md](./references/tmdl-guidelines.md).              |
 | `403 Forbidden` / `identity None`    | User needs Contributor+ role - stop immediately. Do not retry.                                                        |
 | `401 Unauthorized`                   | Wrong `--resource` audience or missing permissions to the item. Check [semantic-model-rest-api.md](./references/semantic-model-rest-api.md). |


### PR DESCRIPTION
Fixes #53

Problem
-------
On Apple Silicon macOS, the powerbi-modeling-mcp server fails to start and the client reports "Failed to connect" / "MCP connection timed out after 60000ms".

This is NOT a clash with the VS Code extension
(analysis-services.powerbi-modeling-mcp); uninstalling it has no effect because this bundle registers its own server via
`npx -y @microsoft/powerbi-modeling-mcp@latest --start`.

That launcher downloads a native Mach-O arm64 binary (@microsoft/powerbi-modeling-mcp-darwin-arm64) which, as of 0.5.0-beta.11, ships UNSIGNED ("code object is not signed at all"). macOS kills the unsigned binary with SIGKILL (exit 137) before it can complete the MCP stdio handshake, so the client waits the full 60s and times out.

Because the config used @latest, every version bump downloads a fresh unsigned binary into a new npx cache path -- which is why it worked for weeks and then broke after an update.

Fix
---
- Pin the modeling-MCP version (@latest -> @0.5.0-beta.11) in all bundle configs so the binary path is stable and only needs to be trusted once.
- Add a macOS troubleshooting row to the semantic-model-authoring skill (all bundle copies) documenting the ad-hoc signing workaround:

    find "$HOME/.npm/_npx" -path '*powerbi-modeling-mcp-*/dist/powerbi-modeling-mcp' -type f \
      | while read -r b; do
          xattr -dr com.apple.quarantine "$b" 2>/dev/null
          codesign --force --sign - "$b"
        done

Verified: after ad-hoc signing, the server registers all tools and reaches "Application started" over stdio in ~1-2s, well within the 60s limit.

The upstream fix is for Microsoft to sign and notarize the darwin-arm64 binary; this change is the client-side workaround plus documentation.