### PR TITLE
Release v0.3.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "fabric-collection",
   "metadata": {
     "description": "Microsoft Skills for Fabric collection for GitHub Copilot CLI",
-    "version": "0.3.8"
+    "version": "0.3.9"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "fabric-skills",
       "source": "./plugins/fabric-skills",
       "description": "Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -35,6 +35,7 @@
         "./skills/sqldb-operations-cli",
         "./skills/spark-operations-cli",
         "./skills/mlv-operations-cli",
+        "./skills/azmon-mirroredcatalogs-operations-cli",
         "./skills/dataflows-consumption-cli",
         "./skills/dataflows-authoring-cli",
         "./skills/dataflows-save-as-authoring-cli",
@@ -82,7 +83,7 @@
       "name": "skills-for-fabric",
       "source": "./plugins/fabric-skills",
       "description": "[DEPRECATED ALIAS of fabric-skills@fabric-collection \u2014 pre-0.3.0 users only; new installs should use fabric-skills.] Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -104,6 +105,7 @@
         "./skills/sqldb-operations-cli",
         "./skills/spark-operations-cli",
         "./skills/mlv-operations-cli",
+        "./skills/azmon-mirroredcatalogs-operations-cli",
         "./skills/dataflows-consumption-cli",
         "./skills/dataflows-authoring-cli",
         "./skills/dataflows-save-as-authoring-cli",
@@ -151,7 +153,7 @@
       "name": "fabric-authoring",
       "source": "./plugins/fabric-authoring",
       "description": "Developer skills for authoring Microsoft Skills for Fabric solutions - SDKs, APIs, automation scripts, CI/CD",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/sqldw-authoring-cli",
@@ -188,7 +190,7 @@
       "name": "fabric-consumption",
       "source": "./plugins/fabric-consumption",
       "description": "Consumer skills for interactive Microsoft Skills for Fabric operations - queries, exploration, monitoring",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -232,9 +234,10 @@
       "name": "fabric-operations",
       "source": "./plugins/fabric-operations",
       "description": "Operations skills for diagnosing Microsoft Fabric performance and health - system views, multi-step investigation workflows",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
+        "./skills/azmon-mirroredcatalogs-operations-cli",
         "./skills/mlv-operations-cli",
         "./skills/sqldw-operations-cli",
         "./skills/sqldb-operations-cli",
@@ -261,7 +264,7 @@
       "name": "powerbi-authoring",
       "source": "./plugins/powerbi-authoring",
       "description": "Developer skills for authoring Microsoft Power BI solutions.",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-authoring",

--- a/.cursorrules
+++ b/.cursorrules
@@ -75,6 +75,9 @@ Developers use REST APIs to manage artifacts, then protocol-specific connections
 ### Spark Operations
 - Operations skill: `skills/spark-operations-cli/SKILL.md` — read-only triage for failed jobs, stuck sessions, performance bottlenecks
 
+### Azure Monitor Observability (Real-Time Intelligence)
+- Operations skill: `skills/azmon-mirroredcatalogs-operations-cli/SKILL.md` — onboard Azure Monitor / App Insights / Log Analytics observability data into Fabric and correlate telemetry with business data for business-impact insights and Operations Agent instructions
+
 ### Dataflows Gen2 (Data Integration)
 - Use Fabric REST API for dataflow lifecycle management and Power Query M mashup authoring
 - Primary CLI tool: `az rest` against the Fabric REST API

--- a/.github/ISSUE_TEMPLATE/fabric_skills_bug.yml
+++ b/.github/ISSUE_TEMPLATE/fabric_skills_bug.yml
@@ -34,6 +34,7 @@ body:
         - Ananke / FabricIQ (Power BI data exploration)
         - Power BI Reports
         - Fabric IQ / Ontology
+        - Azure Monitor into Fabric
         - Infrastructure / repo / CI / general (or not sure)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -33,6 +33,7 @@ body:
         - Ananke / FabricIQ (Power BI data exploration)
         - Power BI Reports
         - Fabric IQ / Ontology
+        - Azure Monitor into Fabric
         - Infrastructure / repo / CI / general (or not sure)
     validations:
       required: true

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "fabric-collection",
   "metadata": {
     "description": "Microsoft Skills for Fabric collection for GitHub Copilot CLI",
-    "version": "0.3.8"
+    "version": "0.3.9"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "fabric-skills",
       "source": "./plugins/fabric-skills",
       "description": "Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -35,6 +35,7 @@
         "./skills/sqldb-operations-cli",
         "./skills/spark-operations-cli",
         "./skills/mlv-operations-cli",
+        "./skills/azmon-mirroredcatalogs-operations-cli",
         "./skills/dataflows-consumption-cli",
         "./skills/dataflows-authoring-cli",
         "./skills/dataflows-save-as-authoring-cli",
@@ -82,7 +83,7 @@
       "name": "skills-for-fabric",
       "source": "./plugins/fabric-skills",
       "description": "[DEPRECATED ALIAS of fabric-skills@fabric-collection \u2014 pre-0.3.0 users only; new installs should use fabric-skills.] Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -104,6 +105,7 @@
         "./skills/sqldb-operations-cli",
         "./skills/spark-operations-cli",
         "./skills/mlv-operations-cli",
+        "./skills/azmon-mirroredcatalogs-operations-cli",
         "./skills/dataflows-consumption-cli",
         "./skills/dataflows-authoring-cli",
         "./skills/dataflows-save-as-authoring-cli",
@@ -151,7 +153,7 @@
       "name": "fabric-authoring",
       "source": "./plugins/fabric-authoring",
       "description": "Developer skills for authoring Microsoft Skills for Fabric solutions - SDKs, APIs, automation scripts, CI/CD",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/sqldw-authoring-cli",
@@ -188,7 +190,7 @@
       "name": "fabric-consumption",
       "source": "./plugins/fabric-consumption",
       "description": "Consumer skills for interactive Microsoft Skills for Fabric operations - queries, exploration, monitoring",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-consumption",
@@ -232,9 +234,10 @@
       "name": "fabric-operations",
       "source": "./plugins/fabric-operations",
       "description": "Operations skills for diagnosing Microsoft Fabric performance and health - system views, multi-step investigation workflows",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
+        "./skills/azmon-mirroredcatalogs-operations-cli",
         "./skills/mlv-operations-cli",
         "./skills/sqldw-operations-cli",
         "./skills/sqldb-operations-cli",
@@ -261,7 +264,7 @@
       "name": "powerbi-authoring",
       "source": "./plugins/powerbi-authoring",
       "description": "Developer skills for authoring Microsoft Power BI solutions.",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "skills": [
         "./skills/check-updates",
         "./skills/semantic-model-authoring",

--- a/.github/workflows/issue-routing.yml
+++ b/.github/workflows/issue-routing.yml
@@ -36,6 +36,7 @@ env:
       {"option":"Ananke / FabricIQ (Power BI data exploration)","slug":"ananke","label":"area:ananke","color":"006b75"},
       {"option":"Power BI Reports","slug":"powerbi-report","label":"area:powerbi-report","color":"d4c5f9"},
       {"option":"Fabric IQ / Ontology","slug":"fabriciq","label":"area:fabriciq","color":"0969da"},
+      {"option":"Azure Monitor into Fabric","slug":"azmon","label":"area:azmon","color":"0e8a16"},
       {"option":"Infrastructure / repo / CI / general (or not sure)","slug":"platform","label":"area:platform","color":"fef2c0"}
     ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ __pycache__/
 *.pyc
 .pytest_cache/
 
+# ADC skills package build output
+/out/
+/build/bin/
+/build/obj/
+
 # Logs
 *.log
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -64,6 +64,10 @@ rules:
     description: Use mlv-operations-cli for MLV refresh scheduling, job monitoring, and cancellation
     reference: skills/mlv-operations-cli/SKILL.md
 
+  - name: azmon_operations
+    description: Use azmon-mirroredcatalogs-operations-cli to onboard Azure Monitor / App Insights / Log Analytics observability data into Fabric and correlate telemetry with business data for business-impact insights and Operations Agent instructions
+    reference: skills/azmon-mirroredcatalogs-operations-cli/SKILL.md
+
   # Dataflows Gen2 (Data Integration)
   - name: dataflows_skills
     description: Authoring skill is dataflows-authoring-cli, consumption skill is dataflows-consumption-cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Fabric REST APIs: https://learn.microsoft.com/en-us/rest/api/fabric/articles/
 - Pipelines for orchestration
 - Parameterize everything for reusability
 - Warehouse operations skill: `skills/sqldw-operations-cli/SKILL.md` — performance diagnostics, slow queries, query insights
+- Azure Monitor observability operations skill: `skills/azmon-mirroredcatalogs-operations-cli/SKILL.md` — onboard Azure Monitor / App Insights / Log Analytics observability data into Fabric and correlate telemetry with business data for business-impact insights and Operations Agent instructions
 
 ### Activator / Reflex
 - Authoring skill: `skills/activator-authoring-cli/SKILL.md` — create Activator items, sources, rules, conditions, and actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ User-facing changes for the public Microsoft Fabric Skills release.
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-07-23
+
+### Added
+- **`skills/azmon-mirroredcatalogs-operations-cli`** -- onboards Azure Monitor / Application Insights / Log Analytics observability data into Microsoft Fabric as a Mirrored Catalog item and turns that telemetry into business-impact insights by correlating observability signals with business data, ending in ready-to-paste Operations Agent instructions.
+
+### Changed
+- **`skills/semantic-model-authoring`** -- removed instructions that referenced the upcoming Copilot file format.
+- **`databricks-migration`** -- expanded Databricks-to-Fabric guidance for `dbutils` replacements, notebook parameters, environments, Lakehouse table references, MLflow, and workload mappings.
+
+### Fixed
+- **`skills/activator-authoring-cli`** -- treat schema-only, zero-row, non-emitting, or stale signal sources as missing source data so the skill stops and asks for source details instead of force-fitting a rule onto an unrelated existing item.
+- **`skills/activator-consumption-cli`** -- route read-only "show me all Activators" prompts to consumption guidance instead of the authoring skill.
+- **`check-updates`** -- detects marketplace plugins, direct plugins, positively identified Git clones, and loose skills copied or materialized from a file or URL; isolates the seven-day cache by installed entry or clone root; provides host-appropriate Copilot, Claude, Cursor, or safe no-command update guidance; and offers an explicit, confirmation-gated migration from official loose copies to a complete current plugin bundle.
+- **`databricks-migration`** -- corrected mount and notebook parameter guidance, and now requires inventory and constraint clarification before recommending a workspace-wide Fabric topology.
+
 ## [0.3.8] - 2026-07-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,9 @@ https://learn.microsoft.com/en-us/rest/api/fabric/articles/
   - Consumption skill: `skills/eventhouse-consumption-cli/SKILL.md` — read-only KQL queries, schema discovery
   - Primary CLI tool: `az rest` via Kusto REST API (`/v1/rest/query` and `/v1/rest/mgmt`)
   - Token audience: `https://kusto.kusto.windows.net/.default`
+- **Azure Monitor Observability (into Fabric)**: Onboard Azure Monitor / Application Insights / Log Analytics telemetry into Fabric and correlate it with business data for business-impact insights
+  - Docs: https://learn.microsoft.com/en-us/azure/azure-monitor/overview
+  - Operations skill: `skills/azmon-mirroredcatalogs-operations-cli/SKILL.md` — onboard Azure Monitor / App Insights / Log Analytics observability data into Fabric, correlate telemetry with business data, and generate Operations Agent instructions
 
 ### OneLake Catalog Search
 - **Catalog Search API**: Cross-workspace item discovery

--- a/README.md
+++ b/README.md
@@ -48,6 +48,37 @@ Replace `fabric-skills` with the focused bundle name to update that bundle. From
 copilot plugin update --all
 ```
 
+### Automatic update checking
+
+Installed Fabric bundles include a non-blocking `check-updates` skill. The first
+Fabric skill invoked in a session detects the marketplace plugin, direct plugin,
+or positively identified skills-for-fabric Git clone that supplied it. When a
+network check is due, it reads the version and changelog from the same repository
+`main` ref and shows update guidance verified for the current agent host without
+executing it.
+
+Automatic network checks run at most once every seven UTC days per installed
+plugin or clone. An explicit check bypasses that cache. If the installation or
+remote version cannot be resolved safely, skill use continues without guessing.
+
+For loose skills copied or materialized from a file or URL, the automatic check
+does not prompt. Run `check-updates` explicitly to confirm whether the files came
+from `microsoft/skills-for-fabric`. After confirmation, it can inspect the public
+marketplace and offer a complete matching plugin bundle; it does not overwrite
+individual copied files.
+
+Plugin guidance is host-aware: GitHub Copilot CLI and Claude Code receive their
+own verified commands. Cursor and other hosts receive documented UI or repository
+guidance instead of a command from a different tool.
+
+```bash
+# Focused consumption bundle
+/fabric-consumption:check-updates
+
+# Full bundle
+/fabric-skills:check-updates
+```
+
 ## What is included
 
 | Bundle | Use it for |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/skills-for-fabric",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "AI coding assistant skills for Microsoft Fabric developers and consumers",
   "repository": {
     "type": "git",

--- a/plugins/fabric-authoring/.github/plugin/plugin.json
+++ b/plugins/fabric-authoring/.github/plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "name": "fabric-authoring",
   "description": "Developer skills for authoring Microsoft Skills for Fabric solutions - SDKs, APIs, automation scripts, CI/CD",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "MIT",
   "repository": "https://github.com/microsoft/skills-for-fabric",
   "keywords": [

--- a/plugins/fabric-authoring/skills/activator-authoring-cli/SKILL.md
+++ b/plugins/fabric-authoring/skills/activator-authoring-cli/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: activator-authoring-cli
 description: >
-  Create alerts, notifications, and automated actions on Fabric data and events
-  via Fabric REST API and `az rest` CLI. **Invoke this skill** whenever the user
-  wants to:
-  (1) create, update, or delete an alert or notification flow,
-  (2) send a Teams message, email, or run a Fabric item when something happens,
-  (3) connect alert logic to Eventhouse, Eventstream, Real-time Hub, or DTB / Ontology data,
-  (4) adjust thresholds, filters, event triggers, or actions,
-  (5) troubleshoot or change an existing Activator/Reflex definition.
-  Invoke this skill **before** asking clarifying questions — clarification is part of this skill, not a preamble to it.
+  Author Fabric Activator rules and Reflex items through Fabric REST API and `az rest`.
+  Invoke for write intents: create or delete items; add or update rule definitions;
+  configure thresholds, filters, Teams/email notifications, Fabric item actions, and
+  Eventhouse/Eventstream/Real-Time Hub/DTB/Ontology sources. Pure GET/explain prompts
+  belong to `activator-consumption-cli`. Clarification for missing sources, thresholds,
+  recipients, and action targets happens inside this skill.
   Triggers: "create an alert", "create an activator", "create a reflex",
   "create an activator item", "create an alert item",
   "notify me when", "let me know when",
@@ -201,6 +198,17 @@ Example rule entity:
 - In the rule's `FabricItemBinding`, set `fabricJobConnectionDocumentId` to the standalone `fabricItemAction-v1.uniqueIdentifier`
 - See [action-types.md](references/action-types.md) for per-target schemas and UDF-specific gotchas (`itemType` vs readback `FunctionSet`, `subitemId`, canonical `parameterType` mapping, dynamic parameter shape)
 
+### Reference Integrity Preflight
+
+Before every `updateDefinition`, validate the exact entity array you will send:
+
+1. Build the set of every top-level `uniqueIdentifier` in `ReflexEntities.json`.
+2. Confirm every `parentContainer.targetUniqueIdentifier`, `parentObject.targetUniqueIdentifier`, `SourceReference.entityId`, `EventReference.entityId`, `AttributeReference.entityId`, and `fabricJobConnectionDocumentId` resolves to an entity in that same array (or to an unchanged entity from the latest decoded readback that is included in the re-encoded array).
+3. Confirm each reference points to the expected entity type: containers to `container-v1`, source/event/attribute/rule/object references to `timeSeriesView-v1` when the template expects a view, source references to the source entity, and Fabric item action bindings to `fabricItemAction-v1`.
+4. If any reference is missing, rebuild the graph from the latest `getDefinition` output and do not call `updateDefinition`.
+
+`FailedToResolveEntity` with `DocumentType timeSeriesView not found` means a rule, attribute, split event, or event reference points at a `timeSeriesView-v1` GUID that is not present in the submitted definition. Treat that as an entity-wiring bug to fix before retrying, not as a transient backend failure.
+
 ### Entity Wiring Summary
 
 ```text
@@ -277,11 +285,23 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 
 ---
 
+## Source Validation Gate
+
+Before authoring **any** rule that references a signal (a measurement, field, or event property), confirm the source is real. A requested source only counts as **real** after all three checks pass:
+
+1. **Resolve** the source in the **requested** workspace only -- do not search or substitute another workspace.
+2. **Validate** that the requested signal column/field exists on that source (KQL table/column, Eventstream field, Real-Time Hub event property, or DTB / Ontology property).
+3. **Observe** at least one representative row/event/sample carrying that signal -- run the KQL / DTB query or inspect the stream and confirm it actually returns data.
+
+Treat **schema-only**, **zero-row**, **non-emitting**, or **stale** evidence as **missing source data**, not a real source. When the source is missing, **stop and ask** which source and fields provide the signal (plus any missing threshold, recipient, or action details). Do **not** create a Reflex or call `updateDefinition` on any existing Activator / Eventstream to force-fit the request, and state plainly that **no Activator / Reflex / Eventstream was created or updated**. The only exception is when the user explicitly instructs you to author against a future / not-yet-emitting source.
+
+---
+
 ## Must / Prefer / Avoid
 
 ### MUST DO
 
-- **Confirm a real source before authoring** -- when the request targets a specific signal or measurement (for example "temperature > 30"), first resolve the workspace and verify that a discoverable source (Eventhouse/KQL table, Eventstream, Real-Time Hub, or DTB / Ontology) actually exposes that signal. If none does, **stop and ask** which source and fields provide it (plus any missing threshold, recipient, or action details) instead of authoring the rule
+- **Confirm a real source before authoring** -- follow the [Source Validation Gate](#source-validation-gate): resolve the source in the requested workspace, validate the requested signal column/field, and observe at least one representative row/event/sample before authoring. Schema-only, zero-row, non-emitting, or stale evidence is **missing source data** -- **stop and ask** which source and fields provide it (plus any missing threshold, recipient, or action details), and state that no Activator/Reflex/Eventstream was created or updated, instead of authoring the rule. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming the source was observed.
 - **Always use `--resource https://api.fabric.microsoft.com`** with `az rest` — without it, token audience is wrong
 - **Always send `--body '{}'`** for `getDefinition` — it is a POST and omitting the body can cause 411 errors
 - **Always Base64-encode** `ReflexEntities.json` payload when calling `updateDefinition`
@@ -289,6 +309,7 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 - **Always use the correct template type** — `AttributeTrigger` for value-based conditions (has ScalarSelectStep + ScalarDetectStep), `EventTrigger` for event-based firing (has FieldsDefaultsStep + EventDetectStep, no ScalarDetectStep)
 - **Always use new GUIDs** for `uniqueIdentifier` when adding entities — duplicate GUIDs cause corruption
 - **Always update all cross-references** when changing a `uniqueIdentifier` — other entities reference it via `targetUniqueIdentifier`
+- **Always run the Reference Integrity Preflight before `updateDefinition`** -- every `targetUniqueIdentifier`, `entityId`, and `fabricJobConnectionDocumentId` in the payload must resolve to an entity included in the submitted `ReflexEntities.json`
 - **Handle LRO responses** — `create`, `getDefinition`, and `updateDefinition` may return 202; poll the `Location` header
 
 ### PREFER
@@ -308,7 +329,8 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 - **Pre-filtering conditions in the KQL query** — return all data from KQL and let the Activator rule steps handle thresholds, text conditions, and dimensional filters. KQL is the data source, not the rule engine
 - **Inline JSON in PowerShell `az rest --body`** — PowerShell mangles quotes and special characters. Always write JSON to a temp file with `[System.IO.File]::WriteAllText($path, $json, [System.Text.UTF8Encoding]::new($false))` and pass `--body @$path`
 - **Reusing display names after deletion** — soft-deleted items hold their name for several minutes. Use a unique name or hard-delete first
-- **Force-fitting a request onto unrelated existing items** -- when no source exposes the requested signal, do NOT create a Reflex or call `updateDefinition` on an unrelated existing Activator / Eventstream to satisfy it; ask for the missing source first
+- **Force-fitting a request onto unrelated existing items** -- when no source clears the [Source Validation Gate](#source-validation-gate) (missing, schema-only, zero-row, non-emitting, or stale), do NOT create a Reflex or call `updateDefinition` on an unrelated existing Activator / Eventstream to satisfy it; ask for the missing source first
+- **Read-only listing or inspection** -- use [activator-consumption-cli](../activator-consumption-cli/SKILL.md) for prompts like "show me all Activators", "list Activators", "show the rules", "inspect this alert", or "decode the definition". This authoring skill should only run when the user asks to create, update, delete, configure, or change something.
 
 ---
 

--- a/plugins/fabric-authoring/skills/activator-authoring-cli/references/dtb-source.md
+++ b/plugins/fabric-authoring/skills/activator-authoring-cli/references/dtb-source.md
@@ -6,7 +6,7 @@ Queries an existing **Digital Twin Builder** or **Ontology** Fabric item on a sc
 
 > **Time-axis default:** If the DTB query results include a reasonable datetime field, prefer `eventTimeSettings` plus `DURATION_START` / `DURATION_END` query parameters. Only use snapshot mode when the query returns current-state rows with no reasonable event-time field.
 
-> **Validate first:** Before creating or updating the Activator, run the DTB / Ontology query directly first and confirm the returned columns, key fields, and timestamp field are correct.
+> **Validate first:** Before creating or updating the Activator, run the DTB / Ontology query directly first and confirm the returned columns, key fields, timestamp field, requested signal field, and at least one representative row are correct. If the query returns no rows or the requested field is missing, treat the source as missing and ask for the correct source and fields rather than authoring against an empty source. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming rows were observed.
 
 ```json
 {

--- a/plugins/fabric-authoring/skills/activator-authoring-cli/references/kql-source.md
+++ b/plugins/fabric-authoring/skills/activator-authoring-cli/references/kql-source.md
@@ -6,7 +6,7 @@ Queries a KQL database (Eventhouse or ADX/Kusto cluster) on a configurable sched
 
 > **Time-axis default:** If the query results include a reasonable datetime column, always configure `eventTimeSettings` and `queryParameters` so the source runs with a time axis. Only fall back to **snapshot mode** when the underlying data has no reasonable timestamp column and each row represents the latest state.
 
-> **Validate first:** Before creating or updating the Activator, run the KQL directly against the target KQL source and confirm the returned columns, timestamp field, and row shape are correct.
+> **Validate first:** Before creating or updating the Activator, run the KQL directly against the target KQL source and confirm the returned columns, timestamp field, and row shape are correct. If the query returns **no rows** (or the table/column does not exist), treat the source as **missing** -- stop and ask for the correct source and fields rather than authoring against an empty source. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming rows were observed.
 
 ```json
 {

--- a/plugins/fabric-authoring/skills/activator-authoring-cli/references/source-types.md
+++ b/plugins/fabric-authoring/skills/activator-authoring-cli/references/source-types.md
@@ -37,6 +37,12 @@ Every entity in `ReflexEntities.json`:
 | `payload` | object | yes | Entity-specific configuration |
 | `type` | string | yes | Entity type (see below) |
 
+## Reference Integrity Preflight
+
+Before submitting `updateDefinition`, validate the full `ReflexEntities.json` array, not just the entity you changed. Every `parentContainer.targetUniqueIdentifier`, `parentObject.targetUniqueIdentifier`, `SourceReference.entityId`, `EventReference.entityId`, and `AttributeReference.entityId` must resolve to a top-level `uniqueIdentifier` in that same submitted array. Fabric item action rules must also resolve `fabricJobConnectionDocumentId` to a `fabricItemAction-v1.uniqueIdentifier` in the same array.
+
+If Fabric returns `FailedToResolveEntity` with `DocumentType timeSeriesView not found`, one of those references points at a `timeSeriesView-v1` GUID that is absent from the payload. Re-read the definition, preserve existing entities, fix the missing reference, and retry only after the preflight passes.
+
 ---
 
 ## Container (`container-v1`)

--- a/plugins/fabric-authoring/skills/check-updates/SKILL.md
+++ b/plugins/fabric-authoring/skills/check-updates/SKILL.md
@@ -1,221 +1,508 @@
 ---
 name: check-updates
 description: >
-  Check for skills-for-fabric marketplace updates at session start. Compares local version 
-  against GitHub releases and shows changelog if updates are available. Use when the 
-  user wants to: (1) check for skill updates, (2) see what's new in skills-for-fabric, 
-  (3) verify current version. Triggers: "check for updates", "am I up to date", 
-  "what version", "update skills", "show changelog".
+  Check an installed skills-for-fabric plugin bundle or git clone for updates,
+  show the matching changelog, and provide host-appropriate update guidance.
+  Use when the user wants to: (1) check for skill updates, (2) see what changed,
+  (3) verify the installed version. Triggers: "check for updates", "am I up to
+  date", "what version", "update skills", "show changelog".
 ---
 
 # Check for Updates
 
-This skill checks for updates to the skills-for-fabric marketplace at the start of each session.
+This is a read-only update checker. It identifies the installation that supplied
+this skill, compares its version with the repository's `main` branch, and shows
+the update path supported by the current agent host. It never updates
+automatically.
 
-## When to Run
+## Cadence
 
-Run this check **once per week** when any skills-for-fabric skill is first invoked. Skip if already checked within the last 7 days.
+Keep these two controls separate:
 
-## Session State
+- **Invocation guard:** Other Fabric skills invoke this skill once per session
+  before continuing.
+- **Network guard:** Automatic invocations perform a remote lookup at most once
+  every 7 days for each detected installation identity.
 
-The update check marker is stored in a **persistent, user-level directory** shared across all sessions and all plugins in the Fabric Skills marketplace:
+If the user's current request directly asks for a version, changelog, or update
+check, treat it as an **explicit invocation** and bypass the 7-day network guard.
+If this skill was invoked only by another skill's session-start notice, treat it
+as an **automatic invocation**.
+
+Always continue with the caller's original task after an automatic invocation,
+including when the check is skipped or fails.
+
+## Procedure
+
+### Step 1: Resolve the Installation Context
+
+Determine one candidate installation root:
+
+1. If the user explicitly supplied an installation path, use that exact path.
+2. Otherwise, start from the active
+   `<skills-root>/check-updates/SKILL.md` file.
+3. When `<skills-root>` is named `skills`, consider its parent as a containing
+   root. Use that containing root only if it has a supported plugin manifest or
+   both `package.json` and a direct `.git` file or directory plus the positive
+   skills-for-fabric Git identity defined below.
+4. Otherwise, use `<skills-root>` as the candidate root. This includes personal
+   copies under `~/.copilot/skills` and `~/.agents/skills`, plus project copies
+   under `.github/skills`, `.agents/skills`, and `.claude/skills`.
+5. If the runtime does not expose the active skill path, report the context as
+   unknown. Do not guess.
+
+Never infer the installation from the shell's current working directory. Never
+walk upward beyond the candidate root. A project containing an unrelated parent
+`.git` directory is not evidence that the skill came from that repository.
+
+Resolve the runtime host independently from the installation channel:
+
+```text
+copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+```
+
+Use the host identity exposed by the current session or runtime. Do not infer it
+from a plugin manifest, install path, or working directory. A deterministic test
+may supply an explicit runtime-host override; normal use may not. If the host
+cannot be established, use `unknown`.
+
+For runtime detection of an already installed plugin, use the first existing
+manifest in this cross-tool precedence:
+
+1. `.plugin/plugin.json`
+2. `plugin.json`
+3. `.github/plugin/plugin.json`
+4. `.claude-plugin/plugin.json`
+
+In this repository, `.github/plugin/plugin.json` is the canonical source
+manifest. `.plugin/plugin.json` and `plugin.json` are compatibility fallbacks
+for other installed layouts or test fixtures. The final location supports
+packages that expose only a Claude-compatible manifest. Do not treat this
+runtime probe order as authoring guidance for this repository.
+
+Then classify the candidate root in this order:
+
+| Channel | Required files at the candidate root | Read |
+|---|---|---|
+| Plugin | one supported plugin manifest | top-level `name`, `version`, `repository` |
+| Git clone | `package.json`, a direct `.git` file or directory, and a positive skills-for-fabric Git identity | top-level `version`, `repository.url` |
+| Copied skills | no plugin or Git layout, plus either a root `SKILL.md` or direct child skill directories containing `SKILL.md` | tentative skill directory names only |
+| Unknown | none of the exact layouts | no identity or update command |
+
+Plugin detection takes precedence if both layouts are present. This lets a
+development fixture retain plugin semantics while using a local Git remote.
+
+A positive Git identity requires both of these checks:
+
+- The final unscoped segment of `package.json` `name` is
+  `skills-for-fabric`. Accepted examples include `skills-for-fabric`,
+  `@microsoft/skills-for-fabric`, and contributor-fork scopes.
+- After removing a trailing slash and `.git`, the final repository path segment
+  is `skills-for-fabric`, compared case-insensitively.
+
+If either check fails, do not promote that containing root to the Git channel
+and do not run Git against it. Continue candidate-root resolution and classify
+the resulting candidate independently; a nested `skills` root may therefore be
+a loose copy. A generic Node repository that happens to contain a `skills/`
+directory is not a skills-for-fabric installation.
+
+A copied channel is terminal until an explicit request confirms its source:
+
+- For an automatic invocation, do not ask a question. Optionally show one short
+  note that the unverified loose copy was skipped and can be checked explicitly,
+  then continue the caller's original task.
+- For an explicit invocation without source confirmation, list the tentative
+  copied skill names, state that source and version are unverified, ask the
+  confirmation question in the copied-channel section, and stop.
+
+Neither path continues to the network guard or remote-version steps.
+
+Build one context object:
+
+```text
+runtimeHost: copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+channel: plugin | git | copy | unknown
+root: exact candidate root
+installKind: marketplace | direct | none
+installScope: user | project | local | managed | none
+manifestName: plugin manifest name | none
+installedName: marketplace entry name | none
+marketplace: marketplace name | none
+sourceId: direct-install source ID | none
+identity: plugin:<marketplace>/<installed-name> | plugin:direct/<source-id> | git:<repository-url-as-stored>|<root>
+localVersion: manifest version
+repository: URL exactly as stored in the selected manifest
+updateTarget: <installed-name>@<marketplace> | <manifest-name> | <root> | none
+copiedSkills: direct skill directory names | none
+```
+
+For a plugin, keep the manifest name separate from the installed marketplace
+entry name. They can differ. Resolve the installed entry from native runtime
+metadata or the native plugin listing when it identifies the candidate root.
+
+For GitHub Copilot CLI marketplace installs, the documented path is
+`~/.copilot/installed-plugins/<marketplace>/<installed-name>`, so those two path
+segments are authoritative.
+
+For a direct Copilot CLI install at
+`~/.copilot/installed-plugins/_direct/<source-id>`, set `installKind` to
+`direct`, use the source ID only for the cache identity, and use the manifest
+name as the bare update target. `_direct` is not a marketplace name.
+
+For Claude Code marketplace installs, resolve the installed entry and scope from
+Claude's native plugin metadata. `claude plugin list --json` can identify the
+entry; the declaring settings file identifies its scope:
+
+- `~/.claude/settings.json` -> `user`
+- `.claude/settings.json` -> `project`
+- `.claude/settings.local.json` -> `local`
+- managed settings -> `managed`
+
+If the same entry exists at more than one scope, list the choices and ask which
+one to update. Do not guess a scope. A plugin loaded only from a skills
+directory, `--plugin-dir`, or `--plugin-url` has no marketplace install record;
+do not fabricate an update command for it.
+
+If native metadata and the installed path are unavailable, use the manifest
+name with marketplace `fabric-collection` only when the mapping is
+unambiguous. The `fabric-skills` manifest is not unambiguous because the legacy
+`skills-for-fabric` marketplace entry uses the same payload. In that case,
+report that the installed entry could not be resolved, ask the user to inspect
+the native plugin list, and do not guess an identity or update command.
+
+For Git `package.json`, accept either a repository object with a `url` property
+or a repository URL string. Keep the repository value exactly as stored and
+append the exact resolved root when building the cache identity. This prevents
+one clone from suppressing checks for another clone of the same repository.
+When parsing a GitHub owner and repository for remote tools, strip only a
+trailing `.git` and trailing slash. Do not alter owner spelling, case,
+underscores, or punctuation.
+
+Validate that required fields are present and that `localVersion` is semantic
+version text. If validation fails, report the malformed field and classify the
+context as unknown rather than using partial metadata.
+
+### Step 2: Apply the Network Guard
+
+Use an exact cache path supplied by the caller only for a deterministic test.
+Otherwise, use this persistent cache file:
 
 ```text
 ~/.config/fabric-collection/last-update-check.json
 ```
-  
-This file contains a JSON object mapping plugin names to the **UTC date** (YYYY-MM-DD) of their last update check:
+
+On Windows, this is:
+
+```text
+$env:USERPROFILE\.config\fabric-collection\last-update-check.json
+```
+
+The file is a flat JSON object keyed by installation identity:
 
 ```json
 {
-  "fabric-skills": "2026-02-17",
-  "another-plugin": "2026-02-16"
+  "plugin:fabric-collection/fabric-consumption": "2026-07-15",
+  "plugin:direct/github-com-example-skills": "2026-07-15",
+  "git:https://github.com/example/skills-for-fabric.git|C:\\repos\\skills-for-fabric": "2026-07-14"
 }
 ```
 
-Before checking, read `~/.config/fabric-collection/last-update-check.json`:
-- If the file exists and the entry for the current plugin is within the last **7 days** (compared to the current **UTC date**), skip the check.
-- If the file is missing, the plugin entry is absent, or the date is more than 7 days old (compared to the current **UTC date**), run the update check.
+Use UTC dates in `YYYY-MM-DD` format.
 
-> **IMPORTANT — use UTC consistently**: Always use the current UTC date when saving and comparing the last-update-check timestamp. Do not use the local system timezone, as it varies across environments and can cause the check to run too often or be skipped. In shell, use `date -u +%Y-%m-%d` (Linux/macOS) or `(Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")` (PowerShell).
+- For an automatic invocation, skip the remote lookup when this identity has a
+  valid date within the last 7 days.
+- For an explicit invocation, perform the remote lookup even when a fresh cache
+  entry exists.
+- Entries for different installed plugin entries or Git clone roots do not
+  suppress each other.
+- Preserve every unrelated entry when writing the file.
+- If the file contains malformed JSON, warn and do not overwrite it.
+- Do not read or write a cache entry for a copied or unknown context.
 
-> **Note**: Create the `~/.config/fabric-collection/` directory if it does not exist. On Windows, use `$env:USERPROFILE\.config\fabric-collection\`.
+After a remote attempt completes, record today's UTC date for the detected
+identity whether the attempt found an update, found no update, or failed, unless
+the cache file was malformed. This prevents an automatic network failure from
+repeating in every session. Do not rewrite the marker when the network guard
+skipped the attempt.
 
-## Update Check Procedure
+### Step 3: Read the Remote Version
 
-### Step 1: Get Local Version
+Read `package.json` and `CHANGELOG.md` from the same repository and the same
+`main` ref. Try these methods in order and stop after the first successful one:
 
-Read the `version` field from the local plugin manifest. Two install layouts exist:
+1. **Git CLI:** Only when the candidate root itself has a direct `.git` file or
+   directory. Do not use `git rev-parse` as the availability check because it
+   can discover an unrelated parent repository.
 
-- **GitHub Copilot CLI plugin install** (`~/.copilot/installed-plugins/fabric-collection/fabric-skills/`): the manifest is `.github/plugin/plugin.json` — there is no `package.json` here.
-- **Manual git clone**: the manifest is `package.json` at the repo root.
+   ```bash
+   git -C "<root>" fetch origin main --quiet
+   git -C "<root>" show origin/main:package.json
+   git -C "<root>" show origin/main:CHANGELOG.md
+   ```
 
-Read whichever is present. Both files contain a top-level `"version": "<semver>"` field.
+2. **Authenticated GitHub tools:** Use GitHub MCP file tools or `gh api` with
+   the owner and repository parsed exactly from the manifest URL. Read
+   `package.json` and `CHANGELOG.md` at ref `main`.
+3. **Public raw content:** For a public repository, read both files from
+   `https://raw.githubusercontent.com/<owner>/<repo>/main/`.
 
-### Step 2: Determine Repository Owner and Name
+Do not use the latest GitHub Release tag as the remote version. Plugin
+marketplace updates follow repository content, and a release tag can lag behind
+the version available to plugin users.
 
-Read the `repository` field from the same manifest you used in Step 1, and parse the URL to get `owner` and `repo`. The two layouts store the field differently:
+If version retrieval fails, show the detected channel, identity, and local
+version with a concise warning. Do not fabricate a remote version. If only the
+changelog retrieval fails, still report the version comparison and note that
+the changelog was unavailable.
 
-- **Copilot CLI plugin install** (`.github/plugin/plugin.json`) — plain URL string:
-  ```text
-  "repository": "https://github.com/<owner>/<repo>"
-  ```
-- **Manual git clone** (`package.json` at the repo root) — object whose `url` ends with `.git`:
-  ```text
-  "repository": { "type": "git", "url": "https://github.com/<owner>/<repo>.git" }
-  ```
+### Step 4: Compare and Report
 
-There is no bare `plugin.json` at the repo root in either layout, and there is no top-level `package.json` in the Copilot CLI plugin install — always use the path that matches your actual layout.
+Compare semantic versions:
 
-> **CRITICAL**: Use the owner string **exactly as it appears** in the URL. Do NOT alter, normalize, or "correct" the owner name — including underscores, mixed case, or any other punctuation. Whatever the manifest's `repository` URL says, that is the correct owner. (LLMs sometimes "auto-correct" underscores to hyphens — don't.)
+- `remoteVersion > localVersion`: update available.
+- `remoteVersion <= localVersion`: up to date.
 
-### Step 3: Fetch Latest Release
+For an update, show the relevant `CHANGELOG.md` entries between the local and
+remote versions, then provide only guidance verified for both the detected
+channel and `runtimeHost`.
 
-Use the available tools in your environment to get the latest version. **Try methods in strict order — only fall back to the next method if the previous one fails or is unavailable.**
+**Plugin channel**
 
-> **IMPORTANT**: Methods A and B work with both public and private repositories. Method C only works with public repos. Always attempt A or B first.
+Never emit one host's plugin command for another host.
 
-**Method A — Git CLI (preferred for git-clone installs)**
+| Runtime host | Verified guidance |
+|---|---|
+| GitHub Copilot CLI | For a marketplace install, show `/plugin update <installed-name>@<marketplace>`. For a direct install, show `/plugin update <manifest-name>`. |
+| Claude Code | For a marketplace install with a resolved scope, show `claude plugin update <installed-name>@<marketplace> --scope <scope>`, then tell the user to run `/reload-plugins` or restart Claude Code. |
+| Cursor | Direct the user to **Customize > Plugins**. For a team marketplace, an administrator can use **Refresh** or **Enable Auto Refresh**. Do not emit a plugin CLI command. |
+| Windsurf, Codex, other, or unknown | Report the available version and repository, but provide no executable plugin command because none is verified for this layout. |
 
-Only available if the skills-for-fabric directory is a Git working tree (i.e. it has a `.git` entry — either a directory in a normal clone, or a file in a worktree/submodule). The Copilot CLI plugin install at `~/.copilot/installed-plugins/fabric-collection/fabric-skills/` has no `.git` entry — for that install layout, skip to Method B. If you want a tool-agnostic check, run `git rev-parse --is-inside-work-tree` and only proceed if it prints `true`.
-
-If you do have a Git clone, fetch the remote `package.json` without pulling:
-
-```bash
-git fetch origin main --quiet
-git show origin/main:package.json
-```
-
-Extract the `version` field from the JSON output. This method is the most reliable because it uses the already-configured remote URL and authentication, and avoids any owner/repo name parsing.
-
-**Method B — GitHub MCP tools (preferred for agentic environments)**
-
-If you have access to GitHub MCP server tools (e.g., `get_file_contents`), use them to read the remote `package.json`. Use the owner and repo extracted in Step 2 **exactly as parsed** (do not modify the strings):
-
-```text
-get_file_contents(owner: "<owner>", repo: "<repo>", path: "package.json")
-```
-
-Extract the `version` field from the response. This method works with private repositories because MCP tools use authenticated GitHub access.
-
-**Method C — GitHub REST API (fallback only, public repos)**
-
-> ⚠️ **Only use this method if Methods A and B both fail or are unavailable.** This method does not work with private repositories.
-
-If the repository is public, make a GET request using the owner/repo from Step 2:
-
-```text
-GET https://api.github.com/repos/<owner>/<repo>/releases/latest
-```
-
-Extract the `tag_name` field (e.g., `v0.2.0`) and remove the `v` prefix.
-
-> **Note**: This method returns 404 for private repositories. If you receive a 404 error, do NOT assume the repository doesn't exist — retry with Method A or B.
-
-### Step 4: Compare Versions
-
-Compare the local version with the remote version using semantic versioning:
-- If remote > local: Update available
-- If remote <= local: Up to date
-
-### Step 5: Display Results
-
-#### If Up to Date
-
-Show a brief confirmation and proceed:
-```text
-✅ skills-for-fabric v0.1.0 is up to date.
-```
-
-#### If Update Available
-
-Show detailed information:
+GitHub Copilot CLI marketplace install:
 
 ```text
-╔══════════════════════════════════════════════════════════════════╗
-║  🔄 skills-for-fabric Update Available                                ║
-║                                                                  ║
-║  Current: v0.1.0  →  Latest: v0.2.0                             ║
-╚══════════════════════════════════════════════════════════════════╝
-
-## What's New in v0.2.0
-
-[Display relevant CHANGELOG.md entries here]
-
-## Update Commands
-
-Choose the update method based on how you installed skills-for-fabric.
-
-### GitHub Copilot CLI (recommended)
-/plugin update fabric-skills@fabric-collection
-
-If you originally installed the plugin under the legacy id, this also works:
-  /plugin update skills-for-fabric@fabric-collection
-
-The plugin was renamed in 0.3.0 (skills-for-fabric → fabric-skills),
-but the legacy id is kept as a deprecated alias of fabric-skills, so
-either /plugin update command pulls the canonical payload.
-
-(Optional cleanup) To migrate your installed entry from the legacy id
-to the canonical fabric-skills id:
-  /plugin uninstall skills-for-fabric@fabric-collection
-  /plugin install fabric-skills@fabric-collection
-
-### Manual (Git clone)
-cd /path/to/skills-for-fabric
-git pull
-
-(There are no installation scripts to re-run on 0.3.0+.)
-
-─────────────────────────────────────────────────────────────────
-Would you like to update now? (The current skill will still work)
+/plugin update <installed-name>@<marketplace>
 ```
 
-### Step 6: Set Update Marker
+The installed marketplace entry is authoritative. For example, an installed
+`fabric-consumption@fabric-collection` entry produces:
 
-After completing the check (regardless of result), update `~/.config/fabric-collection/last-update-check.json` with today's **UTC date** (YYYY-MM-DD) for the current plugin. Create the directory and file if they don't exist. Preserve entries for other plugins already in the file.
+```text
+/plugin update fabric-consumption@fabric-collection
+```
+
+If the installed entry is the legacy `skills-for-fabric` alias, update that
+alias first so the installed entry can receive the current payload, even though
+its copied manifest is named `fabric-skills`:
+
+```text
+/plugin update skills-for-fabric@fabric-collection
+```
+
+Afterward, optional migration to the canonical entry is:
+
+```text
+/plugin uninstall skills-for-fabric@fabric-collection
+/plugin install fabric-skills@fabric-collection
+```
+
+GitHub Copilot CLI direct install:
+
+```text
+/plugin update <manifest-name>
+```
+
+The native CLI update target for a direct install is the bare manifest name.
+Do not append `@_direct` or use the opaque source ID as the update target.
+
+Claude Code marketplace install:
+
+```text
+claude plugin update <installed-name>@<marketplace> --scope <scope>
+```
+
+The entry name and scope must come from Claude's installed-plugin metadata. Do
+not reuse Copilot's `_direct` behavior for Claude Code.
+
+**Git channel**
+
+```text
+git -C "<detected-root>" pull --ff-only
+```
+
+**Unknown channel**
+
+State which expected files were absent and provide no update command. Never
+default to `fabric-skills`.
+
+**Copied-skill channel**
+
+A loose copy has no trustworthy repository, installed version, or native update
+target. This includes a skill materialized from a local file or URL by
+`copilot skill add` when no source metadata accompanies it.
+
+For an automatic invocation, do not interrupt the caller with a source question.
+Skip the copied-skill update flow, optionally state that an explicit update
+check can identify a supported replacement, and continue the caller's task.
+Do not list an executable command.
+
+For an explicit invocation, list the tentative skill names found at the
+candidate root, state that their provenance cannot be verified from the files
+alone, and ask:
+
+```text
+Were these skills copied from https://github.com/microsoft/skills-for-fabric?
+If yes, I can inspect the official public repository and show the supported
+plugin bundle that will refresh them. I will not install or remove anything
+without your confirmation.
+```
+
+Before the user confirms the source, do not contact the network, compare
+versions, write cache state, or offer an executable install/update command.
+
+After explicit confirmation:
+
+1. Read `.github/plugin/marketplace.json` from the `main` ref of
+   `microsoft/skills-for-fabric`, using authenticated GitHub tools first and
+   public raw content second.
+2. Match the tentative skill directory names against the skill paths inside
+   each marketplace plugin source. Treat only exact path matches as evidence.
+3. Prefer a focused plugin that covers all matched non-utility skills. If more
+   than one plugin qualifies, list the valid choices and ask the user to choose.
+   Never choose `fabric-skills` merely because `check-updates` appears in it.
+4. Offer only the replacement path supported by `runtimeHost`:
+
+   GitHub Copilot CLI:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   /plugin install <matched-plugin>@fabric-collection
+   ```
+
+   Claude Code, using `user` for a personal copied-skills root or `project` for
+   a project copied-skills root:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   claude plugin install <matched-plugin>@fabric-collection --scope <scope>
+   ```
+
+   Tell the user to run `/reload-plugins` or restart Claude Code after the
+   install. If the Claude scope cannot be resolved, ask instead of guessing.
+
+   For Cursor, Windsurf, Codex, other, or unknown hosts, link to the official
+   repository's installation instructions and provide no executable replacement
+   command. The current public repository does not expose a verified native
+   plugin marketplace for those hosts.
+
+This installs a complete current bundle instead of overwriting loose files and
+leaving mixed-version dependencies. Keep the loose copy until the native plugin
+is installed and verified. Ask separately before removing it. If no exact
+official mapping exists or the public repository is unavailable, report that
+and do not fabricate a bundle or copy individual files.
+
+## Examples
+
+### Focused plugin bundle
+
+```text
+Host: copilot-cli
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: /plugin update fabric-consumption@fabric-collection
+```
+
+### Claude Code plugin bundle
+
+```text
+Host: claude-code
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: claude plugin update fabric-consumption@fabric-collection --scope user
+Reload: /reload-plugins
+```
+
+### Git clone
+
+```text
+Detected: git:https://github.com/example/skills-for-fabric.git|C:\repos\skills-for-fabric
+Current: 0.3.7
+Latest: 0.3.8
+Update: git -C "C:\repos\skills-for-fabric" pull --ff-only
+```
+
+### Unknown layout
+
+```text
+Could not determine the skills-for-fabric installation at <candidate-root>.
+Expected a supported plugin manifest, or a positively identified
+skills-for-fabric package.json plus a direct .git entry.
+No update command was guessed.
+```
+
+### Confirmed official loose copy
+
+```text
+Host: copilot-cli
+Detected loose skills: check-updates, powerbi-report-planning
+Confirmed source: https://github.com/microsoft/skills-for-fabric
+Supported refresh:
+  /plugin marketplace add microsoft/skills-for-fabric
+  /plugin install powerbi-authoring@fabric-collection
+The loose files were not changed or removed.
+```
 
 ## Must
 
-- Check for updates only once per week (based on UTC calendar date, not session lifetime or local timezone)
-- Always proceed with the requested skill after the check (non-blocking)
-- Handle network errors gracefully (show warning, continue with skill)
-- Display the CHANGELOG.md content for versions between current and latest
+- Resolve identity from the active skill root or an explicit user path.
+- Resolve the runtime host independently from the installation layout.
+- Keep once-per-session invocation separate from the 7-day network guard.
+- Use the installed marketplace entry, not merely the manifest name, in plugin
+  identities and update commands.
+- Keep direct installs distinct from marketplace installs.
+- Require positive package and repository identity before using the Git channel.
+- Isolate Git cache entries by repository and exact clone root.
+- Preserve unrelated cache entries and use UTC dates.
+- Require source confirmation before looking up a loose copy in the official
+  public repository.
+- Match copied skill names to exact public marketplace skill paths.
+- Emit only update or replacement commands verified for the runtime host.
+- Continue non-blockingly after automatic checks.
 
 ## Prefer
 
-- Use Git CLI (Method A) or GitHub MCP tools (Method B) for version checking — these work with private repos
-- Fall back to the public GitHub REST API (Method C) **only** if Methods A and B both fail
-- Show a concise summary rather than overwhelming detail
-- Cache the check result in `~/.config/fabric-collection/last-update-check.json`
-- Provide copy-pasteable update commands
+- Use a root-local Git remote before authenticated GitHub tools.
+- Fetch version and changelog from the same repository ref.
+- Replace confirmed official loose copies through a complete native plugin
+  bundle rather than overwriting individual files.
+- Show concise, copy-pasteable output.
 
 ## Avoid
 
-- Blocking the user from using skills if update check fails
-- Checking on every skill invocation (once per week is sufficient)
-- Attempting Method C (public API) before trying Methods A or B
-- Relying solely on unauthenticated public API calls (will fail for private repos)
-- Auto-updating without user consent
+- Inferring installation context from the current working directory.
+- Letting `git` discover a parent repository.
+- Treating an unrelated package plus `.git` as a skills-for-fabric clone.
+- Inferring the runtime host from a manifest or install path.
+- Showing Copilot or Claude plugin commands to another host.
+- Defaulting focused bundles to `fabric-skills`.
+- Using GitHub Release tags as the plugin marketplace version.
+- Repeating failed automatic network checks every session.
+- Treating a same-named loose folder as proof that it came from the official
+  repository.
+- Replacing individual copied files without their complete bundle dependencies.
+- Updating without explicit user consent.
 
 ## Error Handling
 
-If the update check fails (network error, API rate limit, etc.):
+On failure, report the operation that failed and continue:
 
 ```text
-⚠️ Could not check for skills-for-fabric updates (network error).
-   Continuing with current version (v0.1.0).
-   Run '/skill check-updates' manually to retry.
+Could not check plugin:fabric-collection/fabric-consumption for updates: remote package.json was unavailable.
+Current installed version: 0.3.7
+The automatic check is non-blocking; continuing with the requested task.
 ```
 
-## Manual Invocation
-
-Users can manually check for updates at any time:
-- GitHub Copilot CLI: `/skill check-updates`
-- Other tools: Invoke the check-updates skill directly
-
-## Reference
-
-- **GitHub Repository**: https://github.com/microsoft/skills-for-fabric
-- **Releases**: https://github.com/microsoft/skills-for-fabric/releases
-- **CHANGELOG**: See `CHANGELOG.md` in repository root
+If the user says only "update my skills", clarify whether they want to check for
+an update or execute the detected native update command. Do not execute an
+update based on ambiguous intent.

--- a/plugins/fabric-authoring/skills/dataflows-authoring-cli/SKILL.md
+++ b/plugins/fabric-authoring/skills/dataflows-authoring-cli/SKILL.md
@@ -1,22 +1,21 @@
 ---
 name: dataflows-authoring-cli
 description: >
-  Create, update, delete, and refresh Fabric Dataflows Gen2 via write-side CLI
-  against Fabric Items and Connections APIs. Builds mashup.pq + queryMetadata
-  definitions, triggers parameterized refreshes, manages connections, and
-  configures output destinations (Lakehouse, Warehouse, ADX, Azure SQL).
-  Includes preview-driven authoring loop (executeQuery + customMashupDocument).
-  Lists `supportedConnectionTypes`/`credentialType` per connector.
-  For executing saved queries or reading refresh status, use
-  `dataflows-consumption-cli`.
-  Triggers: "create dataflow", "update dataflow", "delete dataflow",
-  "trigger dataflow refresh", "refresh dataflow", "preview Power Query M",
-  "preview mashup", "preview before save", "iterate dataflow M",
-  "create Fabric data source connection", "create dataflow connection",
-  "bind connection", "list supportedConnectionTypes",
-  "dataflow output destination", "dataflow write to lakehouse",
-  "dataflow write to warehouse", "dataflow write to ADX",
-  "DataDestinations annotation".
+  Create, update, delete, and refresh Fabric Dataflows Gen2 with write-side CLI
+  via Fabric APIs. Build mashup.pq and queryMetadata.json,
+  preview candidate M with executeQuery/customMashupDocument, bind connections,
+  and configure output destinations. For saved
+  query execution or refresh-status reads, use `dataflows-consumption-cli`. If
+  a request explicitly insists on the Dataflows consumption or read-only path
+  for a mutation, do not route here; let consumption refuse before any
+  separately confirmed authoring handoff. Triggers: "create dataflow", "update
+  dataflow", "delete dataflow", "trigger dataflow refresh", "preview Power
+  Query M", "preview before save", "customMashupDocument", "create Fabric data
+  source connection", "create SQL Server source REST", "POST /v1/connections",
+  "supportedConnectionTypes", "passwordReference", "bind
+  connection", "dataflow output destination", "dataflow write to lakehouse",
+  "dataflow write to warehouse", "dataflow write to ADX", "DataDestinations
+  annotation".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -28,6 +27,16 @@ description: >
 > **CRITICAL NOTES**
 > 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering
 > 2. To find the item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace and, then, use JMESPath filtering
+
+> **PRE-MUTATION REQUIREMENTS GATE (mandatory)**
+> Before any mutation, confirm enough user intent for the requested operation.
+> For create or update requests, establish the source, query/schema and
+> transformation, destination behavior, and refresh behavior (including an
+> explicit choice of no destination or no refresh). If the request is generic,
+> such as "set up the Dataflow I need for reporting," ask a structured
+> clarifying question and stop before mutation. Do not infer requirements from
+> unrelated workspace items or create a best-guess source, connection, or
+> Dataflow.
 
 # dataflows-authoring-cli — Dataflows Gen2 Authoring via CLI
 
@@ -52,7 +61,7 @@ description: >
 | [authoring-cli-quickref.md](references/authoring-cli-quickref.md) | One-liner recipes, status enums, base64 helpers, connection-binding quick patterns |
 | [authoring-script-templates.md](references/authoring-script-templates.md) | Full bash + PowerShell templates; end-to-end smoke test; LRO polling pattern |
 | [connection-management.md](references/connection-management.md) | List/create/inspect connections; `supportedConnectionTypes`; resolve `ClusterId`; ID format cheat sheet |
-| [connectors.md](references/connectors.md) | M-side source connectors: live-verified function inventory, Lakehouse deep navigation, runtime-disabled functions (`Web.Page`, `Web.BrowserContents`), `Html.Table` / `Csv.Document` / `Json.Document` patterns |
+| [connectors.md](references/connectors.md) | M-side source connectors: live-verified function inventory, Lakehouse deep navigation, gateway scope for `Web.Page` / `Web.BrowserContents`, and `Html.Table` / `Csv.Document` / `Json.Document` patterns |
 | [m-language.md](references/m-language.md) | M language semantics for Dataflow Gen2: `try` record shapes, per-cell error wrapping in column transforms, `each` scoping in row vs sub-table contexts, optional field access `[?]` / `Record.FieldOrDefault`, quoted identifiers, sandbox-disabled symbols (`File.Contents`) |
 | [mashup-preview.md](references/mashup-preview.md) | `executeQuery` contract: bootstrap branch, auto-wrap rule, hard avoid for unbounded preview |
 | [output-destinations.md](references/output-destinations.md) | Output destination patterns: Lakehouse Table, Lakehouse Files, Warehouse, ADX, Azure SQL. `DataDestinations` annotation, hidden query, `loadEnabled` rules, connection limitations |

--- a/plugins/fabric-authoring/skills/dataflows-authoring-cli/references/connectors.md
+++ b/plugins/fabric-authoring/skills/dataflows-authoring-cli/references/connectors.md
@@ -27,18 +27,28 @@ All functions below have their symbol registered in the Fabric mashup engine (`V
 | `Snowflake.Databases`, `AzureStorage.DataLake`, `Excel.Workbook` | 🔑 Symbol present; not exercised end-to-end here |
 | `Html.Table`, `Csv.Document`, `Json.Document`, `Lines.FromBinary`, `#table` | ✅ Pure parsers — no binding — see [Pure-data parsers](#pure-data-parsers) |
 | `Variable.Value` | 🔑 Symbol present; requires a Variable Library on the dataflow — see [Variable.Value](#variablevalue) |
-| `Web.Page`, `Web.BrowserContents` | ❌ Disabled at runtime — see [Runtime-disabled functions](#runtime-disabled-functions) |
+| `Web.Page`, `Web.BrowserContents` | Gateway-backed in cloud dataflows; disabled in the direct `executeQuery` runtime tested here - see [Browser functions and gateway scope](#browser-functions-and-gateway-scope) |
 
 Full enumeration at runtime via [`#shared`](#shared).
 
-## Runtime-disabled functions
+## Browser functions and gateway scope
+
+Microsoft Learn documents `Web.Page` and `Web.BrowserContents` as available in
+cloud dataflows through an on-premises data gateway. See
+[Using a gateway with the Web connector](https://learn.microsoft.com/en-us/power-query/connectors/web/web-troubleshoot#using-a-gateway-with-the-web-connector).
+
+The direct, gateway-free `executeQuery` runtime probed for this skill returned
+the following errors, even for inline literals:
 
 | Function | Verbatim engine error |
 |---|---|
 | `Web.BrowserContents` | `The module named 'WebBrowserContents' has been disabled in this context.` |
 | `Web.Page` | `The module named 'Html' has been disabled in this context.` |
 
-Both fail even on inline literals (no network or credential dependency). For HTML parsing in Fabric Dataflow Gen2 use [`Html.Table`](#pure-data-parsers) — different module, fully enabled.
+For gateway-free authoring and preview, use `Web.Contents` plus
+[`Html.Table`](#pure-data-parsers). If browser rendering is required, use a
+gateway-backed Web connection and validate through the supported cloud-dataflow
+path rather than direct `executeQuery`.
 
 ## Lakehouse navigation
 
@@ -220,7 +230,7 @@ Without it the privacy firewall blocks evaluation when two or more sources are r
 ### MUST
 
 1. **Match the M function kind to the binding kind.** REST casing differs (REST `"SQL"` ↔ M `Sql.Database`) — see [connection-management.md § Step 1](connection-management.md#step-1--list-supported-connection-types).
-2. **Use `Html.Table` for HTML parsing.** `Web.Page` and `Web.BrowserContents` are disabled at runtime.
+2. **Use `Html.Table` for gateway-free HTML parsing.** `Web.Page` and `Web.BrowserContents` require an on-premises gateway in cloud dataflows and are disabled in the direct `executeQuery` runtime tested here.
 3. **For combined-source documents, add `[AllowCombine = true]`** before `section Section1;`.
 4. **Decode the Arrow stream and inspect `PQ Arrow Metadata`** when reading `executeQuery` results — 200 OK is not success.
 
@@ -232,8 +242,8 @@ Without it the privacy firewall blocks evaluation when two or more sources are r
 
 ### AVOID
 
-1. **`Web.BrowserContents`** — `module 'WebBrowserContents' has been disabled`.
-2. **`Web.Page`** — `module 'Html' has been disabled`.
+1. **`Web.BrowserContents` in direct `executeQuery`** - use a gateway-backed Web connection when browser rendering is required.
+2. **`Web.Page` in direct `executeQuery`** - use a gateway-backed Web connection when the legacy browser function is required.
 3. **`Sql.Database("server")`** (1-arg form) — engine rejects with arity error. Always supply the database name.
 4. **`{[Id="Tables"]}` at the lakehouse-`[Data]` level** — there is no `Tables` folder; tables are listed directly. (`{[Id="Files"]}` IS valid — it's the only folder entry.)
 

--- a/plugins/fabric-authoring/skills/dataflows-authoring-cli/references/m-language.md
+++ b/plugins/fabric-authoring/skills/dataflows-authoring-cli/references/m-language.md
@@ -165,7 +165,7 @@ Use the record form when downstream code (`try ... otherwise` chains, `Table.Rep
 Credentials are required to connect to the File source. (Source at <path>.)
 ```
 
-There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a Lakehouse, Warehouse, OData feed, or `Web.Contents` instead — see [connectors.md § Function inventory](connectors.md#function-inventory). For runtime-disabled `Web.Page` / `Web.BrowserContents`, see [connectors.md § Runtime-disabled functions](connectors.md#runtime-disabled-functions).
+There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a Lakehouse, Warehouse, OData feed, or `Web.Contents` instead -- see [connectors.md Function inventory](connectors.md#function-inventory). For the gateway and direct-`executeQuery` boundary of `Web.Page` / `Web.BrowserContents`, see [connectors.md Browser functions and gateway scope](connectors.md#browser-functions-and-gateway-scope).
 
 ## MUST / PREFER / AVOID
 
@@ -184,7 +184,7 @@ There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a L
 **AVOID**
 
 1. Treating an Arrow-null cell value as "the column has nulls" without testing — it may be an errored cell. Probe with `try Conv{i}[Col]` to disambiguate.
-2. `File.Contents`, `Web.Page`, `Web.BrowserContents` — see [§ `File.Contents`](#filecontents--exposed-but-unusable) and [connectors.md § Runtime-disabled functions](connectors.md#runtime-disabled-functions).
+2. `File.Contents`, plus `Web.Page` / `Web.BrowserContents` in direct `executeQuery` - see [`File.Contents`](#filecontents--exposed-but-unusable) and [connectors.md Browser functions and gateway scope](connectors.md#browser-functions-and-gateway-scope).
 3. Discriminating on `Error.Reason` without setting it explicitly. Both built-in errors and `error "msg"` use `Reason = "Expression.Error"`. For custom reasons use the record form: `error [Reason = "...", Message = "..."]`.
 
 ## See also

--- a/plugins/fabric-authoring/skills/dataflows-save-as-authoring-cli/SKILL.md
+++ b/plugins/fabric-authoring/skills/dataflows-save-as-authoring-cli/SKILL.md
@@ -23,6 +23,18 @@ description: >
 > 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering
 > 2. To find the item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace and, then, use JMESPath filtering
 
+> **GENERATION BOUNDARY -- HARD STOP (mandatory)**
+> This skill executes save-as only from Gen1 to Gen2.1. For an execution
+> request whose source is Gen2, or whose source generation is not established,
+> state that no public save-as or in-place upgrade endpoint is available and
+> stop before API calls. This does not block a read-only readiness scan whose
+> purpose is to discover and classify Gen1 candidates.
+> Do not interpret "choose the closest endpoint and proceed" as approval to
+> export a definition and create a copy, do not invoke the authoring skill
+> automatically, and do not mutate anything. Ask the user to clarify the
+> intended outcome and explicitly approve any separately documented
+> alternative.
+
 # dataflows-save-as-authoring-cli — Dataflow Save-As Gen1 → Gen2.1 CI/CD via CLI
 
 A save-as companion for creating upgraded Gen2.1 copies from Power BI Gen1 dataflows using readiness assessment and guarded execution.

--- a/plugins/fabric-authoring/skills/eventstream-authoring-cli/SKILL.md
+++ b/plugins/fabric-authoring/skills/eventstream-authoring-cli/SKILL.md
@@ -5,15 +5,16 @@ description: >
   the Items REST API. Build definitions with 25 source types (Event Hubs, IoT Hub,
   CDC, Kafka, SampleData), 8 operators (Filter, Aggregate, GroupBy, Join,
   ManageFields, Union, Expand, SQL), 4 destinations (Lakehouse, Eventhouse,
-  Activator, Custom Endpoint), DefaultStream/DerivedStream routing. Use to:
-  (1) author Eventstream topology, (2) add Event Hub source, (3) add filter
-  operator, (4) add CDC source with Debezium flattening, (5) wire destinations,
-  (6) modify/delete Eventstream definitions. Triggers: "create eventstream",
-  "deploy eventstream", "eventstream topology", "add source to eventstream",
-  "add event hub source", "add filter operator", "eventstream filter",
-  "eventstream destination", "CDC source", "eventstream operator",
-  "eventstream definition", "update eventstream", "wire eventstream",
-  "real-time ingestion pipeline", "eventstream topology deployment".
+  Activator, Custom Endpoint), DefaultStream/DerivedStream routing. **Invoke this
+  skill** to: (1) author Eventstream topology, (2) add Event Hub source, (3) add
+  filter operator, (4) add CDC source with Debezium flattening, (5) wire
+  destinations, (6) modify/delete Eventstream definitions. Invoke before making
+  topology changes. Triggers: "create eventstream", "deploy eventstream",
+  "eventstream topology", "add source to eventstream", "add event hub source",
+  "add filter operator", "eventstream filter", "eventstream destination",
+  "CDC source", "eventstream operator", "eventstream definition",
+  "update eventstream", "wire eventstream", "real-time ingestion pipeline",
+  "eventstream topology deployment".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -181,8 +182,8 @@ The Update Definition API returns `202 Accepted` for long-running operations. Po
 **Required structure for ALL operator condition fields:**
 - `column` → object with `{node, columnName, columnPath, expressionType: "ColumnReference"}`
 - `value` → object with `{dataType, value, expressionType: "Literal"}`
-- `operatorType` → string: `GreaterThan`, `LessThan`, `Equals`, `NotEquals`, `GreaterThanOrEqual`, `LessThanOrEqual`
-- `dataType` → `Float`, `Int`, `Long`, `String`, `DateTime`
+- `operatorType` → string: `Equals`, `NotEquals`, `GreaterThan`, `GreaterThanOrEquals`, `LessThan`, `LessThanOrEquals`, `Contains`, `DoesNotContain`, `StartsWith`, `DoesNotStartWith`, `EndsWith`, `DoesNotEndWith`, `IsEmpty`, `IsNull`, `IsNotNull`, `IsNotNullOrEmpty`
+- `dataType` → `BigInt`, `Float`, `Nvarchar(max)`, `DateTime`, `Bit`
 
 This same nested-object pattern applies to **all operators** that reference columns (Filter, Aggregate, GroupBy, Join, ManageFields).
 
@@ -227,3 +228,352 @@ Returns `200 OK` on success.
 - Do NOT exceed 11 combined CustomEndpoint sources and CustomEndpoint/Eventhouse-direct-ingestion destinations
 - Do NOT confuse Eventstream with Eventhouse — they are separate Fabric workloads
 - Do NOT hardcode workspace or item IDs — always discover them via the API
+
+---
+
+## Examples
+
+> **Platform note** — examples use PowerShell. Always write the JSON body to
+> a temp file via `[IO.File]::WriteAllText()` (no BOM) and pass
+> `--body "@$file"` to `az rest`, rather than inline `--body "..."` which
+> `cmd.exe` can mangle. Use `-Compress` with `ConvertTo-Json` to avoid
+> newline issues. The one safe inline exception is `--body '{}'` for empty bodies.
+
+### Example 1: Create an Eventstream with a Source
+
+**Prompt**: "Create an Eventstream called SensorIngestion in my dev workspace with a sample data source."
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+# 2. Create empty Eventstream
+$esBody = @{ displayName = "SensorIngestion"; description = "IoT sensor pipeline" } | ConvertTo-Json -Compress
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) "es_create.json"
+[IO.File]::WriteAllText($bodyFile, $esBody, [System.Text.UTF8Encoding]::new($false))
+$created = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$bodyFile" | ConvertFrom-Json
+
+# 3. Get the created Eventstream ID from response
+$esId = $created.id
+if (-not $esId) { throw "Eventstream creation did not return an ID" }
+
+# 4. Build topology — DefaultStream uses inputNodes (not parentName)
+$topology = @{
+    compatibilityLevel = "1.0"
+    sources = @(@{
+        name = "SampleSource"
+        type = "SampleData"
+        properties = @{ type = "Bicycles" }
+    })
+    streams = @(@{
+        name = "SensorIngestion-stream"
+        type = "DefaultStream"
+        properties = @{}
+        inputNodes = @(@{ name = "SampleSource" })
+    })
+    operators = @()
+    destinations = @()
+}
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+
+# 5. Deploy definition
+$defBody = @{
+    definition = @{
+        parts = @(@{
+            path = "eventstream.json"
+            payload = $topologyB64
+            payloadType = "InlineBase64"
+        })
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+$defFile = Join-Path ([IO.Path]::GetTempPath()) "es_def.json"
+[IO.File]::WriteAllText($defFile, $defBody, [System.Text.UTF8Encoding]::new($false))
+# Note: updateDefinition returns 202 Accepted (LRO). Poll until completion.
+$updateJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/updateDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$defFile"
+if ($LASTEXITCODE -ne 0) { throw "updateDefinition request failed" }
+
+$updateResp = $updateJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($updateResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($updateResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Update succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "updateDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 2: Add a Filter Operator with a DerivedStream
+
+**Prompt**: "Add a filter to my SensorIngestion Eventstream that keeps only events where No_Bikes > 5 and expose the filtered output as a DerivedStream."
+
+> **Important**: Adding a Filter operator node alone does not redirect the DefaultStream.
+> To make the filtered output consumable, wire a DerivedStream (or destination) to the
+> filter's output via `inputNodes`.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get current definition (handles LRO if API returns 202)
+$respJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/getDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body '{}'
+if ($LASTEXITCODE -ne 0 -or -not $respJson) { throw "getDefinition request failed" }
+$resp = $respJson | ConvertFrom-Json
+
+if ($resp.definition) {
+    $def = $resp  # Synchronous — got definition immediately
+} elseif ($resp.operationId) {
+    # Asynchronous (LRO) — poll operation status
+    $def = $null
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') {
+            $def = (az rest --method get `
+              --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)/result" `
+              --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+            break
+        } elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "getDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+    if (-not $def.definition) { throw "getDefinition LRO timed out (last status: $($status.status))" }
+} else {
+    throw "getDefinition returned neither a definition nor an operationId"
+}
+
+# 3. Decode existing topology
+$esPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstream.json' } | Select-Object -First 1
+if (-not $esPart) { throw "eventstream.json part not found in definition" }
+$topology = [Text.Encoding]::UTF8.GetString(
+  [Convert]::FromBase64String($esPart.payload)) | ConvertFrom-Json
+
+# 4. Add Filter operator (PascalCase name — no underscores or hyphens)
+#    Column: expressionType + columnName; Value: expressionType + dataType + value
+$filter = @{
+    name = "FilterLowBikes"
+    type = "Filter"
+    inputNodes = @(@{ name = "SensorIngestion-stream" })
+    properties = @{
+        conditions = @(@{
+            operatorType = "GreaterThan"
+            column = @{
+                expressionType = "ColumnReference"
+                node = $null
+                columnName = "No_Bikes"
+                columnPath = $null
+            }
+            value = @{
+                expressionType = "Literal"
+                dataType = "BigInt"
+                value = "5"
+            }
+        })
+    }
+}
+$existingOps = @($topology.operators | Where-Object { $_ -ne $null })
+$topology.operators = $existingOps + @($filter)
+
+# 5. Add DerivedStream wired to filter output (makes filtered data available)
+$derivedStream = @{
+    name = "FilteredOutput"
+    type = "DerivedStream"
+    properties = @{
+        inputSerialization = @{ type = "Json"; properties = @{ encoding = "UTF8" } }
+    }
+    inputNodes = @(@{ name = "FilterLowBikes" })
+}
+$existingStreams = @($topology.streams | Where-Object { $_ -ne $null })
+$topology.streams = $existingStreams + @($derivedStream)
+
+# 6. Re-encode and update
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+$esPart.payload = $topologyB64
+
+$defBody = @{ definition = @{ parts = $def.definition.parts } } | ConvertTo-Json -Depth 5 -Compress
+$defFile = Join-Path ([IO.Path]::GetTempPath()) "es_def.json"
+[IO.File]::WriteAllText($defFile, $defBody, [System.Text.UTF8Encoding]::new($false))
+# Note: updateDefinition returns 202 Accepted (LRO). Poll until completion.
+$updateJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/updateDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$defFile"
+if ($LASTEXITCODE -ne 0) { throw "updateDefinition request failed" }
+
+$updateResp = $updateJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($updateResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($updateResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Update succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "updateDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 3: Deploy Full Topology (Create with Inline Definition)
+
+**Prompt**: "Create a complete Eventstream called EventPipeline with a Custom Endpoint source, a filter for high-value events, and a DerivedStream for the filtered output."
+
+> **Note**: This uses the Fabric Items API (`POST /items`) to create the Eventstream with its
+> definition in a single call, rather than create-then-update.
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+# 2. Build complete topology with filter + DerivedStream
+$topology = @{
+    compatibilityLevel = "1.0"
+    sources = @(@{
+        name = "CustomSource"
+        type = "CustomEndpoint"
+        properties = @{}
+    })
+    streams = @(
+        @{
+            name = "EventPipeline-stream"
+            type = "DefaultStream"
+            properties = @{}
+            inputNodes = @(@{ name = "CustomSource" })
+        }
+        @{
+            name = "FilteredEvents"
+            type = "DerivedStream"
+            properties = @{
+                inputSerialization = @{ type = "Json"; properties = @{ encoding = "UTF8" } }
+            }
+            inputNodes = @(@{ name = "FilterPremium" })
+        }
+    )
+    operators = @(@{
+        name = "FilterPremium"
+        type = "Filter"
+        inputNodes = @(@{ name = "EventPipeline-stream" })
+        properties = @{
+            conditions = @(@{
+                operatorType = "GreaterThan"
+                column = @{
+                    expressionType = "ColumnReference"
+                        node = $null
+                        columnName = "Amount"
+                        columnPath = $null
+                    }
+                value = @{
+                    expressionType = "Literal"
+                    dataType = "BigInt"
+                    value = "100"
+                }
+            })
+        }
+    })
+    destinations = @()
+}
+
+# 3. Create with inline definition (single API call)
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+
+$body = @{
+    displayName = "EventPipeline"
+    type = "Eventstream"
+    definition = @{
+        parts = @(@{
+            path = "eventstream.json"
+            payload = $topologyB64
+            payloadType = "InlineBase64"
+        })
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) "es_create_full.json"
+[IO.File]::WriteAllText($bodyFile, $body, [System.Text.UTF8Encoding]::new($false))
+
+# Create-with-definition returns 202 Accepted (LRO). Poll until completion.
+$createJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/items" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$bodyFile"
+if ($LASTEXITCODE -ne 0) { throw "Create Eventstream request failed" }
+
+$createResp = $createJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($createResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($createResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Create succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "Create LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 4: Delete an Eventstream
+
+**Prompt**: "Delete the SensorIngestion Eventstream from my dev workspace."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Delete
+az rest --method delete `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId" `
+  --resource "https://api.fabric.microsoft.com"
+```

--- a/plugins/fabric-authoring/skills/semantic-model-authoring/SKILL.md
+++ b/plugins/fabric-authoring/skills/semantic-model-authoring/SKILL.md
@@ -4,14 +4,15 @@ description: >
   Develops and manages Power BI semantic models across Desktop, PBIP projects, and Fabric Service. Handles:
   (1) creating new models (Import, DirectQuery, Direct Lake),
   (2) editing existing models (e.g. measures, tables, columns, relationships),
-  (3) deploying models to Fabric workspaces,
-  (4) working with PBIP project files,
-  (5) refreshing semantic models,
-  (6) configuring data sources and permissions,
-  (7) DAX performance optimization.
+  (3) preparing semantic models for AI/Copilot consumption,
+  (4) deploying models to Fabric workspaces,
+  (5) working with PBIP project files,
+  (6) refreshing semantic models,
+  (7) configuring data sources and permissions,
+  (8) DAX performance optimization.
   Supports both Power BI Desktop and Fabric Service development workflows. For read-only DAX queries, use `semantic-model-consumption`.
   Does NOT handle report layout/visual authoring, workspace administration, or RLS/OLS role membership management.
-  Triggers: "create semantic model", "edit semantic model", "add a DAX measure to semantic model", "refresh semantic model", "set semantic model permissions", "Prepare semantic model for AI/Copilot".
+  Triggers: "create semantic model", "edit semantic model", "add a DAX measure to semantic model", "refresh semantic model", "set semantic model permissions", "Prepare semantic model for AI or Copilot".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -182,7 +183,7 @@ Steps:
 
 ## Workflow: Semantic Model AI Readiness
 
-**When this applies:** User asks to make a semantic model ready for Microsoft Fabric Copilot, a Power BI Data Agent, or any conversational BI experience. Triggers include "Copilot readiness", "AI readiness", "prep for AI", "prepare model for Copilot".
+**When this applies:** User asks to make a semantic model ready for Microsoft Fabric Copilot, a Power BI Data Agent, or any conversational BI experience. Triggers include "Copilot readiness", "AI readiness", "Prep for AI", "prepare model for Copilot".
 
 Load [semantic-model-ai-readiness.md](./references/semantic-model-ai-readiness.md) before starting.
 
@@ -190,9 +191,9 @@ Steps:
 
 1. **Confirm scope & gather context** - via `ask_user`, confirm consumption mode (reports only / conversational BI / both) and model stability per the *When to Apply* section. Collect business context (process, key metrics, common natural-language questions, vocabulary). Do not invent.
 2. **Connect & inventory** - per [Connecting to a Semantic Model](#connecting-to-a-semantic-model). Capture model contents and the source location (PBIP / Fabric workspace / Desktop-only).
-3. **Evaluate & route** - walk the [Readiness Checklist](./references/semantic-model-ai-readiness.md#readiness-checklist) in order; for each gap, classify the fix per [Editing Capability by Source and Tier](./references/semantic-model-ai-readiness.md#editing-capability-by-source-and-tier) (MCP-editable TOM metadata vs PBIP-only artifact).
+3. **Evaluate & route** - walk the [Readiness Checklist](./references/semantic-model-ai-readiness.md#readiness-checklist) in order; for each gap, classify the fix per [Editing Capability](./references/semantic-model-ai-readiness.md#editing-capability) (agent-editable TOM metadata vs AI-specific artifacts the user configures in the Power BI "Prep data for AI" UI).
 4. **Present findings** grouped by severity, each tagged with routing (agent-applicable vs user-action-required). Wait for approval.
-5. **Apply approved changes** - TOM metadata via [Modify an Existing Model](#workflow-modify-an-existing-model); PBIP-only artifacts via direct file edits or Fabric `getDefinition`/`updateDefinition` round-trip; Desktop-only PBIX -> instruct user.
+5. **Apply approved changes** - apply TOM metadata fixes via [Modify an Existing Model](#workflow-modify-an-existing-model); for AI instructions, AI Data Schema, and Verified Answers, instruct the user to configure them in the Power BI "Prep data for AI" UI and, only if the user agrees, offer suggestions per the readiness reference; Desktop-only PBIX -> instruct user.
 6. **Save, validate, recommend live testing** - per [Saving Changes to a Semantic Model](#saving-changes-to-a-semantic-model) and [Validation Checklist](#validation-checklist); advise the user to test representative natural-language prompts in Copilot or the Data Agent and iterate.
 
 ---

--- a/plugins/fabric-authoring/skills/semantic-model-authoring/references/pbip.md
+++ b/plugins/fabric-authoring/skills/semantic-model-authoring/references/pbip.md
@@ -10,14 +10,6 @@ It can include a Semantic Model + Report or just a Report (live connect).
 PBIPFolder/
 ├── [Name].SemanticModel/
 |   ├── /definition # The semantic model definition using TMDL language [REQUIRED]
-│   ├── Copilot/ # Copilot tooling [OPTIONAL]
-│   │   ├── Instructions/ # Contains the AI instructions configured for the semantic model, stored as a single markdown file.
-│   │   │   ├── instructions.md 
-│   │   ├── VerifiedAnswers/ # Contains the configured Verified answers for the semantic model, using PBIR format.
-│   │   │   ├── definitions/
-│   │   ├── schema.json # Contains the schema selection and field synonyms configured for the semantic model. 
-│   │   ├── settings.json # Contains top level Copilot tooling settings. 
-│   │   ├── examplePrompts.json # Contains zero prompts set up for the semantic model.
 |   ├── definition.pbism # The semantic model definition file [REQUIRED]
 |   ├── * # Other semantic model metadata files and folders
 ├── [Name].Report/        
@@ -117,91 +109,6 @@ Example of a `[name].pbip` file:
 ```
 
 Refer to [JSON Schema](https://github.com/microsoft/json-schemas/blob/main/fabric/pbip/pbipProperties/1.0.0/schema.json) for more details.
-
-## Copilot/Instructions/instructions.md
-
-```markdown
-# AI Instructions for Semantic Model
-
-## Business Context & Terminology
-- You are a sales analyst for a retail company analyzing sales performance, customer behavior, and product trends
-...
-```
-
-### Copilot/schema.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/schema/1.0.0/schema.json",
-  "tables": [
-    {
-      "id": "[lineage tag]",
-      "name": "[Table name 1]",
-      "visibility": "Visible",
-      "columns": [
-        {
-          "id": "[lineage tag]",
-          "name": "[Column name 1]",
-          "visibility": "Visible",
-          "synonyms": ["[synonym 1]", "[synonym 2]"]
-        },
-        {
-          "id": "[lineage tag]",
-          "name": "[Column name 2]",
-          "visibility": "Hidden",
-          "synonyms": []
-        }
-      ],
-      "measures": [
-        {
-          "id": "[lineage tag]",
-          "name": "[measure name]",
-          "visibility": "Visible",
-          "synonyms": []
-        }
-      ],
-      "hierarchies": [
-        {
-          "id": "[lineage tag]",
-          "name": "[Hierarchy name]",
-          "visibility": "Visible",
-          "levels": [
-            {
-              "id": "[lineage tag]",
-              "name": "[Level name]",
-              "visibility": "Visible",
-              "synonyms": []
-            }
-          ],
-          "synonyms": []
-        }
-      ],
-      "synonyms": []
-    }
-  ]
-}
-```
-
-### Copilot/settings.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/settings/1.0.0/schema.json",
-  "indexingEnabled": true
-}
-```
-
-### Copilot/examplePrompts.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/examplePrompts/1.0.0/schema.json",
-  "prompts": [
-    "Top 5 customers by Sales Amount",
-    "Margin % by product category"
-  ]
-}
-```
 
 ## References
 

--- a/plugins/fabric-authoring/skills/semantic-model-authoring/references/semantic-model-ai-readiness.md
+++ b/plugins/fabric-authoring/skills/semantic-model-authoring/references/semantic-model-ai-readiness.md
@@ -21,14 +21,14 @@ Ask the user which consumption methods are planned before scoping the readiness 
 
 ## Editing Capability
 
-The agent's ability to *apply* a Copilot readiness item depends on (a) whether the item lives in TOM model metadata or in PBIP-only artifacts, and (b) where the model lives. 
+The agent's ability to *apply* a Copilot readiness item depends on whether the item lives in TOM model metadata (agent-editable) or is an AI-specific artifact that must be configured by the user in the Power BI "Prep data for AI" UI.
 
 | Semantic Model Objects                                                                                   | Editing path                                                                                                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **TOM metadata** - names, descriptions, relationships, measures, hidden flags, data types, summarization | **Prioritize MCP** (any source).                                                                                                                                                                                       |
-| **Everything else** - synonyms, AI instructions, AI Data Schema selection, Verified Answers              | **Edit PBIP files** under `<Name>.SemanticModel/Copilot/`. Edit directly on a PBIP project, or via Fabric workspace `getDefinition`/`updateDefinition` round-trip. Not via MCP. PBIX files cannot be edited by Agents. Load [pbip.md](pbip.md) to understand the file structure. |
+| **TOM metadata** - names, descriptions, relationships, measures, hidden flags, data types, summarization | **Edit via MCP or TMDL** (any source). The agent applies these changes directly.                                                                                                                                       |
+| **AI-specific artifacts** - AI instructions, AI Data Schema selection & synonyms, Verified Answers       | **Not editable by the agent.** Instruct the user to configure these in the Power BI "Prep data for AI" UI. The agent may *offer* suggestions only when appropriate - see sections [4](#4-ai-instructions), [5](#5-ai-data-schema), and [6](#6-verified-answers). |
 
-When presenting findings to the user, tag each item with its routing so the user knows which fixes the agent can apply and which require Desktop work.
+When presenting findings to the user, tag each item with its routing so the user knows which fixes the agent can apply to the model metadata and which the user must configure in the "Prep data for AI" UI.
 
 **Important:** When incapable of editing any metadata, refer the user to [copilot-prepare-data-ai](https://learn.microsoft.com/power-bi/create-reports/copilot-prepare-data-ai) documentation.
 
@@ -57,6 +57,8 @@ Without this, Copilot will produce poor results regardless of any other configur
 - Anticipate common questions: include predefined measures users are most likely to request (e.g., `YTD Sales`, `MoM Growth`, `ROI`, `CAC`, `LTV`). Copilot answers more reliably when the metric already exists as an explicit measure.
 - Consolidate or clearly differentiate duplicate or overlapping measures.
 - Define logical hierarchies on dimension tables to support drill-down (e.g., `Year > Quarter > Month > Day` on a date dimension; `Country > State > City` on a geography dimension).
+- Set `summarizeBy` correctly on numeric columns - especially `None` for IDs, year, month number, postal codes, etc., to prevent accidental sums.
+- Set the `isDefaultLabel` on the column that defines the natural label for each dimension table, allowing Copilot to identify the table's default "name" column (for example, **Product Name** in the **Product** table).
 
 **DON'T:**
 - Leave unused columns or tables in the model - they pollute the schema Copilot sees and increase the chance of wrong field selection.
@@ -68,8 +70,6 @@ Business-friendly naming is one of the highest-impact changes for Copilot readin
 **DO:**
 - Use human-readable names on every visible table, column, and measure (e.g., `Transaction Amount`, not `TR_AMT` or `tr_amt`).
 - Use the language Copilot will be queried in (typically English) for visible names, even if the source system uses another language.
-- Set `summarizeBy` correctly on numeric columns - especially `None` for IDs, year, month number, postal codes, etc., to prevent accidental sums.
-- Set the `isDefaultLabel` (or equivalent default field) on dimension tables so Copilot can identify the natural "name" column.
 
 **DON'T:**
 - Ship CamelCase, snake_case, UPPER_CASE, or technical abbreviations on visible objects.
@@ -95,7 +95,7 @@ Descriptions provide context that names alone cannot convey. Descriptions writte
 
 AI instructions are freeform text that Copilot reads automatically. They are one of the most impactful controls for conversational BI quality.
 
-> **Editing path:** PBIP-level artifact. See [Editing Capability](#editing-capability).
+> **Editing path:** Not editable by the agent - the user configures AI instructions in the Power BI "Prep data for AI" UI. After the model-metadata changes are applied, prompt the user to ask whether they want the agent to draft suggested AI instructions. See [Editing Capability](#editing-capability).
 
 **DO:**
 - Metric routing for ambiguous terms ("when users ask about margin, use `[Standard Margin]`").
@@ -114,22 +114,21 @@ AI instructions are freeform text that Copilot reads automatically. They are one
 **DON'T:**
 - Duplicate large blocks of business logic that already live in descriptions.
 - Encode information that should instead be a measure, a synonym, or a relationship.
-- Rely on instructions to enforce hard rules - the LLM may still ignore them. For non-negotiable behaviour, fix the model itself.
-- Exceed 10.000 characters
+- Restate what descriptions and model metadata already convey.
+- Rely on instructions to enforce hard rules - the LLM may still ignore them. For non-negotiable behavior, fix the model itself.
+- Exceed 10,000 characters
 
 ### 5. AI Data Schema
 
 The AI data schema controls which tables, columns, and measures are exposed to Copilot. It also defines synonyms for tables/columns/measures. Scoping this correctly prevents Copilot from getting confused by helper objects.
 
-> **Editing path:** PBIP-level artifact. See [Editing Capability](#editing-capability).
+> **Editing path:** Not editable by the agent - the user configures the AI Data Schema in the Power BI "Prep data for AI" UI. Prompt the user to ask whether they want suggestions, but only recommend an AI-schema visibility change when the desired AI visibility differs from the model's default visibility (e.g., a measure that should stay visible for reports and ad-hoc exploration but be excluded from AI agents). Do not mirror the report-model visibility as an AI-schema change. See [Editing Capability](#editing-capability).
 
 **DO:**
 - Include only tables, columns, and measures that a business user would meaningfully ask about.
 - Include all dependent objects for selected measures (any column or measure referenced by a selected measure must also be visible to Copilot).
 - Exclude helper measures, intermediate calculations, and technical bridge tables.
 - Exclude duplicate or overlapping measures.
-- Keep the AI schema selection consistent across "Prep for AI" and any Data Agent configuration that points to this model.
-- Configure `synonyms` on tables, columns, and measures for alternative terms users employ (e.g., `Revenue`, `Sales`, `Turnover` for the same measure).
   
 **DON'T:**
 - Default to "expose everything" - it dilutes the signal Copilot uses to pick the right field.
@@ -141,7 +140,6 @@ Verified Answers are pre-built report visuals that Copilot can return for specif
 > **Editing path:** Don't edit verified answers automatically. Instead suggest good candidates for verified answers and ask the user to configure manually in the tool. See [copilot-prepare-data-ai](https://learn.microsoft.com/power-bi/create-reports/copilot-prepare-data-ai-verified-answers) documentation.
 
 **DO:**
-- When reviewing a PBIP, check whether a Verified Answers definition exists in the project. Note its presence in the readiness summary.
-- If absent and the user is interested, point them to the Power BI Desktop authoring experience - do not attempt to author Verified Answers from this skill.
-- Inspect the model measures, based on the measure names, descriptions recommend the top five questions worth setting as verified answers
+- Inspect the model measures and, based on the measure names and descriptions, recommend the top five questions worth setting as Verified Answers.
+- Prompt the user to configure Verified Answers in the Power BI "Prep data for AI" UI - do not attempt to author Verified Answers from this skill.
 

--- a/plugins/fabric-consumption/.github/plugin/plugin.json
+++ b/plugins/fabric-consumption/.github/plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "name": "fabric-consumption",
   "description": "Consumer skills for interactive Microsoft Skills for Fabric operations - queries, exploration, monitoring",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "MIT",
   "repository": "https://github.com/microsoft/skills-for-fabric",
   "keywords": [

--- a/plugins/fabric-consumption/skills/activator-consumption-cli/SKILL.md
+++ b/plugins/fabric-consumption/skills/activator-consumption-cli/SKILL.md
@@ -12,7 +12,7 @@ description: >
   **Invoke this skill before answering questions** about an Activator/Reflex item
   in a Fabric workspace — the listing, lookup, and decoding workflows are part of
   this skill, not preamble to it.
-  Triggers: "show my alerts", "what alerts do I have", "inspect this alert",
+  Triggers: "show my alerts", "what alerts do I have", "show me all activators", "inspect this alert",
   "show me the rule", "show me the action", "show me the source",
   "get reflex definition", "list activators", "list alerts",
   "list reflex items", "show activator items", "activator details",

--- a/plugins/fabric-consumption/skills/check-updates/SKILL.md
+++ b/plugins/fabric-consumption/skills/check-updates/SKILL.md
@@ -1,221 +1,508 @@
 ---
 name: check-updates
 description: >
-  Check for skills-for-fabric marketplace updates at session start. Compares local version 
-  against GitHub releases and shows changelog if updates are available. Use when the 
-  user wants to: (1) check for skill updates, (2) see what's new in skills-for-fabric, 
-  (3) verify current version. Triggers: "check for updates", "am I up to date", 
-  "what version", "update skills", "show changelog".
+  Check an installed skills-for-fabric plugin bundle or git clone for updates,
+  show the matching changelog, and provide host-appropriate update guidance.
+  Use when the user wants to: (1) check for skill updates, (2) see what changed,
+  (3) verify the installed version. Triggers: "check for updates", "am I up to
+  date", "what version", "update skills", "show changelog".
 ---
 
 # Check for Updates
 
-This skill checks for updates to the skills-for-fabric marketplace at the start of each session.
+This is a read-only update checker. It identifies the installation that supplied
+this skill, compares its version with the repository's `main` branch, and shows
+the update path supported by the current agent host. It never updates
+automatically.
 
-## When to Run
+## Cadence
 
-Run this check **once per week** when any skills-for-fabric skill is first invoked. Skip if already checked within the last 7 days.
+Keep these two controls separate:
 
-## Session State
+- **Invocation guard:** Other Fabric skills invoke this skill once per session
+  before continuing.
+- **Network guard:** Automatic invocations perform a remote lookup at most once
+  every 7 days for each detected installation identity.
 
-The update check marker is stored in a **persistent, user-level directory** shared across all sessions and all plugins in the Fabric Skills marketplace:
+If the user's current request directly asks for a version, changelog, or update
+check, treat it as an **explicit invocation** and bypass the 7-day network guard.
+If this skill was invoked only by another skill's session-start notice, treat it
+as an **automatic invocation**.
+
+Always continue with the caller's original task after an automatic invocation,
+including when the check is skipped or fails.
+
+## Procedure
+
+### Step 1: Resolve the Installation Context
+
+Determine one candidate installation root:
+
+1. If the user explicitly supplied an installation path, use that exact path.
+2. Otherwise, start from the active
+   `<skills-root>/check-updates/SKILL.md` file.
+3. When `<skills-root>` is named `skills`, consider its parent as a containing
+   root. Use that containing root only if it has a supported plugin manifest or
+   both `package.json` and a direct `.git` file or directory plus the positive
+   skills-for-fabric Git identity defined below.
+4. Otherwise, use `<skills-root>` as the candidate root. This includes personal
+   copies under `~/.copilot/skills` and `~/.agents/skills`, plus project copies
+   under `.github/skills`, `.agents/skills`, and `.claude/skills`.
+5. If the runtime does not expose the active skill path, report the context as
+   unknown. Do not guess.
+
+Never infer the installation from the shell's current working directory. Never
+walk upward beyond the candidate root. A project containing an unrelated parent
+`.git` directory is not evidence that the skill came from that repository.
+
+Resolve the runtime host independently from the installation channel:
+
+```text
+copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+```
+
+Use the host identity exposed by the current session or runtime. Do not infer it
+from a plugin manifest, install path, or working directory. A deterministic test
+may supply an explicit runtime-host override; normal use may not. If the host
+cannot be established, use `unknown`.
+
+For runtime detection of an already installed plugin, use the first existing
+manifest in this cross-tool precedence:
+
+1. `.plugin/plugin.json`
+2. `plugin.json`
+3. `.github/plugin/plugin.json`
+4. `.claude-plugin/plugin.json`
+
+In this repository, `.github/plugin/plugin.json` is the canonical source
+manifest. `.plugin/plugin.json` and `plugin.json` are compatibility fallbacks
+for other installed layouts or test fixtures. The final location supports
+packages that expose only a Claude-compatible manifest. Do not treat this
+runtime probe order as authoring guidance for this repository.
+
+Then classify the candidate root in this order:
+
+| Channel | Required files at the candidate root | Read |
+|---|---|---|
+| Plugin | one supported plugin manifest | top-level `name`, `version`, `repository` |
+| Git clone | `package.json`, a direct `.git` file or directory, and a positive skills-for-fabric Git identity | top-level `version`, `repository.url` |
+| Copied skills | no plugin or Git layout, plus either a root `SKILL.md` or direct child skill directories containing `SKILL.md` | tentative skill directory names only |
+| Unknown | none of the exact layouts | no identity or update command |
+
+Plugin detection takes precedence if both layouts are present. This lets a
+development fixture retain plugin semantics while using a local Git remote.
+
+A positive Git identity requires both of these checks:
+
+- The final unscoped segment of `package.json` `name` is
+  `skills-for-fabric`. Accepted examples include `skills-for-fabric`,
+  `@microsoft/skills-for-fabric`, and contributor-fork scopes.
+- After removing a trailing slash and `.git`, the final repository path segment
+  is `skills-for-fabric`, compared case-insensitively.
+
+If either check fails, do not promote that containing root to the Git channel
+and do not run Git against it. Continue candidate-root resolution and classify
+the resulting candidate independently; a nested `skills` root may therefore be
+a loose copy. A generic Node repository that happens to contain a `skills/`
+directory is not a skills-for-fabric installation.
+
+A copied channel is terminal until an explicit request confirms its source:
+
+- For an automatic invocation, do not ask a question. Optionally show one short
+  note that the unverified loose copy was skipped and can be checked explicitly,
+  then continue the caller's original task.
+- For an explicit invocation without source confirmation, list the tentative
+  copied skill names, state that source and version are unverified, ask the
+  confirmation question in the copied-channel section, and stop.
+
+Neither path continues to the network guard or remote-version steps.
+
+Build one context object:
+
+```text
+runtimeHost: copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+channel: plugin | git | copy | unknown
+root: exact candidate root
+installKind: marketplace | direct | none
+installScope: user | project | local | managed | none
+manifestName: plugin manifest name | none
+installedName: marketplace entry name | none
+marketplace: marketplace name | none
+sourceId: direct-install source ID | none
+identity: plugin:<marketplace>/<installed-name> | plugin:direct/<source-id> | git:<repository-url-as-stored>|<root>
+localVersion: manifest version
+repository: URL exactly as stored in the selected manifest
+updateTarget: <installed-name>@<marketplace> | <manifest-name> | <root> | none
+copiedSkills: direct skill directory names | none
+```
+
+For a plugin, keep the manifest name separate from the installed marketplace
+entry name. They can differ. Resolve the installed entry from native runtime
+metadata or the native plugin listing when it identifies the candidate root.
+
+For GitHub Copilot CLI marketplace installs, the documented path is
+`~/.copilot/installed-plugins/<marketplace>/<installed-name>`, so those two path
+segments are authoritative.
+
+For a direct Copilot CLI install at
+`~/.copilot/installed-plugins/_direct/<source-id>`, set `installKind` to
+`direct`, use the source ID only for the cache identity, and use the manifest
+name as the bare update target. `_direct` is not a marketplace name.
+
+For Claude Code marketplace installs, resolve the installed entry and scope from
+Claude's native plugin metadata. `claude plugin list --json` can identify the
+entry; the declaring settings file identifies its scope:
+
+- `~/.claude/settings.json` -> `user`
+- `.claude/settings.json` -> `project`
+- `.claude/settings.local.json` -> `local`
+- managed settings -> `managed`
+
+If the same entry exists at more than one scope, list the choices and ask which
+one to update. Do not guess a scope. A plugin loaded only from a skills
+directory, `--plugin-dir`, or `--plugin-url` has no marketplace install record;
+do not fabricate an update command for it.
+
+If native metadata and the installed path are unavailable, use the manifest
+name with marketplace `fabric-collection` only when the mapping is
+unambiguous. The `fabric-skills` manifest is not unambiguous because the legacy
+`skills-for-fabric` marketplace entry uses the same payload. In that case,
+report that the installed entry could not be resolved, ask the user to inspect
+the native plugin list, and do not guess an identity or update command.
+
+For Git `package.json`, accept either a repository object with a `url` property
+or a repository URL string. Keep the repository value exactly as stored and
+append the exact resolved root when building the cache identity. This prevents
+one clone from suppressing checks for another clone of the same repository.
+When parsing a GitHub owner and repository for remote tools, strip only a
+trailing `.git` and trailing slash. Do not alter owner spelling, case,
+underscores, or punctuation.
+
+Validate that required fields are present and that `localVersion` is semantic
+version text. If validation fails, report the malformed field and classify the
+context as unknown rather than using partial metadata.
+
+### Step 2: Apply the Network Guard
+
+Use an exact cache path supplied by the caller only for a deterministic test.
+Otherwise, use this persistent cache file:
 
 ```text
 ~/.config/fabric-collection/last-update-check.json
 ```
-  
-This file contains a JSON object mapping plugin names to the **UTC date** (YYYY-MM-DD) of their last update check:
+
+On Windows, this is:
+
+```text
+$env:USERPROFILE\.config\fabric-collection\last-update-check.json
+```
+
+The file is a flat JSON object keyed by installation identity:
 
 ```json
 {
-  "fabric-skills": "2026-02-17",
-  "another-plugin": "2026-02-16"
+  "plugin:fabric-collection/fabric-consumption": "2026-07-15",
+  "plugin:direct/github-com-example-skills": "2026-07-15",
+  "git:https://github.com/example/skills-for-fabric.git|C:\\repos\\skills-for-fabric": "2026-07-14"
 }
 ```
 
-Before checking, read `~/.config/fabric-collection/last-update-check.json`:
-- If the file exists and the entry for the current plugin is within the last **7 days** (compared to the current **UTC date**), skip the check.
-- If the file is missing, the plugin entry is absent, or the date is more than 7 days old (compared to the current **UTC date**), run the update check.
+Use UTC dates in `YYYY-MM-DD` format.
 
-> **IMPORTANT — use UTC consistently**: Always use the current UTC date when saving and comparing the last-update-check timestamp. Do not use the local system timezone, as it varies across environments and can cause the check to run too often or be skipped. In shell, use `date -u +%Y-%m-%d` (Linux/macOS) or `(Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")` (PowerShell).
+- For an automatic invocation, skip the remote lookup when this identity has a
+  valid date within the last 7 days.
+- For an explicit invocation, perform the remote lookup even when a fresh cache
+  entry exists.
+- Entries for different installed plugin entries or Git clone roots do not
+  suppress each other.
+- Preserve every unrelated entry when writing the file.
+- If the file contains malformed JSON, warn and do not overwrite it.
+- Do not read or write a cache entry for a copied or unknown context.
 
-> **Note**: Create the `~/.config/fabric-collection/` directory if it does not exist. On Windows, use `$env:USERPROFILE\.config\fabric-collection\`.
+After a remote attempt completes, record today's UTC date for the detected
+identity whether the attempt found an update, found no update, or failed, unless
+the cache file was malformed. This prevents an automatic network failure from
+repeating in every session. Do not rewrite the marker when the network guard
+skipped the attempt.
 
-## Update Check Procedure
+### Step 3: Read the Remote Version
 
-### Step 1: Get Local Version
+Read `package.json` and `CHANGELOG.md` from the same repository and the same
+`main` ref. Try these methods in order and stop after the first successful one:
 
-Read the `version` field from the local plugin manifest. Two install layouts exist:
+1. **Git CLI:** Only when the candidate root itself has a direct `.git` file or
+   directory. Do not use `git rev-parse` as the availability check because it
+   can discover an unrelated parent repository.
 
-- **GitHub Copilot CLI plugin install** (`~/.copilot/installed-plugins/fabric-collection/fabric-skills/`): the manifest is `.github/plugin/plugin.json` — there is no `package.json` here.
-- **Manual git clone**: the manifest is `package.json` at the repo root.
+   ```bash
+   git -C "<root>" fetch origin main --quiet
+   git -C "<root>" show origin/main:package.json
+   git -C "<root>" show origin/main:CHANGELOG.md
+   ```
 
-Read whichever is present. Both files contain a top-level `"version": "<semver>"` field.
+2. **Authenticated GitHub tools:** Use GitHub MCP file tools or `gh api` with
+   the owner and repository parsed exactly from the manifest URL. Read
+   `package.json` and `CHANGELOG.md` at ref `main`.
+3. **Public raw content:** For a public repository, read both files from
+   `https://raw.githubusercontent.com/<owner>/<repo>/main/`.
 
-### Step 2: Determine Repository Owner and Name
+Do not use the latest GitHub Release tag as the remote version. Plugin
+marketplace updates follow repository content, and a release tag can lag behind
+the version available to plugin users.
 
-Read the `repository` field from the same manifest you used in Step 1, and parse the URL to get `owner` and `repo`. The two layouts store the field differently:
+If version retrieval fails, show the detected channel, identity, and local
+version with a concise warning. Do not fabricate a remote version. If only the
+changelog retrieval fails, still report the version comparison and note that
+the changelog was unavailable.
 
-- **Copilot CLI plugin install** (`.github/plugin/plugin.json`) — plain URL string:
-  ```text
-  "repository": "https://github.com/<owner>/<repo>"
-  ```
-- **Manual git clone** (`package.json` at the repo root) — object whose `url` ends with `.git`:
-  ```text
-  "repository": { "type": "git", "url": "https://github.com/<owner>/<repo>.git" }
-  ```
+### Step 4: Compare and Report
 
-There is no bare `plugin.json` at the repo root in either layout, and there is no top-level `package.json` in the Copilot CLI plugin install — always use the path that matches your actual layout.
+Compare semantic versions:
 
-> **CRITICAL**: Use the owner string **exactly as it appears** in the URL. Do NOT alter, normalize, or "correct" the owner name — including underscores, mixed case, or any other punctuation. Whatever the manifest's `repository` URL says, that is the correct owner. (LLMs sometimes "auto-correct" underscores to hyphens — don't.)
+- `remoteVersion > localVersion`: update available.
+- `remoteVersion <= localVersion`: up to date.
 
-### Step 3: Fetch Latest Release
+For an update, show the relevant `CHANGELOG.md` entries between the local and
+remote versions, then provide only guidance verified for both the detected
+channel and `runtimeHost`.
 
-Use the available tools in your environment to get the latest version. **Try methods in strict order — only fall back to the next method if the previous one fails or is unavailable.**
+**Plugin channel**
 
-> **IMPORTANT**: Methods A and B work with both public and private repositories. Method C only works with public repos. Always attempt A or B first.
+Never emit one host's plugin command for another host.
 
-**Method A — Git CLI (preferred for git-clone installs)**
+| Runtime host | Verified guidance |
+|---|---|
+| GitHub Copilot CLI | For a marketplace install, show `/plugin update <installed-name>@<marketplace>`. For a direct install, show `/plugin update <manifest-name>`. |
+| Claude Code | For a marketplace install with a resolved scope, show `claude plugin update <installed-name>@<marketplace> --scope <scope>`, then tell the user to run `/reload-plugins` or restart Claude Code. |
+| Cursor | Direct the user to **Customize > Plugins**. For a team marketplace, an administrator can use **Refresh** or **Enable Auto Refresh**. Do not emit a plugin CLI command. |
+| Windsurf, Codex, other, or unknown | Report the available version and repository, but provide no executable plugin command because none is verified for this layout. |
 
-Only available if the skills-for-fabric directory is a Git working tree (i.e. it has a `.git` entry — either a directory in a normal clone, or a file in a worktree/submodule). The Copilot CLI plugin install at `~/.copilot/installed-plugins/fabric-collection/fabric-skills/` has no `.git` entry — for that install layout, skip to Method B. If you want a tool-agnostic check, run `git rev-parse --is-inside-work-tree` and only proceed if it prints `true`.
-
-If you do have a Git clone, fetch the remote `package.json` without pulling:
-
-```bash
-git fetch origin main --quiet
-git show origin/main:package.json
-```
-
-Extract the `version` field from the JSON output. This method is the most reliable because it uses the already-configured remote URL and authentication, and avoids any owner/repo name parsing.
-
-**Method B — GitHub MCP tools (preferred for agentic environments)**
-
-If you have access to GitHub MCP server tools (e.g., `get_file_contents`), use them to read the remote `package.json`. Use the owner and repo extracted in Step 2 **exactly as parsed** (do not modify the strings):
-
-```text
-get_file_contents(owner: "<owner>", repo: "<repo>", path: "package.json")
-```
-
-Extract the `version` field from the response. This method works with private repositories because MCP tools use authenticated GitHub access.
-
-**Method C — GitHub REST API (fallback only, public repos)**
-
-> ⚠️ **Only use this method if Methods A and B both fail or are unavailable.** This method does not work with private repositories.
-
-If the repository is public, make a GET request using the owner/repo from Step 2:
-
-```text
-GET https://api.github.com/repos/<owner>/<repo>/releases/latest
-```
-
-Extract the `tag_name` field (e.g., `v0.2.0`) and remove the `v` prefix.
-
-> **Note**: This method returns 404 for private repositories. If you receive a 404 error, do NOT assume the repository doesn't exist — retry with Method A or B.
-
-### Step 4: Compare Versions
-
-Compare the local version with the remote version using semantic versioning:
-- If remote > local: Update available
-- If remote <= local: Up to date
-
-### Step 5: Display Results
-
-#### If Up to Date
-
-Show a brief confirmation and proceed:
-```text
-✅ skills-for-fabric v0.1.0 is up to date.
-```
-
-#### If Update Available
-
-Show detailed information:
+GitHub Copilot CLI marketplace install:
 
 ```text
-╔══════════════════════════════════════════════════════════════════╗
-║  🔄 skills-for-fabric Update Available                                ║
-║                                                                  ║
-║  Current: v0.1.0  →  Latest: v0.2.0                             ║
-╚══════════════════════════════════════════════════════════════════╝
-
-## What's New in v0.2.0
-
-[Display relevant CHANGELOG.md entries here]
-
-## Update Commands
-
-Choose the update method based on how you installed skills-for-fabric.
-
-### GitHub Copilot CLI (recommended)
-/plugin update fabric-skills@fabric-collection
-
-If you originally installed the plugin under the legacy id, this also works:
-  /plugin update skills-for-fabric@fabric-collection
-
-The plugin was renamed in 0.3.0 (skills-for-fabric → fabric-skills),
-but the legacy id is kept as a deprecated alias of fabric-skills, so
-either /plugin update command pulls the canonical payload.
-
-(Optional cleanup) To migrate your installed entry from the legacy id
-to the canonical fabric-skills id:
-  /plugin uninstall skills-for-fabric@fabric-collection
-  /plugin install fabric-skills@fabric-collection
-
-### Manual (Git clone)
-cd /path/to/skills-for-fabric
-git pull
-
-(There are no installation scripts to re-run on 0.3.0+.)
-
-─────────────────────────────────────────────────────────────────
-Would you like to update now? (The current skill will still work)
+/plugin update <installed-name>@<marketplace>
 ```
 
-### Step 6: Set Update Marker
+The installed marketplace entry is authoritative. For example, an installed
+`fabric-consumption@fabric-collection` entry produces:
 
-After completing the check (regardless of result), update `~/.config/fabric-collection/last-update-check.json` with today's **UTC date** (YYYY-MM-DD) for the current plugin. Create the directory and file if they don't exist. Preserve entries for other plugins already in the file.
+```text
+/plugin update fabric-consumption@fabric-collection
+```
+
+If the installed entry is the legacy `skills-for-fabric` alias, update that
+alias first so the installed entry can receive the current payload, even though
+its copied manifest is named `fabric-skills`:
+
+```text
+/plugin update skills-for-fabric@fabric-collection
+```
+
+Afterward, optional migration to the canonical entry is:
+
+```text
+/plugin uninstall skills-for-fabric@fabric-collection
+/plugin install fabric-skills@fabric-collection
+```
+
+GitHub Copilot CLI direct install:
+
+```text
+/plugin update <manifest-name>
+```
+
+The native CLI update target for a direct install is the bare manifest name.
+Do not append `@_direct` or use the opaque source ID as the update target.
+
+Claude Code marketplace install:
+
+```text
+claude plugin update <installed-name>@<marketplace> --scope <scope>
+```
+
+The entry name and scope must come from Claude's installed-plugin metadata. Do
+not reuse Copilot's `_direct` behavior for Claude Code.
+
+**Git channel**
+
+```text
+git -C "<detected-root>" pull --ff-only
+```
+
+**Unknown channel**
+
+State which expected files were absent and provide no update command. Never
+default to `fabric-skills`.
+
+**Copied-skill channel**
+
+A loose copy has no trustworthy repository, installed version, or native update
+target. This includes a skill materialized from a local file or URL by
+`copilot skill add` when no source metadata accompanies it.
+
+For an automatic invocation, do not interrupt the caller with a source question.
+Skip the copied-skill update flow, optionally state that an explicit update
+check can identify a supported replacement, and continue the caller's task.
+Do not list an executable command.
+
+For an explicit invocation, list the tentative skill names found at the
+candidate root, state that their provenance cannot be verified from the files
+alone, and ask:
+
+```text
+Were these skills copied from https://github.com/microsoft/skills-for-fabric?
+If yes, I can inspect the official public repository and show the supported
+plugin bundle that will refresh them. I will not install or remove anything
+without your confirmation.
+```
+
+Before the user confirms the source, do not contact the network, compare
+versions, write cache state, or offer an executable install/update command.
+
+After explicit confirmation:
+
+1. Read `.github/plugin/marketplace.json` from the `main` ref of
+   `microsoft/skills-for-fabric`, using authenticated GitHub tools first and
+   public raw content second.
+2. Match the tentative skill directory names against the skill paths inside
+   each marketplace plugin source. Treat only exact path matches as evidence.
+3. Prefer a focused plugin that covers all matched non-utility skills. If more
+   than one plugin qualifies, list the valid choices and ask the user to choose.
+   Never choose `fabric-skills` merely because `check-updates` appears in it.
+4. Offer only the replacement path supported by `runtimeHost`:
+
+   GitHub Copilot CLI:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   /plugin install <matched-plugin>@fabric-collection
+   ```
+
+   Claude Code, using `user` for a personal copied-skills root or `project` for
+   a project copied-skills root:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   claude plugin install <matched-plugin>@fabric-collection --scope <scope>
+   ```
+
+   Tell the user to run `/reload-plugins` or restart Claude Code after the
+   install. If the Claude scope cannot be resolved, ask instead of guessing.
+
+   For Cursor, Windsurf, Codex, other, or unknown hosts, link to the official
+   repository's installation instructions and provide no executable replacement
+   command. The current public repository does not expose a verified native
+   plugin marketplace for those hosts.
+
+This installs a complete current bundle instead of overwriting loose files and
+leaving mixed-version dependencies. Keep the loose copy until the native plugin
+is installed and verified. Ask separately before removing it. If no exact
+official mapping exists or the public repository is unavailable, report that
+and do not fabricate a bundle or copy individual files.
+
+## Examples
+
+### Focused plugin bundle
+
+```text
+Host: copilot-cli
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: /plugin update fabric-consumption@fabric-collection
+```
+
+### Claude Code plugin bundle
+
+```text
+Host: claude-code
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: claude plugin update fabric-consumption@fabric-collection --scope user
+Reload: /reload-plugins
+```
+
+### Git clone
+
+```text
+Detected: git:https://github.com/example/skills-for-fabric.git|C:\repos\skills-for-fabric
+Current: 0.3.7
+Latest: 0.3.8
+Update: git -C "C:\repos\skills-for-fabric" pull --ff-only
+```
+
+### Unknown layout
+
+```text
+Could not determine the skills-for-fabric installation at <candidate-root>.
+Expected a supported plugin manifest, or a positively identified
+skills-for-fabric package.json plus a direct .git entry.
+No update command was guessed.
+```
+
+### Confirmed official loose copy
+
+```text
+Host: copilot-cli
+Detected loose skills: check-updates, powerbi-report-planning
+Confirmed source: https://github.com/microsoft/skills-for-fabric
+Supported refresh:
+  /plugin marketplace add microsoft/skills-for-fabric
+  /plugin install powerbi-authoring@fabric-collection
+The loose files were not changed or removed.
+```
 
 ## Must
 
-- Check for updates only once per week (based on UTC calendar date, not session lifetime or local timezone)
-- Always proceed with the requested skill after the check (non-blocking)
-- Handle network errors gracefully (show warning, continue with skill)
-- Display the CHANGELOG.md content for versions between current and latest
+- Resolve identity from the active skill root or an explicit user path.
+- Resolve the runtime host independently from the installation layout.
+- Keep once-per-session invocation separate from the 7-day network guard.
+- Use the installed marketplace entry, not merely the manifest name, in plugin
+  identities and update commands.
+- Keep direct installs distinct from marketplace installs.
+- Require positive package and repository identity before using the Git channel.
+- Isolate Git cache entries by repository and exact clone root.
+- Preserve unrelated cache entries and use UTC dates.
+- Require source confirmation before looking up a loose copy in the official
+  public repository.
+- Match copied skill names to exact public marketplace skill paths.
+- Emit only update or replacement commands verified for the runtime host.
+- Continue non-blockingly after automatic checks.
 
 ## Prefer
 
-- Use Git CLI (Method A) or GitHub MCP tools (Method B) for version checking — these work with private repos
-- Fall back to the public GitHub REST API (Method C) **only** if Methods A and B both fail
-- Show a concise summary rather than overwhelming detail
-- Cache the check result in `~/.config/fabric-collection/last-update-check.json`
-- Provide copy-pasteable update commands
+- Use a root-local Git remote before authenticated GitHub tools.
+- Fetch version and changelog from the same repository ref.
+- Replace confirmed official loose copies through a complete native plugin
+  bundle rather than overwriting individual files.
+- Show concise, copy-pasteable output.
 
 ## Avoid
 
-- Blocking the user from using skills if update check fails
-- Checking on every skill invocation (once per week is sufficient)
-- Attempting Method C (public API) before trying Methods A or B
-- Relying solely on unauthenticated public API calls (will fail for private repos)
-- Auto-updating without user consent
+- Inferring installation context from the current working directory.
+- Letting `git` discover a parent repository.
+- Treating an unrelated package plus `.git` as a skills-for-fabric clone.
+- Inferring the runtime host from a manifest or install path.
+- Showing Copilot or Claude plugin commands to another host.
+- Defaulting focused bundles to `fabric-skills`.
+- Using GitHub Release tags as the plugin marketplace version.
+- Repeating failed automatic network checks every session.
+- Treating a same-named loose folder as proof that it came from the official
+  repository.
+- Replacing individual copied files without their complete bundle dependencies.
+- Updating without explicit user consent.
 
 ## Error Handling
 
-If the update check fails (network error, API rate limit, etc.):
+On failure, report the operation that failed and continue:
 
 ```text
-⚠️ Could not check for skills-for-fabric updates (network error).
-   Continuing with current version (v0.1.0).
-   Run '/skill check-updates' manually to retry.
+Could not check plugin:fabric-collection/fabric-consumption for updates: remote package.json was unavailable.
+Current installed version: 0.3.7
+The automatic check is non-blocking; continuing with the requested task.
 ```
 
-## Manual Invocation
-
-Users can manually check for updates at any time:
-- GitHub Copilot CLI: `/skill check-updates`
-- Other tools: Invoke the check-updates skill directly
-
-## Reference
-
-- **GitHub Repository**: https://github.com/microsoft/skills-for-fabric
-- **Releases**: https://github.com/microsoft/skills-for-fabric/releases
-- **CHANGELOG**: See `CHANGELOG.md` in repository root
+If the user says only "update my skills", clarify whether they want to check for
+an update or execute the detected native update command. Do not execute an
+update based on ambiguous intent.

--- a/plugins/fabric-consumption/skills/dataflows-consumption-cli/SKILL.md
+++ b/plugins/fabric-consumption/skills/dataflows-consumption-cli/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: dataflows-consumption-cli
 description: >
-  Monitor, inspect, and query saved Fabric Dataflows Gen2 via read-only CLI.
-  List dataflows, decode base64 definitions (mashup.pq, queryMetadata.json,
-  .platform), discover parameters, retrieve refresh status and job history,
-  classify queries by staging, and execute queries against saved dataflows via
-  the read-side `executeQuery` mashup engine (Arrow IPC response). Runs
-  persisted or ad-hoc read-only executeQuery requests; parses/renders Arrow
-  results. For previewing
-  candidate M before persisting, or for `supportedConnectionTypes`/`credentialType`
-  discovery and connection configuration, use `dataflows-authoring-cli`
-  (not this skill).
-  Triggers: "list dataflows", "inspect dataflow", "decode dataflow definition",
-  "dataflow parameters", "dataflow refresh status", "refresh history",
+  Monitor, inspect, and query saved Fabric Dataflows Gen2 with read-only CLI.
+  List dataflows, decode mashup.pq/queryMetadata.json/.platform, inspect parameters,
+  refresh status, job history, staging, and destinations, or run saved/ad-hoc
+  read-only executeQuery requests and parse Arrow. Handle explicit
+  requests to mutate through the Dataflows consumption or read-only path by
+  refusing the write; offer `dataflows-authoring-cli` only after separate
+  confirmation. For candidate M before persistence or connection configuration, use
+  `dataflows-authoring-cli`. Triggers: "list dataflows", "inspect dataflow",
+  "decode dataflow definition", "dataflow parameters", "refresh history",
   "last refresh status", "dataflow job history", "execute dataflow query",
-  "executeQuery saved query", "executeQuery fetch rows", "ad-hoc dataflow query",
-  "parse Arrow response", "Arrow IPC", "dataflow staging analysis".
+  "executeQuery saved query", "executeQuery fetch rows", "ad-hoc dataflow
+  query", "parse Arrow response", "Arrow IPC", "dataflow staging analysis",
+  "use Dataflows consumption path to delete", "Dataflows read-only mutation
+  refusal", "separate Dataflows authoring handoff".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -36,9 +35,12 @@ description: >
 > call (e.g. `az rest --method delete/put/patch` against a dataflow, or a POST that
 > creates/overwrites). The only permitted POSTs are the explicitly read-side
 > `getDefinition` and `executeQuery` operations documented below.
-> If the user asks to delete, create, modify, or persist a dataflow, **refuse the
-> mutation** and route them to `dataflows-authoring-cli` — do not run the destructive
-> command, even if the user provides the exact API call.
+> If the user asks to delete, create, modify, or persist a dataflow, **explicitly
+> refuse the mutation in the final response** and name
+> `dataflows-authoring-cli` only as a future handoff. Do not invoke that skill,
+> perform discovery in preparation for the write, or continue the write workflow
+> in the same turn. A mutation may begin only after the user explicitly confirms
+> a separate authoring request.
 
 # dataflows-consumption-cli — Dataflows Gen2 Consumption via CLI
 

--- a/plugins/fabric-consumption/skills/eventstream-consumption-cli/SKILL.md
+++ b/plugins/fabric-consumption/skills/eventstream-consumption-cli/SKILL.md
@@ -5,16 +5,16 @@ description: >
   the Items REST API. Discover Eventstreams across workspaces, decode base64 graph
   topologies tracing event flow from source through operators to destination nodes.
   Validate connection IDs, wiring, retention policies (1-90 days), and throughput
-  levels. Retrieve Custom Endpoint Kafka credentials via Topology API. Use to:
-  (1) list Eventstreams, (2) inspect Eventstream topology showing sources and
-  destinations, (3) validate Eventstream configurations, (4) check Eventstream
-  retention policy and throughput level, (5) get connection strings. Triggers:
-  "list eventstreams", "inspect eventstream", "inspect eventstream topology",
-  "eventstream sources and destinations",
-  "eventstream health", "eventstream configuration", "eventstream retention",
-  "eventstream retention policy", "eventstream throughput level",
-  "eventstream connection string", "custom endpoint credentials",
-  "kafka connection", "check eventstream".
+  levels. Retrieve Custom Endpoint Kafka credentials via Topology API. **Invoke
+  this skill** to: (1) list Eventstreams, (2) inspect Eventstream topology showing
+  sources and destinations, (3) validate Eventstream configurations, (4) check
+  Eventstream retention policy and throughput level, (5) get connection strings.
+  Triggers: "list eventstreams", "inspect eventstream",
+  "describe eventstream topology", "eventstream operator nodes",
+  "eventstream sources and destinations", "eventstream health",
+  "eventstream status", "eventstream configuration", "eventstream retention",
+  "eventstream throughput level", "eventstream connection string",
+  "custom endpoint credentials", "check eventstream".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -284,3 +284,247 @@ Decode `eventstreamProperties.json` and check:
 - Do NOT assume all source types appear in API enums — preview sources exist only in the UI
 - Do NOT modify Eventstream topology with this consumption skill — use `eventstream-authoring-cli` for writes
 - Do NOT attempt to query event data through the Eventstream API — use downstream skills (eventhouse-consumption-cli, sqldw-consumption-cli) for querying landed data
+
+---
+
+## Examples
+
+> **Platform note** — examples use PowerShell. Always write the JSON body to
+> a temp file via `[IO.File]::WriteAllText()` (no BOM) and pass
+> `--body "@$file"` to `az rest`, rather than inline `--body "..."` which
+> `cmd.exe` can mangle. Use `-Compress` with `ConvertTo-Json` to avoid
+> newline issues. The one safe inline exception is `--body '{}'` for empty bodies.
+> For large workspaces, check for `continuationUri` in list responses to handle
+> pagination.
+
+### Example 1: List All Eventstreams in a Workspace
+
+**Prompt**: "List all Eventstreams in my analytics workspace showing their names and IDs."
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+# 2. List Eventstreams (handles pagination)
+$allItems = @()
+$resp = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+$allItems += $resp.value
+while ($resp.continuationUri) {
+    $resp = az rest --method get `
+      --url $resp.continuationUri `
+      --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+    $allItems += $resp.value
+}
+$allItems | Select-Object displayName, id, description | Format-Table
+```
+
+### Example 2: Inspect Eventstream Topology
+
+**Prompt**: "Show me the topology of my SensorIngestion Eventstream — all sources, operators, and destinations."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get topology (returns JSON directly — no base64 decoding needed)
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+# 3. Summarize nodes (filter nulls from arrays)
+Write-Host "Sources:"
+@($topo.sources | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type), id: $($_.id))"
+}
+Write-Host "Operators:"
+@($topo.operators | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+Write-Host "Destinations:"
+@($topo.destinations | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+Write-Host "Streams:"
+@($topo.streams | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+```
+
+### Example 3: Check Retention and Throughput Settings
+
+**Prompt**: "What are the retention and throughput settings for my SensorIngestion Eventstream?"
+
+> **Note**: Retention and throughput settings are stored in the `eventstreamProperties.json`
+> part of the definition (not `eventstream.json`). If this part is absent, the Eventstream
+> uses platform defaults.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/items?type=Eventstream" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get definition (handles LRO if API returns 202)
+$respJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/getDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body '{}'
+if ($LASTEXITCODE -ne 0 -or -not $respJson) { throw "getDefinition request failed" }
+$resp = $respJson | ConvertFrom-Json
+
+if ($resp.definition) {
+    $def = $resp  # Synchronous — got definition immediately
+} elseif ($resp.operationId) {
+    # Asynchronous (LRO) — poll operation status
+    $def = $null
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') {
+            $def = (az rest --method get `
+              --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)/result" `
+              --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+            break
+        } elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "getDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+    if (-not $def.definition) { throw "getDefinition LRO timed out (last status: $($status.status))" }
+} else {
+    throw "getDefinition returned neither a definition nor an operationId"
+}
+
+# 3. Decode eventstreamProperties.json part (holds retention + throughput)
+$propsPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstreamProperties.json' } | Select-Object -First 1
+if ($propsPart) {
+    $props = [Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String($propsPart.payload)) | ConvertFrom-Json
+    Write-Host "Retention: $($props.retentionTimeInDays) days"
+    Write-Host "Throughput Level: $($props.eventThroughputLevel)"
+} else {
+    # Fall back to topology-level properties (older format)
+    $esPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstream.json' } | Select-Object -First 1
+    if (-not $esPart) { throw "eventstream.json part not found in definition" }
+    $topology = [Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String($esPart.payload)) | ConvertFrom-Json
+    if ($topology.properties.retentionTimeInDays) {
+        Write-Host "Retention: $($topology.properties.retentionTimeInDays) days"
+    } else {
+        Write-Host "Retention: (platform default — not explicitly configured)"
+    }
+    if ($topology.properties.eventThroughputLevel) {
+        Write-Host "Throughput Level: $($topology.properties.eventThroughputLevel)"
+    } else {
+        Write-Host "Throughput Level: (platform default — not explicitly configured)"
+    }
+}
+```
+
+### Example 4: Get Custom Endpoint Connection Metadata
+
+**Prompt**: "Get the Kafka connection metadata for the Custom Endpoint source in my SensorIngestion Eventstream."
+
+> **Security**: The connection endpoint returns access keys. Get user confirmation before
+> calling it and avoid logging raw credentials.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs (omitted for brevity)
+
+# 2. Get topology to find Custom Endpoint source ID
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+$ceSource = @($topo.sources | Where-Object { $_.type -eq 'CustomEndpoint' }) | Select-Object -First 1
+if (-not $ceSource) { throw "No CustomEndpoint source found in this Eventstream" }
+$sourceId = $ceSource.id
+
+# 3. Get connection metadata
+$conn = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/sources/$sourceId/connection" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+Write-Host "Fully Qualified Namespace: $($conn.fullyQualifiedNamespace)"
+Write-Host "Event Hub Name:            $($conn.eventHubName)"
+Write-Host "Kafka Bootstrap Server:    $($conn.fullyQualifiedNamespace):9093"
+```
+
+### Example 5: Validate Eventstream Configuration
+
+**Prompt**: "Check if my SensorIngestion Eventstream has any configuration issues."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs (omitted for brevity)
+
+# 2. Get topology
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+# 3. Validate sources
+@($topo.sources | Where-Object { $_ -ne $null }) | ForEach-Object {
+    $src = $_
+    Write-Host "Source: $($src.name) (type: $($src.type))"
+    if ($src.properties.dataConnectionId) {
+        Write-Host "  Cloud connection: $($src.properties.dataConnectionId)"
+    }
+    if ($src.type -in @('AzureEventHub','AzureEventHubExtended','AzureIoTHub','ConfluentCloud','ApacheKafka','AmazonMSKKafka') -and
+        -not $src.properties.consumerGroupName) {
+        Write-Host "  WARNING: No consumer group set (required for $($src.type))"
+    }
+}
+
+# 4. Validate destinations
+@($topo.destinations | Where-Object { $_ -ne $null }) | ForEach-Object {
+    $dst = $_
+    Write-Host "Destination: $($dst.name) (type: $($dst.type))"
+    if (-not $dst.inputNodes -or $dst.inputNodes.Count -eq 0) {
+        Write-Host "  WARNING: No input wired — destination will receive no events"
+    }
+    if ($dst.type -eq 'Eventhouse' -and -not $dst.properties.tableName) {
+        Write-Host "  WARNING: No target table configured"
+    }
+    if ($dst.type -eq 'Eventhouse' -and $dst.properties.dataIngestionMode -eq 'DirectIngestion') {
+        if (-not $dst.properties.connectionName -or -not $dst.properties.mappingRuleName) {
+            Write-Host "  WARNING: DirectIngestion requires connectionName and mappingRuleName"
+        }
+    }
+}
+
+# 5. Check node count limits
+$ceCount = @($topo.sources | Where-Object { $_.type -eq 'CustomEndpoint' }).Count +
+           @($topo.destinations | Where-Object { $_.type -eq 'CustomEndpoint' }).Count +
+           @($topo.destinations | Where-Object { $_.type -eq 'Eventhouse' -and
+             $_.properties.dataIngestionMode -eq 'DirectIngestion' }).Count
+Write-Host "CustomEndpoint + DI count: $ceCount / 11 limit"
+if ($ceCount -gt 11) {
+    Write-Host "WARNING: Exceeds limit of 11 CustomEndpoint + DirectIngestion nodes"
+}
+```

--- a/plugins/fabric-operations/.github/plugin/plugin.json
+++ b/plugins/fabric-operations/.github/plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "name": "fabric-operations",
   "description": "Operations skills for diagnosing Microsoft Fabric performance and health - system views, multi-step investigation workflows",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "MIT",
   "repository": "https://github.com/microsoft/skills-for-fabric",
   "keywords": [
@@ -15,6 +15,7 @@
   ],
   "skills": [
     "./skills/check-updates",
+    "./skills/azmon-mirroredcatalogs-operations-cli",
     "./skills/mlv-operations-cli",
     "./skills/sqldw-operations-cli",
     "./skills/sqldb-operations-cli",

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/SKILL.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/SKILL.md
@@ -1,0 +1,876 @@
+---
+name: azmon-mirroredcatalogs-operations-cli
+description: "Onboard Log Analytics, Application Insights, and Azure Monitor telemetry into Microsoft Fabric as a Mirrored Catalog, then turn it into business-impact insights by correlating telemetry with business data via Eventhouse shortcuts, verified schemas, and ready-to-use Operations Agent instructions. Triggers: onboard Log Analytics telemetry, connect Application Insights to a Mirrored Catalog, correlate App Insights telemetry with business data, build an Operations Agent for business-impact alerting, determine if availability or latency impacted bookings orders or revenue."
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+# azmon-mirroredcatalogs-operations-cli
+
+Guide a user end-to-end to (1) onboard Azure Monitor / Application Insights /
+Log Analytics observability data into Microsoft Fabric as a Mirrored Catalog
+(AzMon) item, and (2) turn that telemetry into **business-impact insights** by
+correlating observability signals with business data (bookings, orders,
+customers, flights, payments, revenue, tenants, accounts, subscriptions, usage
+KPIs, SLA/availability KPIs), ending in ready-to-paste **Operations Agent**
+instructions.
+
+This is a **self-contained Skills-for-Fabric package**. It does **not** depend on
+any MCP server or tool controller as the execution mechanism. Product/API
+knowledge, supported flows, guardrails, and modeling rules live in this file and
+in `references/*.md`.
+
+## Prerequisite Knowledge
+
+Before running this skill, read the shared common guidance:
+
+- [Authentication & token acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition)
+- [Authentication recipes](../../common/COMMON-CLI.md#authentication-recipes)
+
+## Trigger phrases
+
+- onboard Azure Monitor data into Fabric
+- create Azure Monitor item in Fabric
+- connect Application Insights to Fabric
+- correlate App Insights telemetry with business data
+- onboard my LA workspace to Fabric
+- onboard Log Analytics workspace to Fabric
+- connect Log Analytics workspace to Fabric
+- understand if service availability impacted bookings
+- understand if latency impacted conversion
+- correlate exceptions with revenue or orders
+- build Operations Agent for Azure Monitor business impact
+- create business impact insights from Log Analytics data
+
+## When to use this skill (and related skills)
+
+`azmon-mirroredcatalogs-operations-cli` is for onboarding Azure Monitor /
+Application Insights / Log Analytics telemetry into Microsoft Fabric
+(mirroredCatalogs endpoint), correlating that telemetry with business data, and
+generating Operations Agent instructions. For general Eventhouse / KQL querying
+unrelated to Azure Monitor onboarding, use `eventhouse-consumption-cli`; for
+authoring Eventhouse items and databases, use `eventhouse-authoring-cli`.
+
+## Reference index
+
+Read these when the corresponding stage needs product/API detail. Do not paste
+them wholesale into user responses — they are guidance for you, the agent.
+
+| Reference | Use it for |
+|-----------|-----------|
+| [references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md) | Supported vs UI-only flows; connector modes; Fabric item/agent surfaces |
+| [references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md) | Mirrored Catalog item CRUD, definition, discovery, monitoring, refresh |
+| [references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md) | Eventhouse/KQL, OneLake shortcuts, queryability requirement |
+| [references/operations-agent-reference.md](references/operations-agent-reference.md) | Operations Agent instruction template, validation, troubleshooting |
+| [references/app-insights-table-reference.md](references/app-insights-table-reference.md) | App Insights / Azure Monitor telemetry tables and business meaning |
+| [references/app-insights-dynamic-fields-reference.md](references/app-insights-dynamic-fields-reference.md) | Dynamic fields (Properties/CustomDimensions) and hidden business keys |
+| [references/business-correlation-patterns.md](references/business-correlation-patterns.md) | Signal → business-impact patterns and candidate keys |
+| [references/business-insight-modeling-reference.md](references/business-insight-modeling-reference.md) | Bins, derived entities, direct join vs time-window, thresholds |
+
+## Secrecy & scope guardrails
+
+- Do NOT expose Azure Log Analytics backend APIs to the user.
+- Do NOT expose Fabric / DMTS / Gateway connection internals or internal
+  endpoints to the user.
+- Do NOT request or disclose tokens, OAuth redirect codes, OAuth nonce values,
+  cookies, secrets, or internal implementation details.
+- Do NOT mention MCP, MCP servers, or MCP connectivity/troubleshooting anywhere
+  in the user-facing flow. This Skill is self-contained.
+- Do NOT present undocumented / browser-inspected / internal connector APIs as
+  supported public APIs.
+- Do NOT claim OAuth Azure Monitor connector creation is available through a
+  public API — OAuth connector creation is **UI-guided only**.
+- Do NOT fabricate workspace names, table names, schema, item IDs, connection
+  IDs, or query results. Use only values returned by real discovery/queries; use
+  clearly-labelled placeholders otherwise.
+- Do NOT ask the user for JOIN logic, KQL, bins, or thresholds upfront.
+- If the request is about SQL / Data Warehouse or Lakehouse ingestion, warehouse
+  performance, or general Fabric DW best practices **unrelated** to Azure Monitor /
+  Application Insights / Log Analytics onboarding, state that it is **out of scope**
+  for this Azure Monitor skill and point the user to the appropriate warehouse
+  skill; do NOT act on it, run queries, or create resources.
+
+### Domain-agnostic rule
+
+Business entities named anywhere in this Skill or its references — bookings,
+orders, customers, flights, revenue, tenants, payments, and similar — are
+**EXAMPLES ONLY** (non-normative illustrations). The Skill is **domain-agnostic**
+and MUST NOT infer or assume the user's business domain from these examples, from
+table/column names that resemble an example, or from any prior context. The
+user's actual business entities MUST be discovered from real Fabric data
+(Eventhouse / KQL database / Warehouse / Lakehouse / shortcuts) and confirmed with
+the user before use. Until discovered and confirmed, refer to them generically —
+as *business entities*, *business datasets*, *business KPIs*, or *business
+outcomes*.
+
+## EXECUTION CAPABILITY POLICY
+
+The Skill is a guided staged workflow; actual execution depends on capabilities
+available in the current environment. Portal-guided instructions are allowed ONLY
+for OAuth Azure Monitor connector creation — the Skill MUST NOT switch the entire
+onboarding flow to portal guidance as a generic fallback. For all non-OAuth
+stages, the Skill MUST first discover whether a supported execution path exists.
+
+Supported execution paths may include:
+
+- Fabric REST APIs
+- Azure REST APIs
+- Fabric Actions
+- Azure CLI
+- Azure Resource Graph
+- Fabric REST **read-only** discovery via authenticated `az rest --method get`
+  against `https://api.fabric.microsoft.com/...` (discovery/read-only only)
+- Other documented supported capabilities available to the agent
+
+**Log Analytics REST API reference (agent-facing).** When the Skill needs to perform or validate Azure Log Analytics operations, it may consult the official [Log Analytics REST APIs](https://learn.microsoft.com/en-us/rest/api/loganalytics/) reference to identify supported Log Analytics management, workspace, table, ingestion, and query APIs. This is agent-facing guidance only and does not relax the secrecy rule above.
+
+These execution paths are distinct and MUST NOT be conflated:
+
+1. **Kusto / KQL data-plane execution** — telemetry queries; optional, and MUST
+   NOT be used when disabled.
+2. **Azure ARM control-plane discovery** — resource/metadata enumeration.
+3. **Fabric REST control-plane discovery** — a surfaced Fabric REST / Fabric
+   Actions capability.
+4. **Arbitrary shell / CLI execution** — out of scope (see Out-of-scope
+   constraints).
+5. **Fabric REST read-only discovery via authenticated `az rest --method get`** —
+   a narrow GET-only exception for Fabric discovery/read against
+   `https://api.fabric.microsoft.com/...`; never mutates anything and never
+   exposes tokens, secrets, or auth headers. NOT general shell/CLI access.
+
+MCP unavailability alone does NOT mean execution capability is unavailable.
+Unavailability of any single execution path does NOT imply the capability is
+unavailable. Before declaring a capability unavailable, the Skill MUST evaluate
+ALL supported execution paths listed above and confirm none is available.
+
+If no supported execution path exists, the Skill MUST: stop; identify the missing
+capability; explain why it is required; identify which stage is blocked; and wait
+for user confirmation.
+
+The Skill MUST NOT replace validation, Mirrored Catalog creation, discovery,
+monitoring, refresh, shortcut creation, schema verification, or Operations Agent
+creation with portal guidance, and MUST NOT claim an action completed when
+execution capability is unavailable.
+
+
+## PORTAL GUIDANCE POLICY
+
+Prefer automated execution paths (Fabric REST, Azure REST, Fabric Actions, Azure
+CLI, other supported automation) over UI-guided instructions. Before providing
+UI-guided instructions the Skill MUST: (1) evaluate the available execution paths,
+(2) attempt supported ones where available, (3) explain which were evaluated and
+why they cannot be used. OAuth Azure Monitor connector creation is the one
+explicitly supported UI-guided scenario and is exempt from this evaluation.
+
+
+## STRICT STAGED WORKFLOW CONTROLLER (ENFORCED)
+
+The Skill MUST operate as a strict staged workflow controller.
+
+### Stages
+
+1. Intent and scope
+2. Log Analytics workspace selection
+3. Fabric workspace selection
+4. Validation
+5. Connection resolution
+6. AzMon / Mirrored Catalog item creation or reuse
+7. **Business Insight Capture** (immediately after item creation/reuse)
+8. Azure Monitor table discovery
+9. Eventhouse / KQL database selection
+10. Shortcut planning
+11. Shortcut creation
+12. Schema and data verification
+13. Business data discovery and scoring
+14. Correlation planning
+15. Operations Agent instruction generation
+16. Optional Operations Agent creation / validation
+
+### Execution rules
+
+- The Skill MUST track and enforce the current stage.
+- The Skill MUST NOT skip stages.
+- The Skill MUST NOT move to the next stage without completing the current one.
+
+### Stage visibility (REQUIRED in every user-facing response)
+
+Begin every response with exactly this structure:
+
+```text
+Current stage: <stage name>
+What I found:
+<short summary>
+
+Next step:
+<one clear action>
+
+Waiting for your confirmation to continue.
+```
+
+If the current stage is unclear → **STOP** and ask the user where to resume.
+
+**Stage 15 exemption (ready-to-paste block).** The Stage 15 Operations Agent
+instructions are delivered as ONE self-contained, ready-to-paste fenced block.
+For that response only, place the stage-visibility header and the
+`Waiting for your confirmation to continue.` line OUTSIDE and AROUND the fenced
+block — the header (and a one-line summary) immediately before it, the
+confirmation line immediately after it. Do NOT insert the header, summary,
+`What I found` / `Next step` labels, or the confirmation line INSIDE the
+ready-to-paste block: the fenced block must contain only the Operations Agent
+instructions so the user can copy it verbatim.
+
+### Hard stop behavior
+
+After presenting any step that requires confirmation:
+
+- **STOP.**
+- **WAIT** for explicit user confirmation.
+- Do **not** continue automatically.
+
+### Confirmation gates (explicit confirmation REQUIRED before)
+
+- Creating or reusing any resource that modifies Fabric.
+- Selecting an Eventhouse / KQL database.
+- Creating shortcuts.
+- Proceeding from schema verification (Stage 12) to correlation planning
+  (Stage 14).
+- Generating final Operations Agent instructions if the correlation model has
+  not been confirmed.
+- Creating or modifying an Operations Agent.
+
+### Stage guardrails
+
+- Shortcut planning (Stage 10) MUST occur before schema verification or join
+  logic. If schema/join is attempted early → STOP and return to shortcut
+  planning.
+- Shortcut creation (Stage 11) MUST complete before schema verification.
+- Schema verification (Stage 12) MUST complete before correlation planning
+  (Stage 14).
+- If data is not queryable in Eventhouse via shortcuts → STOP → return to
+  shortcut planning / creation.
+- Correlation planning MUST NOT begin until data queryability via shortcuts is
+  confirmed.
+- Business Insight Capture (Stage 7) MUST be satisfied (intent provided OR a
+  suggested direction explicitly selected) before correlation planning. Never
+  assume intent.
+
+### Out-of-scope constraints
+
+The Skill MUST NOT run arbitrary shell/CLI/az/PowerShell commands, perform network
+debugging, investigate server connectivity, or execute infrastructure
+troubleshooting. These are out of scope unless explicitly part of the current
+stage.
+
+**Narrow exception — Fabric REST read-only discovery.** The Skill MAY use an
+authenticated `az rest --method get` call ONLY for Fabric REST read-only
+discovery, and ONLY when ALL hold: endpoint is
+`https://api.fabric.microsoft.com/...`; method is **GET** only; the operation is
+discovery/read-only; nothing is created, updated, deleted, or modified; no tokens,
+secrets, auth headers, or sensitive payloads are exposed; and the Skill states the
+capability path used. This exception does NOT permit arbitrary shell/CLI
+execution, non-GET `az rest` calls, or use of the Kusto / KQL data-plane when
+disabled.
+
+### Response style (ENFORCED)
+
+Behave like a **guided product experience**, not a backend debugger.
+
+- Use concise, business-friendly language.
+- Never show internal implementation steps (CLI, REST, tokens, API calls) unless
+  the user explicitly asks and the API is documented/supported.
+- Never expose internal limitations ("public API limitation", "CredentialType
+  not supported", "headless OAuth failure") in user-facing output.
+- Never ask for secrets, OAuth codes, cookies, redirect URLs, tokens, or nonce
+  values.
+- Summarize findings. Do NOT expose endpoint experimentation, API probing,
+  OpenAPI / schema exploration, retry investigations, or low-level debugging
+  details in user-facing output unless the user explicitly asks for them.
+- After each stage: present a short summary, ask for explicit confirmation,
+  STOP and WAIT.
+
+---
+
+## Stage 1 — Intent and scope
+
+Confirm what the user wants: onboard observability data into Fabric, explore a
+business insight, or both. Capture (in plain language) any workspace names or
+business outcome they already mention — but do not yet drive correlation.
+
+## Stage 2 — Log Analytics workspace selection
+
+Application Insights telemetry is queried through its backing Log Analytics
+workspace (workspace-based Application Insights). Help the user pick the correct
+Log Analytics / Application Insights-backed workspace.
+
+- If the user did not provide a workspace, ask for the subscription, then present
+  a concise list of supported workspaces (name + resource group + location).
+  Never expose raw API responses.
+- Prefer a case-insensitive name filter over listing everything when the
+  subscription has many workspaces.
+
+### Exact-name-not-found fallback (REQUIRED)
+
+When the user names a workspace and no **exact** match exists, the Skill MUST NOT
+fail. Instead:
+
+1. Ask for the subscription if not provided (do not guess).
+2. Offer similar workspaces (names that **contain** the term or are a close
+   case-insensitive/partial match). Broaden the search if a narrow filter returns
+   nothing.
+3. Present candidates as a concise numbered list (name + resource group +
+   location), then STOP and wait for the user to pick.
+4. If exactly one similar workspace is found, still confirm before proceeding.
+5. If none is found, say so plainly and ask for a different subscription or term.
+
+Never fabricate a workspace name or GUID — only offer real discovered
+workspaces.
+
+## Stage 3 — Fabric workspace selection
+
+Help the user choose the target Fabric workspace (display name + id). Use a
+case-insensitive substring filter when helpful. Read-only; nothing is created
+here. Never expose raw API responses or tokens.
+
+### Fabric Workspace Discovery & Capability Resolution Policy (REQUIRED)
+
+Fabric workspaces are **not** ARM resources, so missing automatic enumeration does
+NOT mean no workspace exists. Follow the full required policy in
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md#fabric-workspace-discovery--capability-resolution):
+discover all surfaced Fabric mechanisms first (Fabric REST/Actions, OneLake/Power
+BI, and read-only `az rest --method get` against `https://api.fabric.microsoft.com/...`);
+never terminate on missing enumeration; ask the user for a workspace Name / ID /
+URL; validate before continuing; and mark Stage 3 BLOCKED only after ALL discovery
+AND user-supplied paths are exhausted. UI-guided selection is the final fallback only.
+
+## Stage 4 — Validation
+
+Before any creation, verify:
+
+- The workspace exists.
+- The workspace is **not Sentinel** or otherwise unsupported.
+- The caller has the required Log Analytics access.
+- The caller has sufficient Fabric workspace permission to create the item.
+
+If validation fails, summarize which checks passed/failed in user terms, explain
+the missing capability, and offer to try another workspace or request access.
+See `references/azmon-fabric-api-reference.md` for supported-scope rules.
+
+### Sentinel detection source hierarchy (REQUIRED)
+
+Sentinel detection is a **control-plane** check and MUST NOT be treated as
+dependent on Kusto / KQL data-plane availability. Follow the full required
+hierarchy in
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md#sentinel-detection-source-hierarchy):
+enumerate ARM resources / `Microsoft.OperationsManagement/solutions`
+`SecurityInsights(<workspaceName>)` / `Microsoft.SecurityInsights/*` /
+feature metadata, then classify as **Sentinel / blocked**, **Not Sentinel
+(control-plane verified)**, or — only if all checks are unavailable —
+**not verifiable**. Never fabricate Sentinel status.
+
+### Validation capability discovery (REQUIRED)
+
+Apply the [EXECUTION CAPABILITY POLICY](#execution-capability-policy): evaluate ALL
+supported execution paths (Fabric REST, Azure REST, Fabric Actions, Azure CLI,
+Azure Resource Graph) before declaring validation capability unavailable. MCP is
+only one possible path.
+
+## Stage 5 — Connection resolution
+
+Two connection modes are supported. Keep them **separate**. Never route OAuth
+through Service Principal logic, and never route Service Principal through OAuth /
+interactive sign-in logic. See
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md)
+for the authoritative connector rules.
+
+### Portal guidance boundary
+
+Portal-guided instructions are permitted ONLY for OAuth Azure Monitor connector creation.
+
+Portal guidance is NOT an allowed fallback for:
+
+- LAW validation
+- Fabric workspace validation
+- Connection detection
+- Connection reuse
+- Service Principal connector creation
+- Mirrored Catalog item creation
+- Discovery
+- Monitoring
+- Refresh
+- Eventhouse shortcut creation
+- Schema verification
+- Operations Agent creation
+
+If execution capability for these actions is unavailable, the Skill MUST stop and identify the missing capability.
+
+### Mode A — OAuth (UI-guided only)
+
+- OAuth connector **creation** is interactive, done once in **Fabric → Manage
+  Connections**. The Skill does **not** create OAuth connectors through any API.
+- The Skill **detects and reuses** an existing Azure Monitor OAuth connection for
+  this workspace (read-only, non-destructive).
+- Before classifying OAuth connection detection as "not verifiable", attempt the
+  available Fabric REST **read-only** connection discovery paths, in order:
+  1. A surfaced Fabric REST / Fabric Actions capability, if available.
+  2. Authenticated Fabric REST read-only discovery via `az rest --method get`
+     against `https://api.fabric.microsoft.com/...`, if Azure CLI execution is
+     available and permitted under the read-only Fabric REST discovery exception
+     (GET-only, no modifications, no secret/token/header exposure, capability
+     path stated). This detection is read-only; OAuth connector **creation**
+     remains UI-guided only.
+- Reuse a connection ONLY if it belongs to the **same** Log Analytics workspace
+  (exact data-source-path / LAW resource-id match). Any mismatch → treat as "no
+  matching connection".
+- If exactly one match → reuse automatically and continue.
+- If multiple matches → show display names and ask the user to choose (never
+  auto-pick).
+- If no match → guide the user with this exact, simple message and then WAIT:
+
+```text
+I couldn’t find an existing Azure Monitor connection for this workspace.
+Please create it once in Fabric Manage Connections, then come back and continue.
+
+1. Open Fabric.
+2. Go to Manage Connections.
+3. Select New connection → Azure Monitor.
+4. Sign in with your organizational account.
+5. Use the same Log Analytics Workspace.
+6. When done, come back here and type: Done.
+```
+
+When the user resumes, re-detect and continue automatically ("Connection
+detected. Continuing setup.").
+
+### Mode B — Service Principal (automated create-or-reuse)
+
+Present this as **"connect using Service Principal"** — the automated,
+non-interactive path (no user login, no UI step).
+
+- **Idempotent create-or-reuse**: if a matching Azure Monitor Service Principal
+  connector already exists for the same Log Analytics workspace (same data source
+  path + Service Principal credential type), reuse it — never create a duplicate.
+- Only **one** connector is created per run.
+- **Never** reuse a non-Service-Principal (e.g. OAuth) connector in this mode.
+- **Never** ask the user to paste a client secret into chat. Secrets come from
+  **environment variables or Key Vault references** only, are never echoed,
+  logged, exposed, or included in generated instructions.
+- If required Service Principal inputs are missing, describe **what** is missing
+  (tenant id, app/client id, and a securely-provided secret reference) using
+  presence checks only — never request the secret value in chat.
+
+Automation boundary: infrastructure (connector create-or-reuse, mirrored item
+creation) is automated; **business decisions** (Eventhouse/KQL DB selection,
+shortcut creation) always require explicit user confirmation.
+
+## Stage 6 — AzMon / Mirrored Catalog item creation or reuse
+
+Create the Azure Monitor **Mirrored Catalog** item in the target Fabric
+workspace, or reuse an existing matching item. This is a Fabric-modifying action
+→ confirm first. Supported Mirrored Catalog operations (item CRUD, definition,
+discovery, monitoring, refresh) are documented in
+[references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md).
+
+After the item is created or reused, immediately proceed to Business Insight
+Capture (Stage 7).
+
+## Stage 7 — Business Insight Capture (MANDATORY, happens here — early)
+
+Immediately after the AzMon item is created or reused, ask the user **what
+business insight they want to explore**, so discovery and table selection are
+guided by the business outcome.
+
+Ask in business language, e.g.:
+
+- Did service availability issues impact bookings?
+- Did request latency reduce customer conversions?
+- Did exceptions affect revenue or orders?
+- Did dependency failures impact specific customers, tenants, regions, or
+  flights?
+- Did incidents affect SLA, usage, or customer activity?
+- Did traffic drops correlate with usage KPI degradation?
+
+### Enforcement
+
+The Skill MUST NOT proceed to business correlation without either:
+
+- (a) user-provided business intent, OR
+- (b) explicit user selection from suggested directions.
+
+Never assume intent.
+
+### Fallback (when the user is unsure / vague / no exact match)
+
+Suggest 3–5 directions, each framed as **observability signal → business
+impact**, and ask the user to choose one:
+
+1. Availability failures → booking completion impact.
+2. Request latency → conversion or checkout drop.
+3. Exceptions → failed orders or revenue at risk.
+4. Dependency failures → customer / tenant / region impact.
+5. Traffic drops → usage KPI degradation.
+
+### Important distinction
+
+Capturing intent early is allowed and required. But the Skill MUST NOT generate
+correlation logic yet. Correlation logic only comes after shortcuts exist, schema
+is verified, data is queryable, dynamic fields are inspected, join candidates are
+validated, and data freshness is checked (Stages 10–14).
+
+## Stage 8 — Azure Monitor table discovery
+
+Browse candidate Azure Monitor / Application Insights tables relevant to the
+captured business goal. Use only real discovered scope/table values — never
+fabricate table names. Use
+[references/app-insights-table-reference.md](references/app-insights-table-reference.md)
+to explain what each table means in business terms and which tables best fit the
+stated goal.
+
+### Discovery API fallback policy (REQUIRED)
+
+The **primary** discovery mechanism is the Mirrored Catalog Discovery APIs. If
+discovery appears incomplete, do NOT immediately conclude tables are missing or
+switch to alternative metadata paths. First:
+
+1. Verify mirror status.
+2. Verify refresh / sync status.
+3. Verify discovery scope.
+4. Retry discovery.
+
+Only after these checks may the Skill evaluate alternative metadata paths. See
+[references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md).
+
+## Stage 9 — Eventhouse / KQL database selection
+
+Before asking the user to choose an Eventhouse, run **Eventhouse Recommendation
+Mode**:
+
+1. **Discover** available Eventhouses.
+2. **Inspect** their available contents (tables, shortcuts, KQL databases).
+3. **Score** each Eventhouse.
+4. **Present** a recommendation.
+
+Score each Eventhouse by:
+
+- Relevant business tables
+- Relevant telemetry tables
+- Existing shortcuts
+- Queryable tables
+- KQL database availability
+- Data freshness
+- Alignment to the selected business goal
+
+Present the result in this format:
+
+```text
+Recommended Eventhouse:
+<EventHouseName>
+
+Reason:
+<why this Eventhouse was chosen>
+
+Alternative Eventhouses:
+<list>
+```
+
+The Skill MUST NOT auto-select, even when one Eventhouse scores highest. This is a
+user decision (confirmation gate) — present the recommendation and **require
+explicit confirmation** before proceeding. See
+[references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md).
+
+## Stage 10 — Shortcut planning
+
+Plan OneLake shortcuts from the AzMon item's tables into the selected
+Eventhouse / KQL database **before** any schema verification or join logic.
+Present the plan and STOP for confirmation.
+
+Key rules (see the shortcuts reference for detail):
+
+- Keep source table names **exact** — a renamed shortcut may create the OneLake
+  link but fail to register as a queryable KQL table.
+- A OneLake link alone is **not** enough — the table must be registered as an
+  external/queryable table.
+
+### Shortcut acceleration (SHOULD)
+
+Query acceleration on shortcuts SHOULD be treated as the preferred configuration
+because testing showed schema verification, queryability validation, telemetry
+sampling, correlation analysis, and Operations Agent preparation became
+substantially faster when acceleration was enabled. Present the shortcut plan with
+an acceleration column:
+
+| Shortcut Name | Source | Target | Acceleration Supported (Yes/No) | Acceleration Enabled (Yes/No) |
+|---------------|--------|--------|---------------------------------|-------------------------------|
+
+If acceleration is disabled, explain the potential impact on: queryability
+validation, schema verification, telemetry sampling, correlation analysis, and
+Operations Agent preparation. Do NOT assume acceleration exists in every
+environment — use SHOULD, not MUST. See
+[references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md).
+
+## Stage 11 — Shortcut creation
+
+Only after explicit confirmation, create the planned shortcuts. Then verify each
+table is actually **queryable** in Eventhouse (e.g. `<Table> | take 1`). Do not
+assume a OneLake link means the table is queryable. If a table is not queryable →
+STOP and return to shortcut planning / creation.
+
+When creating ANY shortcut, apply the **Shortcut Acceleration Policy**:
+
+1. Determine whether acceleration is supported for the shortcut.
+2. Determine its current acceleration status.
+3. Enable acceleration when supported and appropriate (preferred configuration).
+4. Report the acceleration status back to the user.
+
+## Stage 12 — Schema and data verification (REQUIRED before correlation)
+
+Never build correlation logic on assumptions or screenshots. Before proposing any
+join, bin, or threshold, verify against the **actual** KQL database.
+
+### Preconditions
+
+1. Operational telemetry tables are available in the Eventhouse / KQL database.
+2. Business tables are available in the same database or queryable via shortcuts.
+3. Tables are **queryable**, not just visible in OneLake.
+4. Schema retrieved via `getschema`.
+5. Dynamic fields inspected and sampled.
+6. Candidate join keys extracted from top-level **and** dynamic columns.
+7. Join keys validated with **non-zero** match results (when a direct join is
+   proposed).
+8. Data freshness verified.
+9. Time window aligned to the real data range.
+10. Relevant categorical values confirmed from real data where rules depend on
+    them.
+
+### Steps
+
+1. **Retrieve real schema.** For each table:
+   `TableName | getschema | project ColumnName, ColumnType`. Use authoritative
+   column names/types — not names guessed from screenshots or table names.
+2. **Inspect and sample dynamic fields.** Business join keys are often nested in
+   dynamic columns (`Properties`, `CustomDimensions`, `Details`, `Measurements`,
+   `Payload`, `Context`). Sample rows and inspect keys. See
+   [references/app-insights-dynamic-fields-reference.md](references/app-insights-dynamic-fields-reference.md).
+3. **Extract candidate business identifiers** with explicit KQL
+   (`tostring(Properties.BookingId)`, with casing fallbacks via `coalesce`).
+4. **Validate join keys against real data.** Prove a candidate joins — run the
+   join and confirm non-zero matches:
+
+   ```kusto
+   AppEvents
+   | extend BookingId = tostring(Properties.BookingId)
+   | where isnotempty(BookingId)
+   | join kind=inner (Bookings | project BookingId = tostring(BookingId)) on BookingId
+   | summarize MatchedRows=count(), DistinctBookings=dcount(BookingId)
+   ```
+
+   Non-zero → **direct join, high confidence**. Zero → the key is wrong or data
+   doesn't overlap; find the real one.
+5. **Check freshness and align the window.**
+   `TableName | summarize Rows=count(), MinTime=min(TimeGenerated), MaxTime=max(TimeGenerated)`.
+   Do not assume `ago(1h)`; use a window covering the actual data range and
+   explain it in user terms.
+6. **Confirm categorical values** used by rules
+   (`Table | summarize count() by <field>`) so impact rules use real categories.
+
+### Telemetry source selection framework (REQUIRED)
+
+Telemetry source selection MUST be **data-driven**. Before selecting a correlation
+model, the Skill MUST inspect ALL candidate telemetry sources discovered (e.g.
+AppEvents, AppExceptions, AppRequests, AppDependencies, AppTraces, AppPageViews,
+AppBrowserTimings, AvailabilityResults, and any other telemetry source present) —
+not just one.
+
+Score each candidate telemetry source by:
+
+1. Business identifiers discovered.
+2. Dynamic-field richness.
+3. Direct-join confidence.
+4. Validated match count.
+5. Business-process context.
+6. Relevance to the selected business goal.
+
+Select the highest-scoring telemetry source. The Skill MUST NOT automatically
+prioritize AppExceptions, and MUST NOT automatically prioritize AppEvents — the
+winner is whichever source scores highest against real data.
+
+### Exit criteria (MANDATORY)
+
+Before Stage 14, ALL must hold: schema retrieved via `getschema`; join keys
+validated with non-zero matches (when a direct join is used); freshness verified
+and window aligned; relevant categorical values confirmed. If any fails → STOP,
+do not proceed.
+
+### Handoff (MANDATORY)
+
+Present a concise summary (verified join keys, match results, business impact if
+any, data time window). Then ask: "Do you want to generate Operations Agent
+instructions based on this verified model?" HARD STOP and wait.
+
+## Stage 13 — Business data discovery and scoring
+
+Business tables are **not** expected to exist in Log Analytics. They may live in
+an Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts.
+Absence of business tables in Log Analytics MUST NOT be interpreted as absence of
+business data — discover them across the available Fabric data surfaces.
+
+If the exact business table or join is not known, do **not** fail. Score
+candidate business databases/tables by likely relevance to the stated goal,
+present a ranked list with explanation, propose shortcut creation for the top
+candidates, and ask the user to choose. Never conclude "no correlation is
+possible" without presenting options. Scoring hints are in
+[references/business-correlation-patterns.md](references/business-correlation-patterns.md).
+
+## Stage 14 — Correlation planning
+
+The user should not need to know joins, KQL, thresholds, or bins. Infer
+candidates from verified top-level schema, verified dynamic fields, sampled
+values, business table schema, actual join test results, and data freshness. When
+asking for confirmation, ask about **business meaning**, not SQL/KQL, e.g.:
+
+> "I found `BookingId` inside `AppEvents.Properties` and it matches
+> `Bookings.BookingId`. Should I treat this as the booking identifier for
+> business impact?"
+
+Present a correlation plan (see
+[references/business-insight-modeling-reference.md](references/business-insight-modeling-reference.md))
+including: operational signal; business impact table; verified join keys;
+whether the join came from top-level columns or dynamic fields; match
+count/validation result; time window + freshness status; proposed bin size;
+metrics and thresholds. Then ask for confirmation and STOP.
+
+Default modeling guidance: prefer **direct joins** when verified identifiers
+exist; use **time-window correlation** only when no direct identifier is found
+(and state clearly it shows correlation, not causality); default bin size **5
+minutes** (larger when data is sparse or KPIs are slower); default derived entity
+**IncidentBin**.
+
+### Correlation planning validation (REQUIRED)
+
+When finalizing the correlation model, the Skill MUST explain **why** the selected
+telemetry source was chosen, justified using real data. Include:
+
+- Match counts.
+- Business identifiers discovered.
+- Direct-join confidence.
+- Validation results.
+
+## Stage 15 — Operations Agent instruction generation
+
+Only after the correlation model is confirmed. Produce a single clean copy/paste
+block using the template in
+[references/operations-agent-reference.md](references/operations-agent-reference.md).
+
+> **Wrapper exemption:** deliver the instructions as ONE self-contained fenced
+> block. Put the stage-visibility header and the
+> `Waiting for your confirmation to continue.` line OUTSIDE the block (before and
+> after it) — never inside — so the copy/paste block stays clean. See
+> [Stage visibility](#stage-visibility-required-in-every-user-facing-response).
+
+The instructions MUST include **explicit KQL**, not conceptual descriptions:
+
+- One verbatim **IncidentBin materialization query** whose **output columns are
+  exactly the alert fields** (includes the `tostring(Properties.x)` extraction,
+  the explicit `join`, and the exact aggregations).
+- A per-field KQL definition list mapping each output column to a one-line
+  expression.
+- Alert rules that reference **actual output columns**.
+
+Include **both** threshold sets:
+
+- **Production-like:** e.g. ErrorCount increases by more than 20% versus the
+  previous-hour baseline; AffectedCustomers ≥ configured business threshold;
+  RevenueAtRisk ≥ configured business threshold.
+- **Relaxed POC / debug:** e.g. `ErrorCount >= 1`; `ErrorCount >= 5 and
+  AffectedBusinessRecords >= 1`; `AffectedCustomers >= 1`.
+
+Required sections: Goal, Data sources, Field mapping definitions, Dynamic field
+extraction logic, Derived analysis entity, IncidentBin materialization query,
+Metric definitions, Correlation logic, Impact logic (production + POC), Alert
+behavior, Output requirements, Validation / POC mode.
+
+### PLAYBOOK MATERIALIZATION REQUIREMENT (MANDATORY)
+
+Testing demonstrated that instructions and KQL **text alone are NOT sufficient**
+for playbook generation — the Fabric Playbook Generator must be able to discover
+the alert fields directly from a real schema object. Before generating Operations
+Agent rules, the Skill MUST:
+
+1. **Materialize IncidentBins** as a real, queryable schema object (a physical
+   table or a function-backed table in the KQL database).
+2. **Expose the alert fields as physical output columns** on that object.
+3. **Verify the schema exists** (e.g. `IncidentBins | getschema`).
+
+Required output columns:
+
+- IncidentBin
+- ErrorCount
+- AffectedCustomers
+- AffectedBookings
+- RevenueAtRisk
+- TopImpactedEntities
+- TopImpactedSteps
+
+The Playbook Generator MUST be able to discover these fields directly from the
+materialized schema. KQL instructions alone are NOT sufficient. Business-specific
+column names (for example `AffectedBookings`, `TopImpactedFlights`) adapt to the
+business entities actually discovered in the data.
+
+## Stage 16 — Optional Operations Agent creation / validation
+
+Offer to create the Operations Agent in the user's Fabric workspace and attach the
+Eventhouse / KQL database that holds the verified data. Confirm target workspace
+and KQL database before creating anything. Then guide validation (start with POC
+thresholds so an alert fires on sparse seed data, then switch to production
+thresholds). See
+[references/operations-agent-reference.md](references/operations-agent-reference.md)
+for creation surface and troubleshooting.
+
+## Troubleshooting (user-facing)
+
+- **"No playbook generated" / cannot compute a field** → the instructions
+  described fields conceptually. Add the explicit KQL materialization query, add
+  per-field KQL definitions, ensure alert rules reference actual output columns,
+  add dynamic-field extraction, and clarify join keys/identifiers. Do not just
+  reword prose.
+- **Start succeeds but no Teams alert arrives** → likely no data matched the
+  rule. Switch to POC/debug thresholds; explain no data may have matched. Do not
+  imply platform failure without evidence.
+
+## Must / Prefer / Avoid
+
+### Must
+- Enforce stages, hard stops, and confirmation gates.
+- Keep OAuth (UI-guided) and Service Principal (automated create-or-reuse)
+  strictly separate.
+- Validate Sentinel and permissions before creation.
+- Verify schema, dynamic fields, join matches, and freshness before correlation.
+- Provide explicit KQL in Operations Agent instructions.
+
+### Prefer
+- Direct joins over time-window correlation.
+- Real discovered values over anything guessed.
+- Business-language confirmation over technical questions.
+
+### Avoid
+- Do not depend on or mention MCP in the user-facing flow.
+- Do not present internal/undocumented APIs as supported.
+- Do not claim OAuth connector creation via public API.
+- Do not fabricate workspaces, tables, schema, IDs, or query results.
+- Do not ask for secrets, OAuth codes, tokens, cookies, or nonces.
+- Do not claim causality when only time-window correlation exists.
+
+## Examples
+
+### Example 1 — Onboard Azure Monitor observability data, then check business impact
+**User:** "In my `Observability` workspace, onboard our Azure Monitor / Log Analytics observability data (it holds our Application Insights tables) into Fabric, then tell me whether last week's latency spike hurt checkout conversions."
+
+**Skill behavior:** Runs the staged workflow — confirms the target workspace and checks onboarding prerequisites (a reachable Azure Monitor / Log Analytics source or connection), stopping with an explicit list of what is missing if any prerequisite is absent. Once the observability data (including the Application Insights telemetry tables) is onboarded and queryable, it discovers the real business dataset in the workspace, correlates the latency signal against the conversion KPI using discovered keys, and reports a specific business-impact conclusion (or an error if the required data is unavailable). It never fabricates workspace names, tables, or query results, and never exposes tokens or connection internals.
+
+### Example 2 — Out-of-scope authoring request
+**User:** "Create a new Spark notebook and build a Delta table pipeline to load my business dataset."
+
+**Skill behavior:** Declines the out-of-scope authoring request, creates nothing in Fabric, and directs the user to the appropriate authoring skill (for example `spark-authoring-cli`) rather than taking over the task.

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-dynamic-fields-reference.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-dynamic-fields-reference.md
@@ -1,0 +1,175 @@
+# Application Insights dynamic fields reference
+
+**Critical:** many telemetry-to-business JOIN keys are **not** top-level columns.
+In Application Insights / Azure Monitor tables, business identifiers are often
+nested inside dynamic JSON-like columns. Schema verification MUST include
+dynamic-field inspection — never rely on top-level schema alone.
+
+## Common dynamic / object columns to inspect
+
+- `Properties`
+- `CustomDimensions`
+- `Details`
+- `Measurements`
+- `Payload`
+- `Context`
+- `customDimensions`
+- `customMeasurements`
+
+## Business identifiers that commonly hide inside dynamic fields
+
+`BookingId`, `booking_id`, `OrderId`, `order_id`, `CustomerId`, `customer_id`,
+`UserId`, `user_id`, `UserAuthenticatedId`, `TenantId`, `tenant_id`, `AccountId`,
+`FlightId`, `flight_number`, `PassportId`, `passport`, `SubscriptionId`,
+`CorrelationId`, `OperationId`, `SessionId`, `Region`, `Country`, `ProductId`,
+`ServiceName`.
+
+## High-priority Application Insights tables for dynamic-field inspection
+
+Before falling back to time-window correlation, inspect dynamic fields in the
+following order:
+
+Inspect these tables wherever they are queryable in the target KQL database —
+**including telemetry that is already present as a native table**, not only the
+shortcuts created in Stage 11. A business join key (e.g. `AppEvents.Properties`)
+may already exist in the Eventhouse independently of the mirrored-catalog
+shortcuts, so enumerate all telemetry tables in the database during Stage 12/13.
+
+1. AppEvents
+   - Properties
+   - Measurements
+   - Typical business identifiers:
+     BookingId, OrderId, CustomerId, FlightId, SessionId, UserId
+
+2. AppExceptions
+   - Properties
+   - Details
+   - Typical business identifiers:
+     PassportId, BookingId, CustomerId, TenantId, OperationId
+
+3. AppRequests
+   - Properties
+   - Typical business identifiers:
+     OperationId, SessionId, CustomerId, OrderId
+
+4. AppDependencies
+   - Properties
+   - Typical business identifiers:
+     CorrelationId, OrderId, TenantId, AccountId
+
+5. AppTraces
+   - Properties
+   - Typical business identifiers:
+     BookingId, CustomerId, OrderId, SessionId
+
+6. AppPageViews
+
+7. AppBrowserTimings
+
+Only after inspecting these tables and validating candidate identifiers should
+the Skill fall back to time-window correlation.
+
+## Required dynamic-field verification steps
+
+During schema verification (Stage 12):
+
+1. Retrieve the real table schema with `getschema`.
+2. Identify dynamic/object/string columns that may hold JSON-like business
+   context.
+3. Sample real rows from those columns.
+4. Inspect the keys inside dynamic columns.
+5. Extract candidate business identifiers with explicit KQL.
+6. Validate candidate joins against real business tables (non-zero matches).
+7. Prefer verified **direct joins** over time-window correlation.
+
+## KQL patterns
+
+### Inspect schema
+
+```kusto
+TableName
+| getschema
+| project ColumnName, ColumnType
+```
+
+### Sample dynamic properties
+
+```kusto
+AppEvents
+| take 10
+| project TimeGenerated, Name, Properties
+```
+
+### Extract possible business identifiers
+
+```kusto
+AppEvents
+| extend BookingId = tostring(Properties.BookingId)
+| project TimeGenerated, Name, BookingId
+```
+
+### Alternative casing / naming (coalesce)
+
+```kusto
+AppEvents
+| extend BookingId = coalesce(
+    tostring(Properties.BookingId),
+    tostring(Properties.bookingId),
+    tostring(Properties.booking_id)
+  )
+```
+
+### Typed (bool / numeric) dynamic values
+
+Not every dynamic value is a string. Boolean and numeric fields (e.g. a
+`faulted` / `isError` flag, a `durationMs` or `amount`) are stored with their
+real type and serialize as JSON literals (`true`/`false`, unquoted numbers).
+Comparing them with `tostring(...) == "True"` silently matches **nothing**.
+Cast to the real type and compare to a typed literal:
+
+```kusto
+AppEvents
+| where tobool(Properties.faulted) == true          // NOT tostring(...) == "True"
+| extend amount = toreal(Properties.amount),
+         retries = tolong(Properties.retryCount)
+```
+
+### Diagnose a zero-match filter before concluding "no data"
+
+If a dynamic-field filter or join returns **0 rows**, confirm the value's real
+type and distinct values before assuming the data is absent — a type/casing
+mismatch is the most common cause:
+
+```kusto
+AppEvents
+| extend f = Properties.faulted
+| summarize count() by value = tostring(f), type = gettype(f)
+```
+
+### Validate a direct join
+
+```kusto
+AppEvents
+| extend BookingId = tostring(Properties.BookingId)
+| where isnotempty(BookingId)
+| join kind=inner (
+    Bookings
+    | project BookingId = tostring(BookingId)
+  ) on BookingId
+| summarize MatchedRows=count(), DistinctBookings=dcount(BookingId)
+```
+
+## Confidence classification
+
+- If a valid business identifier is found inside `Properties` / `CustomDimensions`
+  and the join returns **non-zero** matches → classify as a **direct join, high
+  confidence**.
+- If no direct identifier is found after inspecting top-level columns **and**
+  dynamic fields → fall back to **time-window correlation**, and state clearly
+  that time-window correlation shows **correlation, not causality**.
+
+> **Lesson learned:** screenshots can be misleading. A join key nested in
+> `AppExceptions.Properties` (e.g. `passport`, `flight`) can yield a deterministic
+> direct join to a business table even when top-level columns show nothing usable,
+> and the real data window may be weeks older than assumed. Verify schema,
+> dynamic fields, join matches, and freshness against real data first.

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-table-reference.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-table-reference.md
@@ -1,0 +1,168 @@
+# Application Insights / Azure Monitor table reference
+
+Common Application Insights / Azure Monitor (Log Analytics) telemetry tables, what
+signal each contains, the operational questions it answers, and how it can
+correlate with business data.
+
+> **Not a schema guarantee.** These are common shapes only. The **actual** schema
+> must always be verified against the real Eventhouse / KQL database with
+> `getschema` and sampling (see app-insights-dynamic-fields-reference.md). Column
+> names vary by app, SDK, and ingestion settings.
+
+## External references
+
+- [Azure Monitor tables for microsoft.insights/components (learn)](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/microsoft-insights-components)
+- [Azure Monitor Logs table reference](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/)
+
+## Workspace-based Application Insights tables (`App*`)
+
+### AppRequests
+- **Signal:** incoming server requests — success/failure, duration, result code,
+  operation name, endpoint.
+- **Operational questions:** Which endpoints fail or are slow? What is availability
+  / p95 latency? Where are 5xx spikes?
+- **Business correlation:** conversion, booking completion, checkout failures, API
+  SLA.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Id`, `OperationName`, `Url`,
+  `ResultCode`, `Success`, `DurationMs`, `Name`.
+- **Common dynamic fields:** `Properties`.
+
+### AppDependencies
+- **Signal:** outbound/downstream dependency calls (DB, HTTP, queue) — success,
+  duration, target, type.
+- **Operational questions:** Which downstream dependency failed or slowed? Which
+  target/region is degraded?
+- **Business correlation:** payment failures, inventory lookup failures, regional
+  dependency outages.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Target`, `DependencyType`,
+  `Name`, `Success`, `DurationMs`, `ResultCode`.
+- **Common dynamic fields:** `Properties`.
+
+### AppExceptions
+- **Signal:** application exceptions / failures — type, method, outer message,
+  problem id.
+- **Operational questions:** What is failing and where? Which exception types
+  spike during an incident?
+- **Business correlation:** failed bookings, failed orders, customer-impacting
+  errors.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `ProblemId`, `ExceptionType`,
+  `Method`, `OuterMessage`.
+- **Common dynamic fields:** `Properties`, `Details`.
+
+### AppTraces
+- **Signal:** diagnostic traces / structured logs — message, severity.
+- **Operational questions:** What diagnostic evidence supports a failure or
+  degraded behavior?
+- **Business correlation:** supporting evidence for failures or degraded service;
+  business keys sometimes embedded in `Properties`.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Message`, `SeverityLevel`.
+- **Common dynamic fields:** `Properties`.
+
+### AppEvents
+- **Signal:** custom business/product events emitted by the app (e.g.
+  `BookingStarted`, `CheckoutCompleted`).
+- **Operational questions:** Which funnel step dropped? Which product events
+  stopped firing during an incident?
+- **Business correlation:** funnel steps, booking started/completed, checkout,
+  sign-in — often the **richest** source of business keys in `Properties`.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `OperationId`, `UserId`, `SessionId`.
+- **Common dynamic fields:** `Properties`, `Measurements`.
+
+### AppPageViews
+- **Signal:** frontend page views — page name, url, load duration.
+- **Operational questions:** Which pages are slow or abandoned?
+- **Business correlation:** conversion, abandonment, user-journey drop-off.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Url`, `OperationId`, `UserId`,
+  `SessionId`, `DurationMs`.
+- **Common dynamic fields:** `Properties`.
+
+### AppBrowserTimings
+- **Signal:** client-side timing (network, send, receive, processing, total).
+- **Operational questions:** Where is frontend latency introduced?
+- **Business correlation:** conversion / abandonment tied to page latency.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Url`, `OperationId`,
+  `TotalDuration`.
+- **Common dynamic fields:** `Properties`.
+
+### AppAvailabilityResults / AvailabilityResults (if present)
+- **Signal:** synthetic availability tests — success, duration, location.
+- **Operational questions:** Is the service reachable from each test location?
+- **Business correlation:** availability failures → booking/checkout completion,
+  SLA.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Location`, `Success`, `DurationMs`,
+  `OperationId`.
+- **Common dynamic fields:** `Properties`.
+
+### AppMetrics (where useful)
+- **Signal:** custom metrics (name, value, aggregations).
+- **Business correlation:** business-relevant custom metrics (e.g. cart value,
+  active sessions) by time.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Sum`, `Count`, `ItemCount`.
+- **Common dynamic fields:** `Properties`.
+
+### AppPerformanceCounters (where useful)
+- **Signal:** host/process performance counters (CPU, memory, etc.).
+- **Business correlation:** resource saturation preceding user-facing degradation.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Category`, `Value`, `Instance`.
+
+### AppSystemEvents (where useful)
+- **Signal:** SDK/system events about the telemetry pipeline.
+- **Business correlation:** rarely a direct business key; useful for data-quality
+  context.
+- **Common time column:** `TimeGenerated`.
+
+### Usage-related tables (where relevant)
+- **Signal:** usage/volume of events, page views, sessions over time.
+- **Business correlation:** traffic drop → usage KPI degradation (active users,
+  transactions, revenue events).
+
+## Common cloud/role/location fields (across App* tables)
+
+Useful for regional / service-scoping of impact:
+`AppRoleName` / `CloudRoleName`, `AppRoleInstance`, `ClientCountryOrRegion`,
+`ClientCity`, `ClientType`, `OperationName`. Confirm presence via `getschema`.
+
+## Observability → business quick map
+
+| Table | Typical business impact |
+|-------|------------------------|
+| AppRequests | conversion, booking completion, checkout failures, API SLA |
+| AppExceptions | failed bookings/orders, customer-impacting errors |
+| AppDependencies | payment/inventory failures, regional dependency outages |
+| AppEvents | funnel steps, booking/checkout/sign-in events |
+| AppPageViews / AppBrowserTimings | conversion, abandonment, journey drop-off |
+| AppTraces | supporting evidence for failures / degradation |
+| AppAvailabilityResults | availability failures → booking/SLA impact |
+
+Always confirm the real schema before relying on any field above.
+
+## Telemetry source selection (data-driven, REQUIRED)
+
+No telemetry table is "best" by default. The winning source in one environment
+(e.g. AppEvents) is **not** a general rule. Telemetry source selection MUST be
+data-driven.
+
+Before selecting a correlation model, inspect **all** candidate telemetry sources
+discovered (AppEvents, AppExceptions, AppRequests, AppDependencies, AppTraces,
+AppPageViews, AppBrowserTimings, AvailabilityResults, and any others present).
+Score each candidate by:
+
+1. Business identifiers discovered.
+2. Dynamic-field richness.
+3. Direct-join confidence.
+4. Validated match count.
+5. Business-process context.
+6. Relevance to the selected business goal.
+
+Select the highest-scoring source. Do NOT automatically prioritize AppExceptions.
+Do NOT automatically prioritize AppEvents.

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/azmon-fabric-api-reference.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/azmon-fabric-api-reference.md
@@ -1,0 +1,188 @@
+# Azure Monitor → Fabric API reference
+
+Guidance on which flows are **documented/supported** versus **UI-only** or
+**internal/unsupported**, and the rules for the two connector modes. This file is
+agent guidance — do not paste it verbatim to users.
+
+## Supported vs UI-only vs internal — at a glance
+
+| Capability | Status | Notes |
+|-----------|--------|-------|
+| Mirrored Catalog item CRUD | Documented REST API | See mirrored-catalog-reference.md |
+| Mirrored Catalog item definition | Documented REST API | Item definition format |
+| Mirrored Catalog discovery | Documented REST API | Browse scopes/tables |
+| Mirrored Catalog monitoring | Documented REST API | Item/table mirroring status |
+| Mirrored Catalog refresh / sync | Documented REST API | Trigger metadata sync |
+| Operations Agent item CRUD + definition | Documented Fabric item APIs | `type: "OperationsAgent"` |
+| **OAuth** Azure Monitor connector creation | **UI-only** | Created once in Fabric → Manage Connections. **No public API.** Detect + reuse only. |
+| **Service Principal** connector create-or-reuse | Automated | Idempotent create-or-reuse; secrets from env/Key Vault only |
+| OneLake shortcut creation | Documented, but see caveat | Link alone does not register a queryable KQL table — see eventhouse-shortcuts-reference.md |
+
+## Portal fallback boundary
+
+Portal-guided instructions are allowed ONLY for OAuth Azure Monitor connector creation.
+
+Portal guidance must NOT be used as a generic fallback for:
+
+- Log Analytics workspace validation
+- Fabric workspace validation
+- Connection detection
+- Connection reuse
+- Service Principal connector creation
+- Mirrored Catalog item creation
+- Discovery
+- Monitoring
+- Refresh
+- Eventhouse shortcut creation
+- Schema verification
+- Operations Agent creation
+
+Before declaring a capability unavailable, the Skill should determine whether another supported execution path exists:
+
+- Fabric REST APIs
+- Azure REST APIs
+- Fabric Actions
+- Azure CLI
+- Azure Resource Graph
+- Fabric REST **read-only** discovery via authenticated `az rest --method get`
+  against `https://api.fabric.microsoft.com/...`
+
+MCP unavailability does not automatically imply capability unavailability.
+
+### Fabric REST read-only discovery exception (bounded)
+
+Arbitrary shell / CLI / `az` / PowerShell execution remains out of scope. There
+is ONE narrow exception: the Skill MAY use an authenticated `az rest --method
+get` call for Fabric REST **read-only discovery** only, when ALL of these hold:
+
+- Endpoint is `https://api.fabric.microsoft.com/...`.
+- HTTP method is **GET** only.
+- The operation is discovery / read-only only.
+- Nothing is created, updated, deleted, or modified — no Fabric items, shortcuts,
+  mirrored catalog items, or connectors are created through the CLI.
+- No tokens, secrets, raw auth headers, or sensitive payloads are exposed.
+- The Skill clearly states the capability path used.
+
+This exception is limited to Stage 3 (Fabric workspace discovery) and Stage 5
+(Azure Monitor OAuth connection detection). It does not relax any other stage's
+boundary, does not authorize non-GET `az rest` calls, and does not permit use of
+the Kusto / KQL data-plane when disabled.
+
+## Connector rules (authoritative)
+
+Keep the two modes strictly separated. Never route OAuth through Service
+Principal logic and never route Service Principal through OAuth/interactive
+sign-in logic.
+
+### OAuth mode (UI-guided only)
+
+- OAuth connector **creation** is interactive in **Fabric → Manage Connections**.
+- The Skill only **detects** and **reuses** an existing Azure Monitor OAuth
+  connection. Detection is **non-destructive** (never create/update/delete).
+- **Never** claim public-API support for OAuth Azure Monitor connector creation.
+- **Never** document browser-inspected / internal connector endpoints, hidden
+  payloads, `CredentialType` internals, OAuth codes, tokens, cookies, nonces, or
+  redirect URLs as supported public APIs, and never surface them to the user.
+- Reuse a connection ONLY when the data source path / LAW resource id matches the
+  **same** Log Analytics workspace exactly. Any mismatch → treat as no match.
+- If the user explicitly supplies a connection id, validate it (must be an Azure
+  Monitor Mirrored Catalog connection whose data source path matches this
+  workspace) before reusing. Reject mismatches.
+
+User-facing message when no connection exists (keep it this simple):
+
+```text
+I couldn’t find an existing Azure Monitor connection for this workspace.
+Please create it once in Fabric Manage Connections, then come back and continue.
+```
+
+### Service Principal mode (automated create-or-reuse)
+
+- Automated, non-interactive: no user login, no UI step.
+- **Idempotent**: reuse an existing matching Azure Monitor Service Principal
+  connector for the same Log Analytics workspace (same data source path +
+  Service Principal credential type) instead of creating a duplicate.
+- Only **one** connector per run.
+- **Never** reuse a non-Service-Principal (e.g. OAuth) connector in this mode.
+- **Never** ask the user to paste a raw client secret into chat.
+- Secrets come from **environment variables or Key Vault references** only; they
+  are never echoed, logged, exposed, or included in generated instructions.
+- If required inputs are missing, describe **what** is missing (tenant id, app /
+  client id, and a securely-provided secret reference) using presence checks
+  only. Never request the secret value in chat.
+
+## Supported-scope / validation rules
+
+Before creating anything, verify: the workspace exists; it is **not Sentinel** or
+otherwise unsupported; the caller has required Log Analytics access; the caller
+can create the item in the target Fabric workspace. Surface pass/fail in user
+terms; never expose raw API responses.
+
+### Sentinel detection source hierarchy
+
+Sentinel detection is a **control-plane** check and MUST NOT default to requiring
+Kusto / KQL data-plane availability. Before classifying Sentinel status as "not
+verifiable", attempt all available control-plane / metadata checks, in order:
+
+1. Resource group inventory / ARM resource enumeration.
+2. `Microsoft.OperationsManagement/solutions` named `SecurityInsights(<workspaceName>)`.
+3. `Microsoft.SecurityInsights/*` resources, including `onboardingStates` if surfaced.
+4. Workspace / resource feature metadata, if available.
+
+Indicators found → **Sentinel / blocked**. Indicators absent after complete
+enumeration → **Not Sentinel, verified via control-plane**. Only if all these
+checks are unavailable or inconclusive → **not verifiable**. Kusto may be an
+additional path but is never a required dependency for Sentinel detection. This
+hierarchy does NOT generalize to Log Analytics data-plane/query permission (may
+require a KQL/data-plane path) or Fabric item-creation permission (may require a
+Fabric control-plane capability).
+
+## Fabric workspace discovery & capability resolution
+
+Fabric workspaces are **not** Azure Resource Manager resources. They cannot be
+enumerated through Azure resource listing, Azure Resource Graph, or `az`
+resource commands, so an ARM-only environment reaching Azure resources does
+**not** imply a Fabric control-plane path exists — and the reverse also holds:
+lack of automatic enumeration does NOT mean no Fabric workspace exists.
+
+Stage 3 (Fabric workspace selection) MUST follow this policy (SKILL.md links here
+for the full detail):
+
+- Discover all surfaced Fabric mechanisms first: Fabric REST APIs, Fabric
+  Actions, Fabric / OneLake / Power BI execution capabilities, authenticated
+  Fabric REST read-only discovery via `az rest --method get` against
+  `https://api.fabric.microsoft.com/...` (GET-only, read-only, no modifications,
+  no secret/token/header exposure, capability path stated), or any other
+  documented capability provider available to the agent environment.
+- If automatic enumeration is unavailable, do NOT terminate. Distinguish "no
+  Fabric control-plane capability at all" from "enumeration unavailable but the
+  workflow can continue with user-provided workspace info".
+- Ask the user for a **Fabric Workspace Name**, **Workspace ID**, or **Workspace
+  URL**, then validate it as far as the available capabilities allow.
+- Never fabricate a workspace, workspace id, or validation result, and never
+  claim a Fabric action succeeded when the required execution capability is
+  unavailable.
+- Mark Stage 3 BLOCKED only after every programmatic discovery path AND every
+  user-supplied resolution path (Name / ID / URL) is exhausted. UI-guided
+  selection is permitted only as the final fallback.
+
+## Fabric Operations Agent surface
+
+Operations Agent is a first-class Fabric item (`type: "OperationsAgent"`). It can
+be created and populated through documented Fabric item APIs (create item, then
+set the definition with the instructions and the KQL database data source). Teams
+notifications are a built-in action — no custom channel binding is required for
+basic alerts. See operations-agent-reference.md.
+
+## External references
+
+- [Items - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/items)
+- [Mirrored Catalog item definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/mirrored-catalog-definition)
+- [Discovery - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/discovery)
+- [Monitoring - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/monitoring)
+- [Refresh - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/refresh)
+
+> The Mirrored Catalog references above cover item CRUD, item definition,
+> discovery, monitoring, and refresh/sync operations. They do **not** document
+> OAuth Azure Monitor connector creation. Treat OAuth connector creation as
+> UI-guided only.

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/business-correlation-patterns.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/business-correlation-patterns.md
@@ -1,0 +1,101 @@
+# Business correlation patterns reference
+
+Reusable **observability signal → business impact** patterns, candidate join
+keys, and scoring hints for ranking candidate business tables. Use these to guide
+discovery and correlation planning — always confirm business meaning with the
+user and verify keys against real data before relying on them.
+
+## Domain-agnostic rule (examples only)
+
+Every business entity named in this file — bookings, orders, customers, flights,
+revenue, tenants, payments, and similar — is an **EXAMPLE ONLY**. Do NOT infer the
+user's business domain from these examples. Discover the user's actual business
+entities from real Fabric data and confirm them with the user before use.
+
+Business tables are **not** expected to exist in Log Analytics. They may live in
+an Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts.
+Absence of business tables in Log Analytics MUST NOT be read as absence of
+business data.
+
+## Patterns
+
+### 1. Availability → Bookings
+- **Operational signal:** `AppRequests` failures, `AvailabilityResults` failures,
+  `AppExceptions`.
+- **Business impact:** failed / incomplete bookings.
+- **Candidate keys:** `BookingId`, `CustomerId`, `SessionId`, `OperationId`,
+  custom `Properties`.
+
+### 2. Latency → Conversion
+- **Operational signal:** `AppRequests` duration, `AppPageViews`,
+  `AppBrowserTimings`.
+- **Business impact:** conversion drop, abandonment, funnel degradation.
+- **Candidate keys:** `SessionId`, `UserId`, `CustomerId`, funnel event IDs.
+
+### 3. Exceptions → Orders / Revenue
+- **Operational signal:** `AppExceptions`, `AppTraces`.
+- **Business impact:** failed orders, revenue at risk.
+- **Candidate keys:** `OrderId`, `CustomerId`, `TenantId`, `OperationId`,
+  `Properties`.
+
+### 4. Dependency failures → Customer / Tenant impact
+- **Operational signal:** `AppDependencies` failures / latency.
+- **Business impact:** affected customers, tenants, regions, services.
+- **Candidate keys:** `TenantId`, `AccountId`, `Region`, `DependencyTarget`.
+
+### 5. Regional outage → Business KPI impact
+- **Operational signal:** `CloudRoleName`, `Region`, `ClientCountryOrRegion`,
+  location fields.
+- **Business impact:** regional bookings, customers, transactions, SLA.
+- **Candidate keys:** `Region`, `Country`, `Location`, `AirportCode`,
+  `DataCenter`.
+
+### 6. Traffic drop → Usage KPI degradation
+- **Operational signal:** `AppEvents`, `AppPageViews`, `AppRequests` volume drop.
+- **Business impact:** lower active users, reduced transactions, reduced revenue
+  events.
+- **Candidate keys:** `UserId`, `SessionId`, `ProductId`, event names.
+
+## Business data scoring hints
+
+When the exact business table or join is not known, **do not fail**. Score
+candidate business databases/tables by likely relevance to the stated goal,
+present a ranked list with explanation, propose shortcut creation for the top
+candidates, and ask the user to choose. Never conclude "no correlation is
+possible" without options.
+
+| Business goal | Prioritize tables |
+|---------------|-------------------|
+| Booking impact | Bookings, Reservations, Orders, Flights, Customers, Transactions |
+| Revenue impact | Orders, Payments, Revenue, Invoices, Subscriptions |
+| Customer impact | Customers, Accounts, Tenants, Users, Subscriptions |
+| Regional impact | Regions, Locations, Airports, DataCenters, Countries |
+| Service availability | AppRequests, AvailabilityResults, AppExceptions, AppDependencies + business completion tables |
+| Conversion | AppEvents, AppPageViews, AppRequests + funnel/business event tables |
+
+## Candidate key reference
+
+Infer candidates from column/table names; confirm meaning with the user and
+verify against real data before relying on them.
+
+- **Customer identifiers:** `CustomerId`, `UserId`, `PassportRef`, `AccountId`,
+  `TenantId`, `SubscriptionId`.
+- **Entity identifiers:** `FlightId`, `OrderId`, `BookingId`, `SessionId`,
+  `OperationId`, `RequestId`, `ResourceId`.
+- **Timestamps:** `TimeGenerated`, `Timestamp`, `EventTime`, `BookingTime`,
+  `CreatedTime`.
+- **Region/location:** `Region`, `Location`, `originAirport`,
+  `destinationAirport`, `Country`, `DataCenter`.
+
+## Table classification hints
+
+- **Operational telemetry:** AppEvents, AppExceptions, AppRequests, AppPageViews,
+  AppBrowserTimings, AppDependencies, AvailabilityResults, AzureMetrics, Perf,
+  Usage.
+- **Business tables:** Bookings, Customers, Flights, Orders, Payments,
+  CounterCheckins, Subscriptions, Invoices.
+- **Context/enrichment tables:** Flights, Regions, Products, Services, Tenants,
+  Airports.
+
+Confirm business meaning with the user; never fabricate tables the user has not
+confirmed.

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/business-insight-modeling-reference.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/business-insight-modeling-reference.md
@@ -1,0 +1,114 @@
+# Business insight modeling reference
+
+How to turn a **verified** telemetry + business dataset into a correlation model
+without asking the user for joins, KQL, bins, or thresholds. The user confirms
+**business meaning**; the Skill translates it into the technical model.
+
+## Inputs the model is inferred from
+
+- Verified top-level schema (`getschema`).
+- Verified dynamic fields (sampled `Properties` / `CustomDimensions`).
+- Sampled values.
+- Business table schema.
+- Actual join test results (non-zero match counts).
+- Data freshness (real min/max time range).
+
+Never propose a model before these are verified (Stage 12).
+
+## Direct join vs time-window correlation
+
+- **Direct join (preferred, high confidence):** a shared identifier exists and a
+  test join returns non-zero matches. Use it. State the match count.
+- **Time-window correlation (fallback):** no shared identifier after inspecting
+  top-level and dynamic fields. Correlate events within the same time bin. Always
+  state that this shows **correlation, not causality**.
+
+## Bins
+
+- **Default bin size: 5 minutes.** Explain it as granular enough to catch short
+  operational spikes while aggregating enough events to be meaningful and reduce
+  per-event noise.
+- Use a **larger** bin when data is **sparse** (few events → 15–60 min) or when
+  business KPIs are **slower** (e.g. daily bookings). Adjust for very noisy /
+  high-volume data to stabilize the signal.
+
+## Derived entity
+
+- Default derived entity name: **IncidentBin** (unless a better
+  business-specific name exists).
+- Each IncidentBin represents one time window and is the unit of analysis for
+  metrics and alert rules.
+
+## Confirming business meaning (not SQL)
+
+Ask about meaning, e.g.:
+
+> "I found `BookingId` inside `AppEvents.Properties` and it matches
+> `Bookings.BookingId`. Should I treat this as the booking identifier for
+> business impact?"
+
+Do not ask "what join should I use?" or "what bin/threshold do you want?".
+
+## Correlation plan contents (present before generating instructions)
+
+- Operational signal (which table/event indicates the problem).
+- Business impact table.
+- Verified join keys.
+- Whether the join came from **top-level columns** or **dynamic fields**
+  (`Properties` / `CustomDimensions`).
+- Match count / validation result.
+- Time window + freshness status.
+- Proposed bin size.
+- Metrics and thresholds.
+
+Then ask for confirmation and STOP.
+
+### Correlation planning validation (REQUIRED)
+
+When finalizing the correlation model, explain **why** the selected telemetry
+source was chosen, justified with real data. Include: match counts, business
+identifiers discovered, direct-join confidence, and validation results. The
+selected telemetry source must be justified against actual data — never chosen by
+default or by assumption. Candidate telemetry sources must have been inspected and
+scored before selection (see app-insights-table-reference.md).
+
+## Metrics (typical)
+
+- `ErrorCount` — faulted operational events per IncidentBin.
+- `AffectedCustomers` — distinct impacted customers per IncidentBin.
+- `AffectedBusinessRecords` — impacted business records per IncidentBin.
+- `RevenueAtRisk` — summed revenue of impacted records per IncidentBin.
+- `TopImpactedEntities` — top impacted entities by impact.
+- `ImpactBand` — high / low / none.
+
+## Thresholds
+
+Always include **both** sets in the generated instructions.
+
+- **Production-like:**
+  - ErrorCount increases by more than 20% vs previous-hour baseline.
+  - AffectedCustomers ≥ configured business threshold.
+  - RevenueAtRisk ≥ configured business threshold.
+- **Relaxed POC / debug** (validate Start + Teams alert end-to-end):
+  - `ErrorCount >= 1`
+  - `ErrorCount >= 5 and AffectedBusinessRecords >= 1`
+  - `AffectedCustomers >= 1`
+
+## Freshness and time window
+
+Check the real data range before generating instructions:
+
+```kusto
+TableName
+| summarize Rows=count(), MinTime=min(TimeGenerated), MaxTime=max(TimeGenerated)
+```
+
+If data is old or sparse, do not assume `ago(1h)` — use a window covering the
+actual range and explain it in user terms. Watch for locale-formatted timestamps
+(DD/MM vs MM/DD) when reading results.
+
+## Handoff to instruction generation
+
+The materialization query output columns MUST match the alert fields exactly. See
+operations-agent-reference.md for the explicit-KQL requirement and the full
+instruction template.

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/eventhouse-shortcuts-reference.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/eventhouse-shortcuts-reference.md
@@ -1,0 +1,112 @@
+# Eventhouse & OneLake shortcuts reference
+
+How the mirrored Azure Monitor tables become **queryable** in an Eventhouse / KQL
+database, and the queryability requirement that must be verified before any
+correlation logic.
+
+## Eventhouse / KQL database
+
+An Eventhouse hosts one or more KQL databases queried with KQL. The onboarding
+flow lands Azure Monitor telemetry (and, via additional shortcuts, business
+tables) into a KQL database so telemetry and business data can be correlated with
+KQL.
+
+- **Eventhouse / KQL database selection is a user decision.** Always present the
+  discovered options and require explicit confirmation. Never auto-select, even
+  when discovery has a recommended default.
+- The Eventhouse query URI (`queryServiceUri` in Eventhouse properties) is where
+  `getschema`, sampling, and validation queries run during schema verification.
+
+## OneLake shortcuts — the queryability requirement (CRITICAL)
+
+Making a mirrored table queryable requires **two** things:
+
+1. **Exact source table name.** A renamed shortcut (e.g. `LAQS_AppTraces` for
+   source `AppTraces`) creates the OneLake link but may NOT register as a
+   queryable KQL table (e.g. `General_BadRequest: Request is invalid`). Keep the
+   exact source table name.
+2. **The table must be registered as a queryable/external table.** A OneLake link
+   alone is not enough. The Fabric **UI "Add table"** flow both creates the
+   shortcut and registers the external table, so it becomes queryable. Creating
+   only the OneLake link means the table will not appear in
+   `.show external tables` and queries return 400.
+3. **Mirrored AzMon tables live under a `dbo` schema folder.** In the mirrored
+   catalog item's OneLake, tables are nested at `Tables/dbo/<TableName>`, not
+   directly under `Tables/<TableName>`. A shortcut's OneLake target path must
+   therefore include the schema segment (`target.oneLake.path =
+   "Tables/dbo/<TableName>"`). Confirm the exact folder by listing `Tables/`
+   first — it typically contains a single `dbo` directory holding every table.
+
+## Shortcut planning and creation (stage rules)
+
+- **Shortcut planning happens before schema verification or join logic.** Present
+  the plan and STOP for confirmation.
+- **Shortcut creation requires explicit confirmation.**
+- **Handle "already exists" idempotently.** If shortcut creation returns a
+  conflict (e.g. HTTP 409 `EntityConflict` / `ShortcutsOperationNotAllowed` when
+  the conflict policy is `Abort`), do **not** treat it as a failure and do **not**
+  overwrite. A shortcut of that name already exists — verify it points to the
+  intended source and is queryable (`.show external tables` + `TableName | take 1`),
+  then proceed. Only recreate if the existing shortcut targets a different source.
+- After creation, **verify queryability** with a lightweight query before building
+  any correlation logic. Stage 11 validates **queryability, NOT table size**, so
+  use a single-row probe rather than a full scan:
+
+  ```kusto
+  TableName
+  | take 1
+  ```
+
+  (`TableName | limit 1` is equivalent.) Avoid `TableName | count` here — on
+  large external Delta tables a `count` forces an unnecessary full scan, causing
+  long execution times and validation delays.
+
+- If a table is not queryable → **STOP** and return to shortcut planning /
+  creation. Do not build correlation logic on screenshots or assumed schema.
+- A brand-new AzMon item won't surface tables until its mirror has materialized
+  them; wait/refresh before expecting queryable tables.
+
+## Shortcut acceleration policy (SHOULD)
+
+Query acceleration SHOULD be treated as the preferred configuration for newly
+created shortcuts. Testing showed significant performance improvements once
+acceleration was enabled — schema verification, queryability validation,
+telemetry sampling, correlation analysis, and Operations Agent preparation all
+became substantially faster.
+
+When creating ANY shortcut:
+
+1. Determine whether acceleration is **supported**.
+2. Determine the **current** acceleration status.
+3. **Enable** acceleration when supported and appropriate.
+4. **Report** the acceleration status.
+
+During Shortcut Planning (Stage 10), show for each shortcut: Shortcut Name,
+Source, Target, Acceleration Supported (Yes/No), Acceleration Enabled (Yes/No). If
+acceleration is disabled, explain the potential impact on queryability validation,
+schema verification, telemetry sampling, correlation analysis, and Operations
+Agent preparation.
+
+This is a **SHOULD**, not a MUST — do not assume acceleration exists in every
+environment.
+
+## Verify external table registration
+
+After adding tables, confirm registration and queryability:
+
+```kusto
+.show external tables
+```
+
+```kusto
+TableName
+| take 1
+```
+
+Stage 11 validates queryability, NOT table size. Prefer the single-row probe
+`TableName | take 1` (or `TableName | limit 1`). Avoid `TableName | count`, which
+forces a full scan of large external Delta tables and slows validation.
+
+If a table is missing from `.show external tables`, it was linked but not
+registered — re-add it via the UI "Add table" flow (which both links and
+registers), keeping the exact source name.

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/mirrored-catalog-reference.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/mirrored-catalog-reference.md
@@ -1,0 +1,89 @@
+# Mirrored Catalog reference
+
+Supported Fabric Mirrored Catalog operations for onboarding Azure Monitor /
+Application Insights / Log Analytics data as an AzMon item. All operations below
+are documented REST APIs.
+
+> **Preview / beta status:** The Azure Monitor Mirrored Catalog item is in
+> **Preview**, and its Discovery, Monitoring, and Refresh operations are `(beta)`
+> — they require the `beta=true` query parameter. Treat this surface as subject
+> to change and confirm the current shape against Microsoft Learn before relying
+> on it.
+
+## What a Mirrored Catalog (AzMon) item is
+
+A Fabric item that mirrors an external catalog (here, Azure Monitor / Log
+Analytics) into Fabric so its tables become discoverable and, via Eventhouse
+shortcuts, queryable in a KQL database. The item is created in a target Fabric
+workspace and bound to a connection (OAuth or Service Principal) for the source
+Log Analytics workspace.
+
+## Operation groups
+
+### Item CRUD
+
+Create, get, update, list, and delete the Mirrored Catalog item in a Fabric
+workspace. Creating the item requires a valid connection for the source Log
+Analytics workspace and sufficient Fabric workspace permission. Capture the
+returned item id for later monitoring/refresh calls.
+
+- [Items - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/items)
+
+### Item definition
+
+The item definition describes the mirrored catalog configuration (source binding,
+selected scope/tables where applicable). Read the current definition before
+editing; do not fabricate definition fields.
+
+- [Mirrored Catalog item definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/mirrored-catalog-definition)
+
+### Discovery
+
+Browse available source **scopes** (namespaces) and **tables** after the
+connection/item is available. Use only returned scope/table values — never
+fabricate table names. Discovery is read-only.
+
+- [Discovery - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/discovery)
+
+#### Discovery API fallback policy
+
+The Mirrored Catalog Discovery APIs are the **primary** discovery mechanism. If
+discovery appears incomplete, do NOT immediately switch to alternative metadata
+paths. First:
+
+1. Verify mirror status.
+2. Verify refresh / sync status.
+3. Verify discovery scope.
+4. Retry discovery.
+
+Only after these checks may alternative metadata paths be evaluated.
+
+### Monitoring
+
+Report readiness/status of the mirrored item and of individual tables rather than
+guessing readiness. A brand-new item will not surface tables until its mirror has
+materialized them.
+
+- [Monitoring - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/monitoring)
+
+### Refresh / run sync job
+
+Trigger a catalog metadata refresh / sync after item creation to bring table
+metadata up to date. Do not claim refresh completed unless the service confirms
+it.
+
+- [Refresh - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/refresh)
+
+## Guardrails
+
+- These APIs cover item CRUD, definition, discovery, monitoring, and
+  refresh/sync. They do **not** document OAuth Azure Monitor connector creation —
+  treat OAuth connector creation as UI-guided (see azmon-fabric-api-reference.md).
+- Discovery/monitoring output is authoritative for names/status; do not invent
+  values.
+- Mirroring metadata into the catalog is **not** the same as a table being
+  queryable in Eventhouse. Queryability requires an Eventhouse shortcut that
+  registers the table (see eventhouse-shortcuts-reference.md).
+- Business tables are **not** expected in Log Analytics. They may exist in an
+  Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts. Their
+  absence in Log Analytics does NOT mean business data is absent.

--- a/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/operations-agent-reference.md
+++ b/plugins/fabric-operations/skills/azmon-mirroredcatalogs-operations-cli/references/operations-agent-reference.md
@@ -1,0 +1,243 @@
+# Operations Agent reference
+
+Everything needed to generate, create, validate, and troubleshoot a Microsoft
+Fabric **Operations Agent** over the Eventhouse/KQL database holding the verified
+telemetry + business data. The end product is a clean copy/paste block of
+instructions the user pastes into Fabric.
+
+## Core principle
+
+The user is **not** expected to know join logic, time binning, derived-entity
+modeling, metric computation, or thresholds. Never open with "what JOIN should I
+use?" or "what bin/threshold do you want?". Infer candidates from the **verified**
+schema (Stage 12), propose in business language, confirm business meaning, then
+translate to the technical model on the user's behalf.
+
+## Give explicit per-field KQL, not conceptual descriptions (REQUIRED)
+
+The Fabric playbook generator will **not infer** joins, aggregations, or how to
+compute a metric. Conceptual-only field names (e.g. "AffectedCustomers",
+"RevenueAtRisk") cause generation to fail with **"No playbook generated"** and
+"I was not able to determine how to compute X". To avoid this:
+
+- Provide **one verbatim materialization query** whose **output columns ARE the
+  alert fields** (the `summarize`/`extend` produces `ErrorCount`,
+  `AffectedCustomers`, `RevenueAtRisk`, … by `IncidentBin`). Include the
+  `tostring(Properties.x)` extraction, the explicit `join`, and the exact
+  aggregations (`count()`, `dcount()`, `dcountif()`, `sum()`, `make_set()`).
+- Add a **field-definition list** restating each output column's KQL in one line
+  (e.g. `AffectedCustomers = dcount(passport) by IncidentBin`), so message
+  placeholders map 1:1 to columns.
+- Make each **alert rule reference a concrete output column**. If one metric
+  drives both the trigger and the message text (e.g. `RevenueAtRisk >= 1000` and
+  `$<RevenueAtRisk>` in the message), say so explicitly.
+
+## Playbook materialization requirement (MANDATORY)
+
+Operations Agent creation can succeed while **playbook generation still fails**
+until the incident entity is materialized as a real, queryable schema object.
+Testing confirmed that instructions and KQL text alone are NOT sufficient — the
+Playbook Generator discovers alert fields from an actual schema, not from prose.
+
+Before generating Operations Agent rules:
+
+1. **Materialize IncidentBins** as a real, queryable schema object (a physical
+   table, or a stored-function-backed table, in the KQL database).
+2. **Expose the alert fields as physical output columns.**
+3. **Verify the schema exists** (`IncidentBins | getschema`).
+
+Required output columns:
+
+- IncidentBin
+- ErrorCount
+- AffectedCustomers
+- AffectedBookings
+- RevenueAtRisk
+- TopImpactedEntities
+- TopImpactedSteps
+
+The Playbook Generator MUST be able to discover these fields directly from the
+materialized schema. KQL instructions alone are NOT sufficient. Business-specific
+column names adapt to the business entities actually discovered in the data.
+
+## Required sections of the generated instructions
+
+Goal · Data sources · Field mapping definitions · Dynamic field extraction logic ·
+Derived analysis entity · IncidentBin materialization query · Metric definitions ·
+Correlation logic · Impact logic (production + POC) · Alert behavior · Output
+requirements · Validation / POC mode.
+
+## Instruction template
+
+Fill `<...>` placeholders with confirmed table/column names. Leave unknowns as
+explicit placeholders — do not invent schema. Output as one copy/paste block.
+
+```text
+Goal:
+Detect operational incidents and correlate them with business impact.
+
+Data sources:
+Operational telemetry tables:
+- <OperationalTable>
+Business tables:
+- <BusinessTable>
+Context/enrichment tables:
+- <ContextTable>
+
+Field mapping definitions:
+- Customer identifier: <BusinessTable>.<CustomerIdColumn>
+- Operational time:    <OperationalTable>.<OperationalTimestampColumn>
+- Business time:       <BusinessTable>.<BusinessTimestampColumn>
+
+Dynamic field extraction logic:
+- Extract business keys nested in dynamic columns, e.g.
+  BusinessKey = tostring(<OperationalTable>.Properties.<KeyName>)
+- Use coalesce() for casing/naming variants:
+  BusinessKey = coalesce(
+    tostring(Properties.<KeyName>),
+    tostring(Properties.<keyName>),
+    tostring(Properties.<key_name>))
+
+Join keys:
+- Join <OperationalTable> to <BusinessTable> on <JoinKey> when available.
+- If no direct key exists, correlate within the same 5-minute time bin
+  (correlation, not causality).
+
+Derived analysis entity:
+Create IncidentBin. Each IncidentBin is one 5-minute window and is the unit of
+analysis for rules and alerts.
+
+IncidentBin materialization query (output columns == alert fields):
+<OperationalTable>
+| where <OperationalTimestampColumn> between (datetime(<MinTime>) .. datetime(<MaxTime>))
+| extend BusinessKey = tostring(Properties.<KeyName>)
+| where isnotempty(BusinessKey)
+| join kind=inner (
+    <BusinessTable>
+    | project BusinessKey = tostring(<JoinKey>), <CustomerIdColumn>, <RevenueColumn>
+  ) on BusinessKey
+| summarize
+    ErrorCount             = count(),
+    AffectedCustomers      = dcount(<CustomerIdColumn>),
+    AffectedBusinessRecords = dcount(BusinessKey),
+    RevenueAtRisk          = sum(<RevenueColumn>),
+    TopImpactedEntities    = make_set(<ContextColumn>, 3),
+    TopImpactedSteps       = make_set(<OperationStepColumn>, 3)
+    by IncidentBin = bin(<OperationalTimestampColumn>, 5m)
+
+Metric definitions:
+- ErrorCount = count() of faulted operational events by IncidentBin.
+- AffectedCustomers = dcount(<CustomerIdColumn>) by IncidentBin.
+- AffectedBusinessRecords = dcount(BusinessKey) by IncidentBin.
+- RevenueAtRisk = sum(<RevenueColumn>) by IncidentBin.
+- TopImpactedEntities = make_set(<ContextColumn>, 3) by IncidentBin.
+- TopImpactedSteps = make_set(<OperationStepColumn>, 3) by IncidentBin.
+
+Correlation logic:
+Evaluate each IncidentBin for operational degradation and business impact.
+Use direct joins when verified identifiers exist; otherwise time-window
+correlation (correlation, not causality).
+
+Impact logic:
+Production-like thresholds:
+- ErrorCount increases by more than 20% vs previous-hour baseline.
+- AffectedCustomers >= <configured business threshold>.
+- RevenueAtRisk >= <configured business threshold>.
+POC / debug thresholds (validate Start + Teams alert end-to-end):
+- ErrorCount >= 1
+- ErrorCount >= 5 and AffectedBusinessRecords >= 1
+- AffectedCustomers >= 1
+
+Alert behavior:
+- One alert per 5-minute IncidentBin.
+- Include business context and recommended action.
+
+Output requirements:
+Alert title, incident time window, ErrorCount, AffectedCustomers,
+AffectedBusinessRecords, RevenueAtRisk, TopImpactedEntities, business impact
+summary, recommended action, investigation link if available.
+
+Validation / POC mode:
+Start with POC thresholds to confirm Start runs and a Teams alert arrives, then
+switch to production-like thresholds for steady-state monitoring.
+```
+
+## Creating the agent (optional Stage 16)
+
+Operations Agent is a first-class Fabric item (`type: "OperationsAgent"`), so it
+can be created and populated through documented Fabric item APIs.
+
+> **Auth restriction (verified — MUST check before this stage).** The Create
+> OperationsAgent API supports a **User (delegated) identity only** — **service
+> principal and managed identity are NOT supported**
+> ([Microsoft Learn: Create Operations Agent](https://learn.microsoft.com/en-us/rest/api/fabric/operationsagent/items/create-operations-agent)
+> — Microsoft Entra supported identities: User = Yes, Service principal & Managed
+> identities = No). If the current session is authenticated as a service principal
+> or managed identity, STOP and instruct the user to switch to delegated user auth
+> before creating the agent; the create call will otherwise fail. (The
+> OperationsAgent item is in Preview.)
+
+1. Create the agent item in the target workspace (capture the returned item id).
+2. Read the current definition, set `configuration.instructions` to the Instruction template
+   block, and add the KQL database under `configuration.dataSources` as a
+   `KustoDatabase` entry keyed by a friendly alias; then update the definition.
+   Do **not** include an empty `playbook` object (it fails with "No rule
+   definitions available in the playbook.").
+3. Use the real **KQL database** item id (the `KQLDatabase` item whose display
+   name matches the target Eventhouse — not the `Eventhouse` item).
+
+Note (verified behavior): `updateDefinition` reliably saves the **instructions**
+text, but live **bindings** (`dataSources[].id`, `messageDestination`) may read
+back as placeholders (all-zeros / null) even on `200` — the portal Build page is
+authoritative and typically shows the attached KQL database. Have the user open
+the agent's **Build** page to confirm the Knowledge data source, let the playbook
+generate, then **Save** and **Start**. Teams notifications are a built-in action;
+no custom channel binding is required for basic alerts.
+
+## Validation & troubleshooting
+
+- **"No playbook generated" / "cannot compute X"** → conceptual-only fields, or
+  the incident entity was not materialized as a real schema object. Materialize
+  IncidentBins so its output columns are physical, discoverable columns; add the
+  explicit materialization query (output columns == alert fields), the
+  per-field KQL list, dynamic-field extraction, and concrete join keys; ensure
+  each alert rule references an actual output column. Map specific messages:
+  missing thresholds → add numeric thresholds; missing field mapping → add
+  explicit field definitions; missing customer/entity id → add the identifier
+  mapping; missing join key → specify keys or fall back to 5-minute correlation;
+  missing time column → specify the timestamp columns.
+- **Start succeeds but no Teams alert** → likely no data matched (thresholds too
+  strict for the window). Switch to POC thresholds (`ErrorCount >= 1`, or
+  `ErrorCount >= 5 and AffectedCustomers >= 1`), then restore production
+  thresholds. Do not imply platform failure without evidence.
+
+## Guardrails
+
+- Do not fabricate schema — use placeholders when names are unknown.
+- Confirm business meaning before producing final instructions.
+- Say "correlated", not "caused", when only time-window correlation exists.
+- Do not require the user to know KQL or joins.
+- Only recommend adding Actions when the user needs capabilities beyond the
+  built-in Teams alerts.
+
+
+## External References
+
+### Microsoft Learn
+
+Create and Configure Operations Agents - Microsoft Fabric
+
+https://learn.microsoft.com/en-us/fabric/real-time-intelligence/operations-agent
+
+### Microsoft Community Hub
+
+Microsoft Fabric Operations Agent Step by Step Walkthrough
+
+https://techcommunity.microsoft.com/blog/analyticsonazure/microsoft-fabric-operations-agent-step-by-step-walkthrough/4512572
+
+Use these references when:
+- creating new Operations Agents
+- understanding playbook generation behavior
+- troubleshooting rule generation failures
+- validating expected Operations Agent workflow
+

--- a/plugins/fabric-operations/skills/check-updates/SKILL.md
+++ b/plugins/fabric-operations/skills/check-updates/SKILL.md
@@ -1,221 +1,508 @@
 ---
 name: check-updates
 description: >
-  Check for skills-for-fabric marketplace updates at session start. Compares local version 
-  against GitHub releases and shows changelog if updates are available. Use when the 
-  user wants to: (1) check for skill updates, (2) see what's new in skills-for-fabric, 
-  (3) verify current version. Triggers: "check for updates", "am I up to date", 
-  "what version", "update skills", "show changelog".
+  Check an installed skills-for-fabric plugin bundle or git clone for updates,
+  show the matching changelog, and provide host-appropriate update guidance.
+  Use when the user wants to: (1) check for skill updates, (2) see what changed,
+  (3) verify the installed version. Triggers: "check for updates", "am I up to
+  date", "what version", "update skills", "show changelog".
 ---
 
 # Check for Updates
 
-This skill checks for updates to the skills-for-fabric marketplace at the start of each session.
+This is a read-only update checker. It identifies the installation that supplied
+this skill, compares its version with the repository's `main` branch, and shows
+the update path supported by the current agent host. It never updates
+automatically.
 
-## When to Run
+## Cadence
 
-Run this check **once per week** when any skills-for-fabric skill is first invoked. Skip if already checked within the last 7 days.
+Keep these two controls separate:
 
-## Session State
+- **Invocation guard:** Other Fabric skills invoke this skill once per session
+  before continuing.
+- **Network guard:** Automatic invocations perform a remote lookup at most once
+  every 7 days for each detected installation identity.
 
-The update check marker is stored in a **persistent, user-level directory** shared across all sessions and all plugins in the Fabric Skills marketplace:
+If the user's current request directly asks for a version, changelog, or update
+check, treat it as an **explicit invocation** and bypass the 7-day network guard.
+If this skill was invoked only by another skill's session-start notice, treat it
+as an **automatic invocation**.
+
+Always continue with the caller's original task after an automatic invocation,
+including when the check is skipped or fails.
+
+## Procedure
+
+### Step 1: Resolve the Installation Context
+
+Determine one candidate installation root:
+
+1. If the user explicitly supplied an installation path, use that exact path.
+2. Otherwise, start from the active
+   `<skills-root>/check-updates/SKILL.md` file.
+3. When `<skills-root>` is named `skills`, consider its parent as a containing
+   root. Use that containing root only if it has a supported plugin manifest or
+   both `package.json` and a direct `.git` file or directory plus the positive
+   skills-for-fabric Git identity defined below.
+4. Otherwise, use `<skills-root>` as the candidate root. This includes personal
+   copies under `~/.copilot/skills` and `~/.agents/skills`, plus project copies
+   under `.github/skills`, `.agents/skills`, and `.claude/skills`.
+5. If the runtime does not expose the active skill path, report the context as
+   unknown. Do not guess.
+
+Never infer the installation from the shell's current working directory. Never
+walk upward beyond the candidate root. A project containing an unrelated parent
+`.git` directory is not evidence that the skill came from that repository.
+
+Resolve the runtime host independently from the installation channel:
+
+```text
+copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+```
+
+Use the host identity exposed by the current session or runtime. Do not infer it
+from a plugin manifest, install path, or working directory. A deterministic test
+may supply an explicit runtime-host override; normal use may not. If the host
+cannot be established, use `unknown`.
+
+For runtime detection of an already installed plugin, use the first existing
+manifest in this cross-tool precedence:
+
+1. `.plugin/plugin.json`
+2. `plugin.json`
+3. `.github/plugin/plugin.json`
+4. `.claude-plugin/plugin.json`
+
+In this repository, `.github/plugin/plugin.json` is the canonical source
+manifest. `.plugin/plugin.json` and `plugin.json` are compatibility fallbacks
+for other installed layouts or test fixtures. The final location supports
+packages that expose only a Claude-compatible manifest. Do not treat this
+runtime probe order as authoring guidance for this repository.
+
+Then classify the candidate root in this order:
+
+| Channel | Required files at the candidate root | Read |
+|---|---|---|
+| Plugin | one supported plugin manifest | top-level `name`, `version`, `repository` |
+| Git clone | `package.json`, a direct `.git` file or directory, and a positive skills-for-fabric Git identity | top-level `version`, `repository.url` |
+| Copied skills | no plugin or Git layout, plus either a root `SKILL.md` or direct child skill directories containing `SKILL.md` | tentative skill directory names only |
+| Unknown | none of the exact layouts | no identity or update command |
+
+Plugin detection takes precedence if both layouts are present. This lets a
+development fixture retain plugin semantics while using a local Git remote.
+
+A positive Git identity requires both of these checks:
+
+- The final unscoped segment of `package.json` `name` is
+  `skills-for-fabric`. Accepted examples include `skills-for-fabric`,
+  `@microsoft/skills-for-fabric`, and contributor-fork scopes.
+- After removing a trailing slash and `.git`, the final repository path segment
+  is `skills-for-fabric`, compared case-insensitively.
+
+If either check fails, do not promote that containing root to the Git channel
+and do not run Git against it. Continue candidate-root resolution and classify
+the resulting candidate independently; a nested `skills` root may therefore be
+a loose copy. A generic Node repository that happens to contain a `skills/`
+directory is not a skills-for-fabric installation.
+
+A copied channel is terminal until an explicit request confirms its source:
+
+- For an automatic invocation, do not ask a question. Optionally show one short
+  note that the unverified loose copy was skipped and can be checked explicitly,
+  then continue the caller's original task.
+- For an explicit invocation without source confirmation, list the tentative
+  copied skill names, state that source and version are unverified, ask the
+  confirmation question in the copied-channel section, and stop.
+
+Neither path continues to the network guard or remote-version steps.
+
+Build one context object:
+
+```text
+runtimeHost: copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+channel: plugin | git | copy | unknown
+root: exact candidate root
+installKind: marketplace | direct | none
+installScope: user | project | local | managed | none
+manifestName: plugin manifest name | none
+installedName: marketplace entry name | none
+marketplace: marketplace name | none
+sourceId: direct-install source ID | none
+identity: plugin:<marketplace>/<installed-name> | plugin:direct/<source-id> | git:<repository-url-as-stored>|<root>
+localVersion: manifest version
+repository: URL exactly as stored in the selected manifest
+updateTarget: <installed-name>@<marketplace> | <manifest-name> | <root> | none
+copiedSkills: direct skill directory names | none
+```
+
+For a plugin, keep the manifest name separate from the installed marketplace
+entry name. They can differ. Resolve the installed entry from native runtime
+metadata or the native plugin listing when it identifies the candidate root.
+
+For GitHub Copilot CLI marketplace installs, the documented path is
+`~/.copilot/installed-plugins/<marketplace>/<installed-name>`, so those two path
+segments are authoritative.
+
+For a direct Copilot CLI install at
+`~/.copilot/installed-plugins/_direct/<source-id>`, set `installKind` to
+`direct`, use the source ID only for the cache identity, and use the manifest
+name as the bare update target. `_direct` is not a marketplace name.
+
+For Claude Code marketplace installs, resolve the installed entry and scope from
+Claude's native plugin metadata. `claude plugin list --json` can identify the
+entry; the declaring settings file identifies its scope:
+
+- `~/.claude/settings.json` -> `user`
+- `.claude/settings.json` -> `project`
+- `.claude/settings.local.json` -> `local`
+- managed settings -> `managed`
+
+If the same entry exists at more than one scope, list the choices and ask which
+one to update. Do not guess a scope. A plugin loaded only from a skills
+directory, `--plugin-dir`, or `--plugin-url` has no marketplace install record;
+do not fabricate an update command for it.
+
+If native metadata and the installed path are unavailable, use the manifest
+name with marketplace `fabric-collection` only when the mapping is
+unambiguous. The `fabric-skills` manifest is not unambiguous because the legacy
+`skills-for-fabric` marketplace entry uses the same payload. In that case,
+report that the installed entry could not be resolved, ask the user to inspect
+the native plugin list, and do not guess an identity or update command.
+
+For Git `package.json`, accept either a repository object with a `url` property
+or a repository URL string. Keep the repository value exactly as stored and
+append the exact resolved root when building the cache identity. This prevents
+one clone from suppressing checks for another clone of the same repository.
+When parsing a GitHub owner and repository for remote tools, strip only a
+trailing `.git` and trailing slash. Do not alter owner spelling, case,
+underscores, or punctuation.
+
+Validate that required fields are present and that `localVersion` is semantic
+version text. If validation fails, report the malformed field and classify the
+context as unknown rather than using partial metadata.
+
+### Step 2: Apply the Network Guard
+
+Use an exact cache path supplied by the caller only for a deterministic test.
+Otherwise, use this persistent cache file:
 
 ```text
 ~/.config/fabric-collection/last-update-check.json
 ```
-  
-This file contains a JSON object mapping plugin names to the **UTC date** (YYYY-MM-DD) of their last update check:
+
+On Windows, this is:
+
+```text
+$env:USERPROFILE\.config\fabric-collection\last-update-check.json
+```
+
+The file is a flat JSON object keyed by installation identity:
 
 ```json
 {
-  "fabric-skills": "2026-02-17",
-  "another-plugin": "2026-02-16"
+  "plugin:fabric-collection/fabric-consumption": "2026-07-15",
+  "plugin:direct/github-com-example-skills": "2026-07-15",
+  "git:https://github.com/example/skills-for-fabric.git|C:\\repos\\skills-for-fabric": "2026-07-14"
 }
 ```
 
-Before checking, read `~/.config/fabric-collection/last-update-check.json`:
-- If the file exists and the entry for the current plugin is within the last **7 days** (compared to the current **UTC date**), skip the check.
-- If the file is missing, the plugin entry is absent, or the date is more than 7 days old (compared to the current **UTC date**), run the update check.
+Use UTC dates in `YYYY-MM-DD` format.
 
-> **IMPORTANT — use UTC consistently**: Always use the current UTC date when saving and comparing the last-update-check timestamp. Do not use the local system timezone, as it varies across environments and can cause the check to run too often or be skipped. In shell, use `date -u +%Y-%m-%d` (Linux/macOS) or `(Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")` (PowerShell).
+- For an automatic invocation, skip the remote lookup when this identity has a
+  valid date within the last 7 days.
+- For an explicit invocation, perform the remote lookup even when a fresh cache
+  entry exists.
+- Entries for different installed plugin entries or Git clone roots do not
+  suppress each other.
+- Preserve every unrelated entry when writing the file.
+- If the file contains malformed JSON, warn and do not overwrite it.
+- Do not read or write a cache entry for a copied or unknown context.
 
-> **Note**: Create the `~/.config/fabric-collection/` directory if it does not exist. On Windows, use `$env:USERPROFILE\.config\fabric-collection\`.
+After a remote attempt completes, record today's UTC date for the detected
+identity whether the attempt found an update, found no update, or failed, unless
+the cache file was malformed. This prevents an automatic network failure from
+repeating in every session. Do not rewrite the marker when the network guard
+skipped the attempt.
 
-## Update Check Procedure
+### Step 3: Read the Remote Version
 
-### Step 1: Get Local Version
+Read `package.json` and `CHANGELOG.md` from the same repository and the same
+`main` ref. Try these methods in order and stop after the first successful one:
 
-Read the `version` field from the local plugin manifest. Two install layouts exist:
+1. **Git CLI:** Only when the candidate root itself has a direct `.git` file or
+   directory. Do not use `git rev-parse` as the availability check because it
+   can discover an unrelated parent repository.
 
-- **GitHub Copilot CLI plugin install** (`~/.copilot/installed-plugins/fabric-collection/fabric-skills/`): the manifest is `.github/plugin/plugin.json` — there is no `package.json` here.
-- **Manual git clone**: the manifest is `package.json` at the repo root.
+   ```bash
+   git -C "<root>" fetch origin main --quiet
+   git -C "<root>" show origin/main:package.json
+   git -C "<root>" show origin/main:CHANGELOG.md
+   ```
 
-Read whichever is present. Both files contain a top-level `"version": "<semver>"` field.
+2. **Authenticated GitHub tools:** Use GitHub MCP file tools or `gh api` with
+   the owner and repository parsed exactly from the manifest URL. Read
+   `package.json` and `CHANGELOG.md` at ref `main`.
+3. **Public raw content:** For a public repository, read both files from
+   `https://raw.githubusercontent.com/<owner>/<repo>/main/`.
 
-### Step 2: Determine Repository Owner and Name
+Do not use the latest GitHub Release tag as the remote version. Plugin
+marketplace updates follow repository content, and a release tag can lag behind
+the version available to plugin users.
 
-Read the `repository` field from the same manifest you used in Step 1, and parse the URL to get `owner` and `repo`. The two layouts store the field differently:
+If version retrieval fails, show the detected channel, identity, and local
+version with a concise warning. Do not fabricate a remote version. If only the
+changelog retrieval fails, still report the version comparison and note that
+the changelog was unavailable.
 
-- **Copilot CLI plugin install** (`.github/plugin/plugin.json`) — plain URL string:
-  ```text
-  "repository": "https://github.com/<owner>/<repo>"
-  ```
-- **Manual git clone** (`package.json` at the repo root) — object whose `url` ends with `.git`:
-  ```text
-  "repository": { "type": "git", "url": "https://github.com/<owner>/<repo>.git" }
-  ```
+### Step 4: Compare and Report
 
-There is no bare `plugin.json` at the repo root in either layout, and there is no top-level `package.json` in the Copilot CLI plugin install — always use the path that matches your actual layout.
+Compare semantic versions:
 
-> **CRITICAL**: Use the owner string **exactly as it appears** in the URL. Do NOT alter, normalize, or "correct" the owner name — including underscores, mixed case, or any other punctuation. Whatever the manifest's `repository` URL says, that is the correct owner. (LLMs sometimes "auto-correct" underscores to hyphens — don't.)
+- `remoteVersion > localVersion`: update available.
+- `remoteVersion <= localVersion`: up to date.
 
-### Step 3: Fetch Latest Release
+For an update, show the relevant `CHANGELOG.md` entries between the local and
+remote versions, then provide only guidance verified for both the detected
+channel and `runtimeHost`.
 
-Use the available tools in your environment to get the latest version. **Try methods in strict order — only fall back to the next method if the previous one fails or is unavailable.**
+**Plugin channel**
 
-> **IMPORTANT**: Methods A and B work with both public and private repositories. Method C only works with public repos. Always attempt A or B first.
+Never emit one host's plugin command for another host.
 
-**Method A — Git CLI (preferred for git-clone installs)**
+| Runtime host | Verified guidance |
+|---|---|
+| GitHub Copilot CLI | For a marketplace install, show `/plugin update <installed-name>@<marketplace>`. For a direct install, show `/plugin update <manifest-name>`. |
+| Claude Code | For a marketplace install with a resolved scope, show `claude plugin update <installed-name>@<marketplace> --scope <scope>`, then tell the user to run `/reload-plugins` or restart Claude Code. |
+| Cursor | Direct the user to **Customize > Plugins**. For a team marketplace, an administrator can use **Refresh** or **Enable Auto Refresh**. Do not emit a plugin CLI command. |
+| Windsurf, Codex, other, or unknown | Report the available version and repository, but provide no executable plugin command because none is verified for this layout. |
 
-Only available if the skills-for-fabric directory is a Git working tree (i.e. it has a `.git` entry — either a directory in a normal clone, or a file in a worktree/submodule). The Copilot CLI plugin install at `~/.copilot/installed-plugins/fabric-collection/fabric-skills/` has no `.git` entry — for that install layout, skip to Method B. If you want a tool-agnostic check, run `git rev-parse --is-inside-work-tree` and only proceed if it prints `true`.
-
-If you do have a Git clone, fetch the remote `package.json` without pulling:
-
-```bash
-git fetch origin main --quiet
-git show origin/main:package.json
-```
-
-Extract the `version` field from the JSON output. This method is the most reliable because it uses the already-configured remote URL and authentication, and avoids any owner/repo name parsing.
-
-**Method B — GitHub MCP tools (preferred for agentic environments)**
-
-If you have access to GitHub MCP server tools (e.g., `get_file_contents`), use them to read the remote `package.json`. Use the owner and repo extracted in Step 2 **exactly as parsed** (do not modify the strings):
-
-```text
-get_file_contents(owner: "<owner>", repo: "<repo>", path: "package.json")
-```
-
-Extract the `version` field from the response. This method works with private repositories because MCP tools use authenticated GitHub access.
-
-**Method C — GitHub REST API (fallback only, public repos)**
-
-> ⚠️ **Only use this method if Methods A and B both fail or are unavailable.** This method does not work with private repositories.
-
-If the repository is public, make a GET request using the owner/repo from Step 2:
-
-```text
-GET https://api.github.com/repos/<owner>/<repo>/releases/latest
-```
-
-Extract the `tag_name` field (e.g., `v0.2.0`) and remove the `v` prefix.
-
-> **Note**: This method returns 404 for private repositories. If you receive a 404 error, do NOT assume the repository doesn't exist — retry with Method A or B.
-
-### Step 4: Compare Versions
-
-Compare the local version with the remote version using semantic versioning:
-- If remote > local: Update available
-- If remote <= local: Up to date
-
-### Step 5: Display Results
-
-#### If Up to Date
-
-Show a brief confirmation and proceed:
-```text
-✅ skills-for-fabric v0.1.0 is up to date.
-```
-
-#### If Update Available
-
-Show detailed information:
+GitHub Copilot CLI marketplace install:
 
 ```text
-╔══════════════════════════════════════════════════════════════════╗
-║  🔄 skills-for-fabric Update Available                                ║
-║                                                                  ║
-║  Current: v0.1.0  →  Latest: v0.2.0                             ║
-╚══════════════════════════════════════════════════════════════════╝
-
-## What's New in v0.2.0
-
-[Display relevant CHANGELOG.md entries here]
-
-## Update Commands
-
-Choose the update method based on how you installed skills-for-fabric.
-
-### GitHub Copilot CLI (recommended)
-/plugin update fabric-skills@fabric-collection
-
-If you originally installed the plugin under the legacy id, this also works:
-  /plugin update skills-for-fabric@fabric-collection
-
-The plugin was renamed in 0.3.0 (skills-for-fabric → fabric-skills),
-but the legacy id is kept as a deprecated alias of fabric-skills, so
-either /plugin update command pulls the canonical payload.
-
-(Optional cleanup) To migrate your installed entry from the legacy id
-to the canonical fabric-skills id:
-  /plugin uninstall skills-for-fabric@fabric-collection
-  /plugin install fabric-skills@fabric-collection
-
-### Manual (Git clone)
-cd /path/to/skills-for-fabric
-git pull
-
-(There are no installation scripts to re-run on 0.3.0+.)
-
-─────────────────────────────────────────────────────────────────
-Would you like to update now? (The current skill will still work)
+/plugin update <installed-name>@<marketplace>
 ```
 
-### Step 6: Set Update Marker
+The installed marketplace entry is authoritative. For example, an installed
+`fabric-consumption@fabric-collection` entry produces:
 
-After completing the check (regardless of result), update `~/.config/fabric-collection/last-update-check.json` with today's **UTC date** (YYYY-MM-DD) for the current plugin. Create the directory and file if they don't exist. Preserve entries for other plugins already in the file.
+```text
+/plugin update fabric-consumption@fabric-collection
+```
+
+If the installed entry is the legacy `skills-for-fabric` alias, update that
+alias first so the installed entry can receive the current payload, even though
+its copied manifest is named `fabric-skills`:
+
+```text
+/plugin update skills-for-fabric@fabric-collection
+```
+
+Afterward, optional migration to the canonical entry is:
+
+```text
+/plugin uninstall skills-for-fabric@fabric-collection
+/plugin install fabric-skills@fabric-collection
+```
+
+GitHub Copilot CLI direct install:
+
+```text
+/plugin update <manifest-name>
+```
+
+The native CLI update target for a direct install is the bare manifest name.
+Do not append `@_direct` or use the opaque source ID as the update target.
+
+Claude Code marketplace install:
+
+```text
+claude plugin update <installed-name>@<marketplace> --scope <scope>
+```
+
+The entry name and scope must come from Claude's installed-plugin metadata. Do
+not reuse Copilot's `_direct` behavior for Claude Code.
+
+**Git channel**
+
+```text
+git -C "<detected-root>" pull --ff-only
+```
+
+**Unknown channel**
+
+State which expected files were absent and provide no update command. Never
+default to `fabric-skills`.
+
+**Copied-skill channel**
+
+A loose copy has no trustworthy repository, installed version, or native update
+target. This includes a skill materialized from a local file or URL by
+`copilot skill add` when no source metadata accompanies it.
+
+For an automatic invocation, do not interrupt the caller with a source question.
+Skip the copied-skill update flow, optionally state that an explicit update
+check can identify a supported replacement, and continue the caller's task.
+Do not list an executable command.
+
+For an explicit invocation, list the tentative skill names found at the
+candidate root, state that their provenance cannot be verified from the files
+alone, and ask:
+
+```text
+Were these skills copied from https://github.com/microsoft/skills-for-fabric?
+If yes, I can inspect the official public repository and show the supported
+plugin bundle that will refresh them. I will not install or remove anything
+without your confirmation.
+```
+
+Before the user confirms the source, do not contact the network, compare
+versions, write cache state, or offer an executable install/update command.
+
+After explicit confirmation:
+
+1. Read `.github/plugin/marketplace.json` from the `main` ref of
+   `microsoft/skills-for-fabric`, using authenticated GitHub tools first and
+   public raw content second.
+2. Match the tentative skill directory names against the skill paths inside
+   each marketplace plugin source. Treat only exact path matches as evidence.
+3. Prefer a focused plugin that covers all matched non-utility skills. If more
+   than one plugin qualifies, list the valid choices and ask the user to choose.
+   Never choose `fabric-skills` merely because `check-updates` appears in it.
+4. Offer only the replacement path supported by `runtimeHost`:
+
+   GitHub Copilot CLI:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   /plugin install <matched-plugin>@fabric-collection
+   ```
+
+   Claude Code, using `user` for a personal copied-skills root or `project` for
+   a project copied-skills root:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   claude plugin install <matched-plugin>@fabric-collection --scope <scope>
+   ```
+
+   Tell the user to run `/reload-plugins` or restart Claude Code after the
+   install. If the Claude scope cannot be resolved, ask instead of guessing.
+
+   For Cursor, Windsurf, Codex, other, or unknown hosts, link to the official
+   repository's installation instructions and provide no executable replacement
+   command. The current public repository does not expose a verified native
+   plugin marketplace for those hosts.
+
+This installs a complete current bundle instead of overwriting loose files and
+leaving mixed-version dependencies. Keep the loose copy until the native plugin
+is installed and verified. Ask separately before removing it. If no exact
+official mapping exists or the public repository is unavailable, report that
+and do not fabricate a bundle or copy individual files.
+
+## Examples
+
+### Focused plugin bundle
+
+```text
+Host: copilot-cli
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: /plugin update fabric-consumption@fabric-collection
+```
+
+### Claude Code plugin bundle
+
+```text
+Host: claude-code
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: claude plugin update fabric-consumption@fabric-collection --scope user
+Reload: /reload-plugins
+```
+
+### Git clone
+
+```text
+Detected: git:https://github.com/example/skills-for-fabric.git|C:\repos\skills-for-fabric
+Current: 0.3.7
+Latest: 0.3.8
+Update: git -C "C:\repos\skills-for-fabric" pull --ff-only
+```
+
+### Unknown layout
+
+```text
+Could not determine the skills-for-fabric installation at <candidate-root>.
+Expected a supported plugin manifest, or a positively identified
+skills-for-fabric package.json plus a direct .git entry.
+No update command was guessed.
+```
+
+### Confirmed official loose copy
+
+```text
+Host: copilot-cli
+Detected loose skills: check-updates, powerbi-report-planning
+Confirmed source: https://github.com/microsoft/skills-for-fabric
+Supported refresh:
+  /plugin marketplace add microsoft/skills-for-fabric
+  /plugin install powerbi-authoring@fabric-collection
+The loose files were not changed or removed.
+```
 
 ## Must
 
-- Check for updates only once per week (based on UTC calendar date, not session lifetime or local timezone)
-- Always proceed with the requested skill after the check (non-blocking)
-- Handle network errors gracefully (show warning, continue with skill)
-- Display the CHANGELOG.md content for versions between current and latest
+- Resolve identity from the active skill root or an explicit user path.
+- Resolve the runtime host independently from the installation layout.
+- Keep once-per-session invocation separate from the 7-day network guard.
+- Use the installed marketplace entry, not merely the manifest name, in plugin
+  identities and update commands.
+- Keep direct installs distinct from marketplace installs.
+- Require positive package and repository identity before using the Git channel.
+- Isolate Git cache entries by repository and exact clone root.
+- Preserve unrelated cache entries and use UTC dates.
+- Require source confirmation before looking up a loose copy in the official
+  public repository.
+- Match copied skill names to exact public marketplace skill paths.
+- Emit only update or replacement commands verified for the runtime host.
+- Continue non-blockingly after automatic checks.
 
 ## Prefer
 
-- Use Git CLI (Method A) or GitHub MCP tools (Method B) for version checking — these work with private repos
-- Fall back to the public GitHub REST API (Method C) **only** if Methods A and B both fail
-- Show a concise summary rather than overwhelming detail
-- Cache the check result in `~/.config/fabric-collection/last-update-check.json`
-- Provide copy-pasteable update commands
+- Use a root-local Git remote before authenticated GitHub tools.
+- Fetch version and changelog from the same repository ref.
+- Replace confirmed official loose copies through a complete native plugin
+  bundle rather than overwriting individual files.
+- Show concise, copy-pasteable output.
 
 ## Avoid
 
-- Blocking the user from using skills if update check fails
-- Checking on every skill invocation (once per week is sufficient)
-- Attempting Method C (public API) before trying Methods A or B
-- Relying solely on unauthenticated public API calls (will fail for private repos)
-- Auto-updating without user consent
+- Inferring installation context from the current working directory.
+- Letting `git` discover a parent repository.
+- Treating an unrelated package plus `.git` as a skills-for-fabric clone.
+- Inferring the runtime host from a manifest or install path.
+- Showing Copilot or Claude plugin commands to another host.
+- Defaulting focused bundles to `fabric-skills`.
+- Using GitHub Release tags as the plugin marketplace version.
+- Repeating failed automatic network checks every session.
+- Treating a same-named loose folder as proof that it came from the official
+  repository.
+- Replacing individual copied files without their complete bundle dependencies.
+- Updating without explicit user consent.
 
 ## Error Handling
 
-If the update check fails (network error, API rate limit, etc.):
+On failure, report the operation that failed and continue:
 
 ```text
-⚠️ Could not check for skills-for-fabric updates (network error).
-   Continuing with current version (v0.1.0).
-   Run '/skill check-updates' manually to retry.
+Could not check plugin:fabric-collection/fabric-consumption for updates: remote package.json was unavailable.
+Current installed version: 0.3.7
+The automatic check is non-blocking; continuing with the requested task.
 ```
 
-## Manual Invocation
-
-Users can manually check for updates at any time:
-- GitHub Copilot CLI: `/skill check-updates`
-- Other tools: Invoke the check-updates skill directly
-
-## Reference
-
-- **GitHub Repository**: https://github.com/microsoft/skills-for-fabric
-- **Releases**: https://github.com/microsoft/skills-for-fabric/releases
-- **CHANGELOG**: See `CHANGELOG.md` in repository root
+If the user says only "update my skills", clarify whether they want to check for
+an update or execute the detected native update command. Do not execute an
+update based on ambiguous intent.

--- a/plugins/fabric-skills/.github/plugin/plugin.json
+++ b/plugins/fabric-skills/.github/plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "name": "fabric-skills",
   "description": "Complete bundle: all Microsoft Skills for Fabric for developers and consumers",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "MIT",
   "repository": "https://github.com/microsoft/skills-for-fabric",
   "keywords": [
@@ -39,6 +39,7 @@
     "./skills/sqldb-operations-cli",
     "./skills/spark-operations-cli",
     "./skills/mlv-operations-cli",
+    "./skills/azmon-mirroredcatalogs-operations-cli",
     "./skills/dataflows-consumption-cli",
     "./skills/dataflows-authoring-cli",
     "./skills/dataflows-save-as-authoring-cli",

--- a/plugins/fabric-skills/skills/activator-authoring-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/activator-authoring-cli/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: activator-authoring-cli
 description: >
-  Create alerts, notifications, and automated actions on Fabric data and events
-  via Fabric REST API and `az rest` CLI. **Invoke this skill** whenever the user
-  wants to:
-  (1) create, update, or delete an alert or notification flow,
-  (2) send a Teams message, email, or run a Fabric item when something happens,
-  (3) connect alert logic to Eventhouse, Eventstream, Real-time Hub, or DTB / Ontology data,
-  (4) adjust thresholds, filters, event triggers, or actions,
-  (5) troubleshoot or change an existing Activator/Reflex definition.
-  Invoke this skill **before** asking clarifying questions — clarification is part of this skill, not a preamble to it.
+  Author Fabric Activator rules and Reflex items through Fabric REST API and `az rest`.
+  Invoke for write intents: create or delete items; add or update rule definitions;
+  configure thresholds, filters, Teams/email notifications, Fabric item actions, and
+  Eventhouse/Eventstream/Real-Time Hub/DTB/Ontology sources. Pure GET/explain prompts
+  belong to `activator-consumption-cli`. Clarification for missing sources, thresholds,
+  recipients, and action targets happens inside this skill.
   Triggers: "create an alert", "create an activator", "create a reflex",
   "create an activator item", "create an alert item",
   "notify me when", "let me know when",
@@ -201,6 +198,17 @@ Example rule entity:
 - In the rule's `FabricItemBinding`, set `fabricJobConnectionDocumentId` to the standalone `fabricItemAction-v1.uniqueIdentifier`
 - See [action-types.md](references/action-types.md) for per-target schemas and UDF-specific gotchas (`itemType` vs readback `FunctionSet`, `subitemId`, canonical `parameterType` mapping, dynamic parameter shape)
 
+### Reference Integrity Preflight
+
+Before every `updateDefinition`, validate the exact entity array you will send:
+
+1. Build the set of every top-level `uniqueIdentifier` in `ReflexEntities.json`.
+2. Confirm every `parentContainer.targetUniqueIdentifier`, `parentObject.targetUniqueIdentifier`, `SourceReference.entityId`, `EventReference.entityId`, `AttributeReference.entityId`, and `fabricJobConnectionDocumentId` resolves to an entity in that same array (or to an unchanged entity from the latest decoded readback that is included in the re-encoded array).
+3. Confirm each reference points to the expected entity type: containers to `container-v1`, source/event/attribute/rule/object references to `timeSeriesView-v1` when the template expects a view, source references to the source entity, and Fabric item action bindings to `fabricItemAction-v1`.
+4. If any reference is missing, rebuild the graph from the latest `getDefinition` output and do not call `updateDefinition`.
+
+`FailedToResolveEntity` with `DocumentType timeSeriesView not found` means a rule, attribute, split event, or event reference points at a `timeSeriesView-v1` GUID that is not present in the submitted definition. Treat that as an entity-wiring bug to fix before retrying, not as a transient backend failure.
+
 ### Entity Wiring Summary
 
 ```text
@@ -277,11 +285,23 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 
 ---
 
+## Source Validation Gate
+
+Before authoring **any** rule that references a signal (a measurement, field, or event property), confirm the source is real. A requested source only counts as **real** after all three checks pass:
+
+1. **Resolve** the source in the **requested** workspace only -- do not search or substitute another workspace.
+2. **Validate** that the requested signal column/field exists on that source (KQL table/column, Eventstream field, Real-Time Hub event property, or DTB / Ontology property).
+3. **Observe** at least one representative row/event/sample carrying that signal -- run the KQL / DTB query or inspect the stream and confirm it actually returns data.
+
+Treat **schema-only**, **zero-row**, **non-emitting**, or **stale** evidence as **missing source data**, not a real source. When the source is missing, **stop and ask** which source and fields provide the signal (plus any missing threshold, recipient, or action details). Do **not** create a Reflex or call `updateDefinition` on any existing Activator / Eventstream to force-fit the request, and state plainly that **no Activator / Reflex / Eventstream was created or updated**. The only exception is when the user explicitly instructs you to author against a future / not-yet-emitting source.
+
+---
+
 ## Must / Prefer / Avoid
 
 ### MUST DO
 
-- **Confirm a real source before authoring** -- when the request targets a specific signal or measurement (for example "temperature > 30"), first resolve the workspace and verify that a discoverable source (Eventhouse/KQL table, Eventstream, Real-Time Hub, or DTB / Ontology) actually exposes that signal. If none does, **stop and ask** which source and fields provide it (plus any missing threshold, recipient, or action details) instead of authoring the rule
+- **Confirm a real source before authoring** -- follow the [Source Validation Gate](#source-validation-gate): resolve the source in the requested workspace, validate the requested signal column/field, and observe at least one representative row/event/sample before authoring. Schema-only, zero-row, non-emitting, or stale evidence is **missing source data** -- **stop and ask** which source and fields provide it (plus any missing threshold, recipient, or action details), and state that no Activator/Reflex/Eventstream was created or updated, instead of authoring the rule. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming the source was observed.
 - **Always use `--resource https://api.fabric.microsoft.com`** with `az rest` — without it, token audience is wrong
 - **Always send `--body '{}'`** for `getDefinition` — it is a POST and omitting the body can cause 411 errors
 - **Always Base64-encode** `ReflexEntities.json` payload when calling `updateDefinition`
@@ -289,6 +309,7 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 - **Always use the correct template type** — `AttributeTrigger` for value-based conditions (has ScalarSelectStep + ScalarDetectStep), `EventTrigger` for event-based firing (has FieldsDefaultsStep + EventDetectStep, no ScalarDetectStep)
 - **Always use new GUIDs** for `uniqueIdentifier` when adding entities — duplicate GUIDs cause corruption
 - **Always update all cross-references** when changing a `uniqueIdentifier` — other entities reference it via `targetUniqueIdentifier`
+- **Always run the Reference Integrity Preflight before `updateDefinition`** -- every `targetUniqueIdentifier`, `entityId`, and `fabricJobConnectionDocumentId` in the payload must resolve to an entity included in the submitted `ReflexEntities.json`
 - **Handle LRO responses** — `create`, `getDefinition`, and `updateDefinition` may return 202; poll the `Location` header
 
 ### PREFER
@@ -308,7 +329,8 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 - **Pre-filtering conditions in the KQL query** — return all data from KQL and let the Activator rule steps handle thresholds, text conditions, and dimensional filters. KQL is the data source, not the rule engine
 - **Inline JSON in PowerShell `az rest --body`** — PowerShell mangles quotes and special characters. Always write JSON to a temp file with `[System.IO.File]::WriteAllText($path, $json, [System.Text.UTF8Encoding]::new($false))` and pass `--body @$path`
 - **Reusing display names after deletion** — soft-deleted items hold their name for several minutes. Use a unique name or hard-delete first
-- **Force-fitting a request onto unrelated existing items** -- when no source exposes the requested signal, do NOT create a Reflex or call `updateDefinition` on an unrelated existing Activator / Eventstream to satisfy it; ask for the missing source first
+- **Force-fitting a request onto unrelated existing items** -- when no source clears the [Source Validation Gate](#source-validation-gate) (missing, schema-only, zero-row, non-emitting, or stale), do NOT create a Reflex or call `updateDefinition` on an unrelated existing Activator / Eventstream to satisfy it; ask for the missing source first
+- **Read-only listing or inspection** -- use [activator-consumption-cli](../activator-consumption-cli/SKILL.md) for prompts like "show me all Activators", "list Activators", "show the rules", "inspect this alert", or "decode the definition". This authoring skill should only run when the user asks to create, update, delete, configure, or change something.
 
 ---
 

--- a/plugins/fabric-skills/skills/activator-authoring-cli/references/dtb-source.md
+++ b/plugins/fabric-skills/skills/activator-authoring-cli/references/dtb-source.md
@@ -6,7 +6,7 @@ Queries an existing **Digital Twin Builder** or **Ontology** Fabric item on a sc
 
 > **Time-axis default:** If the DTB query results include a reasonable datetime field, prefer `eventTimeSettings` plus `DURATION_START` / `DURATION_END` query parameters. Only use snapshot mode when the query returns current-state rows with no reasonable event-time field.
 
-> **Validate first:** Before creating or updating the Activator, run the DTB / Ontology query directly first and confirm the returned columns, key fields, and timestamp field are correct.
+> **Validate first:** Before creating or updating the Activator, run the DTB / Ontology query directly first and confirm the returned columns, key fields, timestamp field, requested signal field, and at least one representative row are correct. If the query returns no rows or the requested field is missing, treat the source as missing and ask for the correct source and fields rather than authoring against an empty source. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming rows were observed.
 
 ```json
 {

--- a/plugins/fabric-skills/skills/activator-authoring-cli/references/kql-source.md
+++ b/plugins/fabric-skills/skills/activator-authoring-cli/references/kql-source.md
@@ -6,7 +6,7 @@ Queries a KQL database (Eventhouse or ADX/Kusto cluster) on a configurable sched
 
 > **Time-axis default:** If the query results include a reasonable datetime column, always configure `eventTimeSettings` and `queryParameters` so the source runs with a time axis. Only fall back to **snapshot mode** when the underlying data has no reasonable timestamp column and each row represents the latest state.
 
-> **Validate first:** Before creating or updating the Activator, run the KQL directly against the target KQL source and confirm the returned columns, timestamp field, and row shape are correct.
+> **Validate first:** Before creating or updating the Activator, run the KQL directly against the target KQL source and confirm the returned columns, timestamp field, and row shape are correct. If the query returns **no rows** (or the table/column does not exist), treat the source as **missing** -- stop and ask for the correct source and fields rather than authoring against an empty source. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming rows were observed.
 
 ```json
 {

--- a/plugins/fabric-skills/skills/activator-authoring-cli/references/source-types.md
+++ b/plugins/fabric-skills/skills/activator-authoring-cli/references/source-types.md
@@ -37,6 +37,12 @@ Every entity in `ReflexEntities.json`:
 | `payload` | object | yes | Entity-specific configuration |
 | `type` | string | yes | Entity type (see below) |
 
+## Reference Integrity Preflight
+
+Before submitting `updateDefinition`, validate the full `ReflexEntities.json` array, not just the entity you changed. Every `parentContainer.targetUniqueIdentifier`, `parentObject.targetUniqueIdentifier`, `SourceReference.entityId`, `EventReference.entityId`, and `AttributeReference.entityId` must resolve to a top-level `uniqueIdentifier` in that same submitted array. Fabric item action rules must also resolve `fabricJobConnectionDocumentId` to a `fabricItemAction-v1.uniqueIdentifier` in the same array.
+
+If Fabric returns `FailedToResolveEntity` with `DocumentType timeSeriesView not found`, one of those references points at a `timeSeriesView-v1` GUID that is absent from the payload. Re-read the definition, preserve existing entities, fix the missing reference, and retry only after the preflight passes.
+
 ---
 
 ## Container (`container-v1`)

--- a/plugins/fabric-skills/skills/activator-consumption-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/activator-consumption-cli/SKILL.md
@@ -12,7 +12,7 @@ description: >
   **Invoke this skill before answering questions** about an Activator/Reflex item
   in a Fabric workspace — the listing, lookup, and decoding workflows are part of
   this skill, not preamble to it.
-  Triggers: "show my alerts", "what alerts do I have", "inspect this alert",
+  Triggers: "show my alerts", "what alerts do I have", "show me all activators", "inspect this alert",
   "show me the rule", "show me the action", "show me the source",
   "get reflex definition", "list activators", "list alerts",
   "list reflex items", "show activator items", "activator details",

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/SKILL.md
@@ -1,0 +1,876 @@
+---
+name: azmon-mirroredcatalogs-operations-cli
+description: "Onboard Log Analytics, Application Insights, and Azure Monitor telemetry into Microsoft Fabric as a Mirrored Catalog, then turn it into business-impact insights by correlating telemetry with business data via Eventhouse shortcuts, verified schemas, and ready-to-use Operations Agent instructions. Triggers: onboard Log Analytics telemetry, connect Application Insights to a Mirrored Catalog, correlate App Insights telemetry with business data, build an Operations Agent for business-impact alerting, determine if availability or latency impacted bookings orders or revenue."
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+# azmon-mirroredcatalogs-operations-cli
+
+Guide a user end-to-end to (1) onboard Azure Monitor / Application Insights /
+Log Analytics observability data into Microsoft Fabric as a Mirrored Catalog
+(AzMon) item, and (2) turn that telemetry into **business-impact insights** by
+correlating observability signals with business data (bookings, orders,
+customers, flights, payments, revenue, tenants, accounts, subscriptions, usage
+KPIs, SLA/availability KPIs), ending in ready-to-paste **Operations Agent**
+instructions.
+
+This is a **self-contained Skills-for-Fabric package**. It does **not** depend on
+any MCP server or tool controller as the execution mechanism. Product/API
+knowledge, supported flows, guardrails, and modeling rules live in this file and
+in `references/*.md`.
+
+## Prerequisite Knowledge
+
+Before running this skill, read the shared common guidance:
+
+- [Authentication & token acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition)
+- [Authentication recipes](../../common/COMMON-CLI.md#authentication-recipes)
+
+## Trigger phrases
+
+- onboard Azure Monitor data into Fabric
+- create Azure Monitor item in Fabric
+- connect Application Insights to Fabric
+- correlate App Insights telemetry with business data
+- onboard my LA workspace to Fabric
+- onboard Log Analytics workspace to Fabric
+- connect Log Analytics workspace to Fabric
+- understand if service availability impacted bookings
+- understand if latency impacted conversion
+- correlate exceptions with revenue or orders
+- build Operations Agent for Azure Monitor business impact
+- create business impact insights from Log Analytics data
+
+## When to use this skill (and related skills)
+
+`azmon-mirroredcatalogs-operations-cli` is for onboarding Azure Monitor /
+Application Insights / Log Analytics telemetry into Microsoft Fabric
+(mirroredCatalogs endpoint), correlating that telemetry with business data, and
+generating Operations Agent instructions. For general Eventhouse / KQL querying
+unrelated to Azure Monitor onboarding, use `eventhouse-consumption-cli`; for
+authoring Eventhouse items and databases, use `eventhouse-authoring-cli`.
+
+## Reference index
+
+Read these when the corresponding stage needs product/API detail. Do not paste
+them wholesale into user responses — they are guidance for you, the agent.
+
+| Reference | Use it for |
+|-----------|-----------|
+| [references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md) | Supported vs UI-only flows; connector modes; Fabric item/agent surfaces |
+| [references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md) | Mirrored Catalog item CRUD, definition, discovery, monitoring, refresh |
+| [references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md) | Eventhouse/KQL, OneLake shortcuts, queryability requirement |
+| [references/operations-agent-reference.md](references/operations-agent-reference.md) | Operations Agent instruction template, validation, troubleshooting |
+| [references/app-insights-table-reference.md](references/app-insights-table-reference.md) | App Insights / Azure Monitor telemetry tables and business meaning |
+| [references/app-insights-dynamic-fields-reference.md](references/app-insights-dynamic-fields-reference.md) | Dynamic fields (Properties/CustomDimensions) and hidden business keys |
+| [references/business-correlation-patterns.md](references/business-correlation-patterns.md) | Signal → business-impact patterns and candidate keys |
+| [references/business-insight-modeling-reference.md](references/business-insight-modeling-reference.md) | Bins, derived entities, direct join vs time-window, thresholds |
+
+## Secrecy & scope guardrails
+
+- Do NOT expose Azure Log Analytics backend APIs to the user.
+- Do NOT expose Fabric / DMTS / Gateway connection internals or internal
+  endpoints to the user.
+- Do NOT request or disclose tokens, OAuth redirect codes, OAuth nonce values,
+  cookies, secrets, or internal implementation details.
+- Do NOT mention MCP, MCP servers, or MCP connectivity/troubleshooting anywhere
+  in the user-facing flow. This Skill is self-contained.
+- Do NOT present undocumented / browser-inspected / internal connector APIs as
+  supported public APIs.
+- Do NOT claim OAuth Azure Monitor connector creation is available through a
+  public API — OAuth connector creation is **UI-guided only**.
+- Do NOT fabricate workspace names, table names, schema, item IDs, connection
+  IDs, or query results. Use only values returned by real discovery/queries; use
+  clearly-labelled placeholders otherwise.
+- Do NOT ask the user for JOIN logic, KQL, bins, or thresholds upfront.
+- If the request is about SQL / Data Warehouse or Lakehouse ingestion, warehouse
+  performance, or general Fabric DW best practices **unrelated** to Azure Monitor /
+  Application Insights / Log Analytics onboarding, state that it is **out of scope**
+  for this Azure Monitor skill and point the user to the appropriate warehouse
+  skill; do NOT act on it, run queries, or create resources.
+
+### Domain-agnostic rule
+
+Business entities named anywhere in this Skill or its references — bookings,
+orders, customers, flights, revenue, tenants, payments, and similar — are
+**EXAMPLES ONLY** (non-normative illustrations). The Skill is **domain-agnostic**
+and MUST NOT infer or assume the user's business domain from these examples, from
+table/column names that resemble an example, or from any prior context. The
+user's actual business entities MUST be discovered from real Fabric data
+(Eventhouse / KQL database / Warehouse / Lakehouse / shortcuts) and confirmed with
+the user before use. Until discovered and confirmed, refer to them generically —
+as *business entities*, *business datasets*, *business KPIs*, or *business
+outcomes*.
+
+## EXECUTION CAPABILITY POLICY
+
+The Skill is a guided staged workflow; actual execution depends on capabilities
+available in the current environment. Portal-guided instructions are allowed ONLY
+for OAuth Azure Monitor connector creation — the Skill MUST NOT switch the entire
+onboarding flow to portal guidance as a generic fallback. For all non-OAuth
+stages, the Skill MUST first discover whether a supported execution path exists.
+
+Supported execution paths may include:
+
+- Fabric REST APIs
+- Azure REST APIs
+- Fabric Actions
+- Azure CLI
+- Azure Resource Graph
+- Fabric REST **read-only** discovery via authenticated `az rest --method get`
+  against `https://api.fabric.microsoft.com/...` (discovery/read-only only)
+- Other documented supported capabilities available to the agent
+
+**Log Analytics REST API reference (agent-facing).** When the Skill needs to perform or validate Azure Log Analytics operations, it may consult the official [Log Analytics REST APIs](https://learn.microsoft.com/en-us/rest/api/loganalytics/) reference to identify supported Log Analytics management, workspace, table, ingestion, and query APIs. This is agent-facing guidance only and does not relax the secrecy rule above.
+
+These execution paths are distinct and MUST NOT be conflated:
+
+1. **Kusto / KQL data-plane execution** — telemetry queries; optional, and MUST
+   NOT be used when disabled.
+2. **Azure ARM control-plane discovery** — resource/metadata enumeration.
+3. **Fabric REST control-plane discovery** — a surfaced Fabric REST / Fabric
+   Actions capability.
+4. **Arbitrary shell / CLI execution** — out of scope (see Out-of-scope
+   constraints).
+5. **Fabric REST read-only discovery via authenticated `az rest --method get`** —
+   a narrow GET-only exception for Fabric discovery/read against
+   `https://api.fabric.microsoft.com/...`; never mutates anything and never
+   exposes tokens, secrets, or auth headers. NOT general shell/CLI access.
+
+MCP unavailability alone does NOT mean execution capability is unavailable.
+Unavailability of any single execution path does NOT imply the capability is
+unavailable. Before declaring a capability unavailable, the Skill MUST evaluate
+ALL supported execution paths listed above and confirm none is available.
+
+If no supported execution path exists, the Skill MUST: stop; identify the missing
+capability; explain why it is required; identify which stage is blocked; and wait
+for user confirmation.
+
+The Skill MUST NOT replace validation, Mirrored Catalog creation, discovery,
+monitoring, refresh, shortcut creation, schema verification, or Operations Agent
+creation with portal guidance, and MUST NOT claim an action completed when
+execution capability is unavailable.
+
+
+## PORTAL GUIDANCE POLICY
+
+Prefer automated execution paths (Fabric REST, Azure REST, Fabric Actions, Azure
+CLI, other supported automation) over UI-guided instructions. Before providing
+UI-guided instructions the Skill MUST: (1) evaluate the available execution paths,
+(2) attempt supported ones where available, (3) explain which were evaluated and
+why they cannot be used. OAuth Azure Monitor connector creation is the one
+explicitly supported UI-guided scenario and is exempt from this evaluation.
+
+
+## STRICT STAGED WORKFLOW CONTROLLER (ENFORCED)
+
+The Skill MUST operate as a strict staged workflow controller.
+
+### Stages
+
+1. Intent and scope
+2. Log Analytics workspace selection
+3. Fabric workspace selection
+4. Validation
+5. Connection resolution
+6. AzMon / Mirrored Catalog item creation or reuse
+7. **Business Insight Capture** (immediately after item creation/reuse)
+8. Azure Monitor table discovery
+9. Eventhouse / KQL database selection
+10. Shortcut planning
+11. Shortcut creation
+12. Schema and data verification
+13. Business data discovery and scoring
+14. Correlation planning
+15. Operations Agent instruction generation
+16. Optional Operations Agent creation / validation
+
+### Execution rules
+
+- The Skill MUST track and enforce the current stage.
+- The Skill MUST NOT skip stages.
+- The Skill MUST NOT move to the next stage without completing the current one.
+
+### Stage visibility (REQUIRED in every user-facing response)
+
+Begin every response with exactly this structure:
+
+```text
+Current stage: <stage name>
+What I found:
+<short summary>
+
+Next step:
+<one clear action>
+
+Waiting for your confirmation to continue.
+```
+
+If the current stage is unclear → **STOP** and ask the user where to resume.
+
+**Stage 15 exemption (ready-to-paste block).** The Stage 15 Operations Agent
+instructions are delivered as ONE self-contained, ready-to-paste fenced block.
+For that response only, place the stage-visibility header and the
+`Waiting for your confirmation to continue.` line OUTSIDE and AROUND the fenced
+block — the header (and a one-line summary) immediately before it, the
+confirmation line immediately after it. Do NOT insert the header, summary,
+`What I found` / `Next step` labels, or the confirmation line INSIDE the
+ready-to-paste block: the fenced block must contain only the Operations Agent
+instructions so the user can copy it verbatim.
+
+### Hard stop behavior
+
+After presenting any step that requires confirmation:
+
+- **STOP.**
+- **WAIT** for explicit user confirmation.
+- Do **not** continue automatically.
+
+### Confirmation gates (explicit confirmation REQUIRED before)
+
+- Creating or reusing any resource that modifies Fabric.
+- Selecting an Eventhouse / KQL database.
+- Creating shortcuts.
+- Proceeding from schema verification (Stage 12) to correlation planning
+  (Stage 14).
+- Generating final Operations Agent instructions if the correlation model has
+  not been confirmed.
+- Creating or modifying an Operations Agent.
+
+### Stage guardrails
+
+- Shortcut planning (Stage 10) MUST occur before schema verification or join
+  logic. If schema/join is attempted early → STOP and return to shortcut
+  planning.
+- Shortcut creation (Stage 11) MUST complete before schema verification.
+- Schema verification (Stage 12) MUST complete before correlation planning
+  (Stage 14).
+- If data is not queryable in Eventhouse via shortcuts → STOP → return to
+  shortcut planning / creation.
+- Correlation planning MUST NOT begin until data queryability via shortcuts is
+  confirmed.
+- Business Insight Capture (Stage 7) MUST be satisfied (intent provided OR a
+  suggested direction explicitly selected) before correlation planning. Never
+  assume intent.
+
+### Out-of-scope constraints
+
+The Skill MUST NOT run arbitrary shell/CLI/az/PowerShell commands, perform network
+debugging, investigate server connectivity, or execute infrastructure
+troubleshooting. These are out of scope unless explicitly part of the current
+stage.
+
+**Narrow exception — Fabric REST read-only discovery.** The Skill MAY use an
+authenticated `az rest --method get` call ONLY for Fabric REST read-only
+discovery, and ONLY when ALL hold: endpoint is
+`https://api.fabric.microsoft.com/...`; method is **GET** only; the operation is
+discovery/read-only; nothing is created, updated, deleted, or modified; no tokens,
+secrets, auth headers, or sensitive payloads are exposed; and the Skill states the
+capability path used. This exception does NOT permit arbitrary shell/CLI
+execution, non-GET `az rest` calls, or use of the Kusto / KQL data-plane when
+disabled.
+
+### Response style (ENFORCED)
+
+Behave like a **guided product experience**, not a backend debugger.
+
+- Use concise, business-friendly language.
+- Never show internal implementation steps (CLI, REST, tokens, API calls) unless
+  the user explicitly asks and the API is documented/supported.
+- Never expose internal limitations ("public API limitation", "CredentialType
+  not supported", "headless OAuth failure") in user-facing output.
+- Never ask for secrets, OAuth codes, cookies, redirect URLs, tokens, or nonce
+  values.
+- Summarize findings. Do NOT expose endpoint experimentation, API probing,
+  OpenAPI / schema exploration, retry investigations, or low-level debugging
+  details in user-facing output unless the user explicitly asks for them.
+- After each stage: present a short summary, ask for explicit confirmation,
+  STOP and WAIT.
+
+---
+
+## Stage 1 — Intent and scope
+
+Confirm what the user wants: onboard observability data into Fabric, explore a
+business insight, or both. Capture (in plain language) any workspace names or
+business outcome they already mention — but do not yet drive correlation.
+
+## Stage 2 — Log Analytics workspace selection
+
+Application Insights telemetry is queried through its backing Log Analytics
+workspace (workspace-based Application Insights). Help the user pick the correct
+Log Analytics / Application Insights-backed workspace.
+
+- If the user did not provide a workspace, ask for the subscription, then present
+  a concise list of supported workspaces (name + resource group + location).
+  Never expose raw API responses.
+- Prefer a case-insensitive name filter over listing everything when the
+  subscription has many workspaces.
+
+### Exact-name-not-found fallback (REQUIRED)
+
+When the user names a workspace and no **exact** match exists, the Skill MUST NOT
+fail. Instead:
+
+1. Ask for the subscription if not provided (do not guess).
+2. Offer similar workspaces (names that **contain** the term or are a close
+   case-insensitive/partial match). Broaden the search if a narrow filter returns
+   nothing.
+3. Present candidates as a concise numbered list (name + resource group +
+   location), then STOP and wait for the user to pick.
+4. If exactly one similar workspace is found, still confirm before proceeding.
+5. If none is found, say so plainly and ask for a different subscription or term.
+
+Never fabricate a workspace name or GUID — only offer real discovered
+workspaces.
+
+## Stage 3 — Fabric workspace selection
+
+Help the user choose the target Fabric workspace (display name + id). Use a
+case-insensitive substring filter when helpful. Read-only; nothing is created
+here. Never expose raw API responses or tokens.
+
+### Fabric Workspace Discovery & Capability Resolution Policy (REQUIRED)
+
+Fabric workspaces are **not** ARM resources, so missing automatic enumeration does
+NOT mean no workspace exists. Follow the full required policy in
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md#fabric-workspace-discovery--capability-resolution):
+discover all surfaced Fabric mechanisms first (Fabric REST/Actions, OneLake/Power
+BI, and read-only `az rest --method get` against `https://api.fabric.microsoft.com/...`);
+never terminate on missing enumeration; ask the user for a workspace Name / ID /
+URL; validate before continuing; and mark Stage 3 BLOCKED only after ALL discovery
+AND user-supplied paths are exhausted. UI-guided selection is the final fallback only.
+
+## Stage 4 — Validation
+
+Before any creation, verify:
+
+- The workspace exists.
+- The workspace is **not Sentinel** or otherwise unsupported.
+- The caller has the required Log Analytics access.
+- The caller has sufficient Fabric workspace permission to create the item.
+
+If validation fails, summarize which checks passed/failed in user terms, explain
+the missing capability, and offer to try another workspace or request access.
+See `references/azmon-fabric-api-reference.md` for supported-scope rules.
+
+### Sentinel detection source hierarchy (REQUIRED)
+
+Sentinel detection is a **control-plane** check and MUST NOT be treated as
+dependent on Kusto / KQL data-plane availability. Follow the full required
+hierarchy in
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md#sentinel-detection-source-hierarchy):
+enumerate ARM resources / `Microsoft.OperationsManagement/solutions`
+`SecurityInsights(<workspaceName>)` / `Microsoft.SecurityInsights/*` /
+feature metadata, then classify as **Sentinel / blocked**, **Not Sentinel
+(control-plane verified)**, or — only if all checks are unavailable —
+**not verifiable**. Never fabricate Sentinel status.
+
+### Validation capability discovery (REQUIRED)
+
+Apply the [EXECUTION CAPABILITY POLICY](#execution-capability-policy): evaluate ALL
+supported execution paths (Fabric REST, Azure REST, Fabric Actions, Azure CLI,
+Azure Resource Graph) before declaring validation capability unavailable. MCP is
+only one possible path.
+
+## Stage 5 — Connection resolution
+
+Two connection modes are supported. Keep them **separate**. Never route OAuth
+through Service Principal logic, and never route Service Principal through OAuth /
+interactive sign-in logic. See
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md)
+for the authoritative connector rules.
+
+### Portal guidance boundary
+
+Portal-guided instructions are permitted ONLY for OAuth Azure Monitor connector creation.
+
+Portal guidance is NOT an allowed fallback for:
+
+- LAW validation
+- Fabric workspace validation
+- Connection detection
+- Connection reuse
+- Service Principal connector creation
+- Mirrored Catalog item creation
+- Discovery
+- Monitoring
+- Refresh
+- Eventhouse shortcut creation
+- Schema verification
+- Operations Agent creation
+
+If execution capability for these actions is unavailable, the Skill MUST stop and identify the missing capability.
+
+### Mode A — OAuth (UI-guided only)
+
+- OAuth connector **creation** is interactive, done once in **Fabric → Manage
+  Connections**. The Skill does **not** create OAuth connectors through any API.
+- The Skill **detects and reuses** an existing Azure Monitor OAuth connection for
+  this workspace (read-only, non-destructive).
+- Before classifying OAuth connection detection as "not verifiable", attempt the
+  available Fabric REST **read-only** connection discovery paths, in order:
+  1. A surfaced Fabric REST / Fabric Actions capability, if available.
+  2. Authenticated Fabric REST read-only discovery via `az rest --method get`
+     against `https://api.fabric.microsoft.com/...`, if Azure CLI execution is
+     available and permitted under the read-only Fabric REST discovery exception
+     (GET-only, no modifications, no secret/token/header exposure, capability
+     path stated). This detection is read-only; OAuth connector **creation**
+     remains UI-guided only.
+- Reuse a connection ONLY if it belongs to the **same** Log Analytics workspace
+  (exact data-source-path / LAW resource-id match). Any mismatch → treat as "no
+  matching connection".
+- If exactly one match → reuse automatically and continue.
+- If multiple matches → show display names and ask the user to choose (never
+  auto-pick).
+- If no match → guide the user with this exact, simple message and then WAIT:
+
+```text
+I couldn’t find an existing Azure Monitor connection for this workspace.
+Please create it once in Fabric Manage Connections, then come back and continue.
+
+1. Open Fabric.
+2. Go to Manage Connections.
+3. Select New connection → Azure Monitor.
+4. Sign in with your organizational account.
+5. Use the same Log Analytics Workspace.
+6. When done, come back here and type: Done.
+```
+
+When the user resumes, re-detect and continue automatically ("Connection
+detected. Continuing setup.").
+
+### Mode B — Service Principal (automated create-or-reuse)
+
+Present this as **"connect using Service Principal"** — the automated,
+non-interactive path (no user login, no UI step).
+
+- **Idempotent create-or-reuse**: if a matching Azure Monitor Service Principal
+  connector already exists for the same Log Analytics workspace (same data source
+  path + Service Principal credential type), reuse it — never create a duplicate.
+- Only **one** connector is created per run.
+- **Never** reuse a non-Service-Principal (e.g. OAuth) connector in this mode.
+- **Never** ask the user to paste a client secret into chat. Secrets come from
+  **environment variables or Key Vault references** only, are never echoed,
+  logged, exposed, or included in generated instructions.
+- If required Service Principal inputs are missing, describe **what** is missing
+  (tenant id, app/client id, and a securely-provided secret reference) using
+  presence checks only — never request the secret value in chat.
+
+Automation boundary: infrastructure (connector create-or-reuse, mirrored item
+creation) is automated; **business decisions** (Eventhouse/KQL DB selection,
+shortcut creation) always require explicit user confirmation.
+
+## Stage 6 — AzMon / Mirrored Catalog item creation or reuse
+
+Create the Azure Monitor **Mirrored Catalog** item in the target Fabric
+workspace, or reuse an existing matching item. This is a Fabric-modifying action
+→ confirm first. Supported Mirrored Catalog operations (item CRUD, definition,
+discovery, monitoring, refresh) are documented in
+[references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md).
+
+After the item is created or reused, immediately proceed to Business Insight
+Capture (Stage 7).
+
+## Stage 7 — Business Insight Capture (MANDATORY, happens here — early)
+
+Immediately after the AzMon item is created or reused, ask the user **what
+business insight they want to explore**, so discovery and table selection are
+guided by the business outcome.
+
+Ask in business language, e.g.:
+
+- Did service availability issues impact bookings?
+- Did request latency reduce customer conversions?
+- Did exceptions affect revenue or orders?
+- Did dependency failures impact specific customers, tenants, regions, or
+  flights?
+- Did incidents affect SLA, usage, or customer activity?
+- Did traffic drops correlate with usage KPI degradation?
+
+### Enforcement
+
+The Skill MUST NOT proceed to business correlation without either:
+
+- (a) user-provided business intent, OR
+- (b) explicit user selection from suggested directions.
+
+Never assume intent.
+
+### Fallback (when the user is unsure / vague / no exact match)
+
+Suggest 3–5 directions, each framed as **observability signal → business
+impact**, and ask the user to choose one:
+
+1. Availability failures → booking completion impact.
+2. Request latency → conversion or checkout drop.
+3. Exceptions → failed orders or revenue at risk.
+4. Dependency failures → customer / tenant / region impact.
+5. Traffic drops → usage KPI degradation.
+
+### Important distinction
+
+Capturing intent early is allowed and required. But the Skill MUST NOT generate
+correlation logic yet. Correlation logic only comes after shortcuts exist, schema
+is verified, data is queryable, dynamic fields are inspected, join candidates are
+validated, and data freshness is checked (Stages 10–14).
+
+## Stage 8 — Azure Monitor table discovery
+
+Browse candidate Azure Monitor / Application Insights tables relevant to the
+captured business goal. Use only real discovered scope/table values — never
+fabricate table names. Use
+[references/app-insights-table-reference.md](references/app-insights-table-reference.md)
+to explain what each table means in business terms and which tables best fit the
+stated goal.
+
+### Discovery API fallback policy (REQUIRED)
+
+The **primary** discovery mechanism is the Mirrored Catalog Discovery APIs. If
+discovery appears incomplete, do NOT immediately conclude tables are missing or
+switch to alternative metadata paths. First:
+
+1. Verify mirror status.
+2. Verify refresh / sync status.
+3. Verify discovery scope.
+4. Retry discovery.
+
+Only after these checks may the Skill evaluate alternative metadata paths. See
+[references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md).
+
+## Stage 9 — Eventhouse / KQL database selection
+
+Before asking the user to choose an Eventhouse, run **Eventhouse Recommendation
+Mode**:
+
+1. **Discover** available Eventhouses.
+2. **Inspect** their available contents (tables, shortcuts, KQL databases).
+3. **Score** each Eventhouse.
+4. **Present** a recommendation.
+
+Score each Eventhouse by:
+
+- Relevant business tables
+- Relevant telemetry tables
+- Existing shortcuts
+- Queryable tables
+- KQL database availability
+- Data freshness
+- Alignment to the selected business goal
+
+Present the result in this format:
+
+```text
+Recommended Eventhouse:
+<EventHouseName>
+
+Reason:
+<why this Eventhouse was chosen>
+
+Alternative Eventhouses:
+<list>
+```
+
+The Skill MUST NOT auto-select, even when one Eventhouse scores highest. This is a
+user decision (confirmation gate) — present the recommendation and **require
+explicit confirmation** before proceeding. See
+[references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md).
+
+## Stage 10 — Shortcut planning
+
+Plan OneLake shortcuts from the AzMon item's tables into the selected
+Eventhouse / KQL database **before** any schema verification or join logic.
+Present the plan and STOP for confirmation.
+
+Key rules (see the shortcuts reference for detail):
+
+- Keep source table names **exact** — a renamed shortcut may create the OneLake
+  link but fail to register as a queryable KQL table.
+- A OneLake link alone is **not** enough — the table must be registered as an
+  external/queryable table.
+
+### Shortcut acceleration (SHOULD)
+
+Query acceleration on shortcuts SHOULD be treated as the preferred configuration
+because testing showed schema verification, queryability validation, telemetry
+sampling, correlation analysis, and Operations Agent preparation became
+substantially faster when acceleration was enabled. Present the shortcut plan with
+an acceleration column:
+
+| Shortcut Name | Source | Target | Acceleration Supported (Yes/No) | Acceleration Enabled (Yes/No) |
+|---------------|--------|--------|---------------------------------|-------------------------------|
+
+If acceleration is disabled, explain the potential impact on: queryability
+validation, schema verification, telemetry sampling, correlation analysis, and
+Operations Agent preparation. Do NOT assume acceleration exists in every
+environment — use SHOULD, not MUST. See
+[references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md).
+
+## Stage 11 — Shortcut creation
+
+Only after explicit confirmation, create the planned shortcuts. Then verify each
+table is actually **queryable** in Eventhouse (e.g. `<Table> | take 1`). Do not
+assume a OneLake link means the table is queryable. If a table is not queryable →
+STOP and return to shortcut planning / creation.
+
+When creating ANY shortcut, apply the **Shortcut Acceleration Policy**:
+
+1. Determine whether acceleration is supported for the shortcut.
+2. Determine its current acceleration status.
+3. Enable acceleration when supported and appropriate (preferred configuration).
+4. Report the acceleration status back to the user.
+
+## Stage 12 — Schema and data verification (REQUIRED before correlation)
+
+Never build correlation logic on assumptions or screenshots. Before proposing any
+join, bin, or threshold, verify against the **actual** KQL database.
+
+### Preconditions
+
+1. Operational telemetry tables are available in the Eventhouse / KQL database.
+2. Business tables are available in the same database or queryable via shortcuts.
+3. Tables are **queryable**, not just visible in OneLake.
+4. Schema retrieved via `getschema`.
+5. Dynamic fields inspected and sampled.
+6. Candidate join keys extracted from top-level **and** dynamic columns.
+7. Join keys validated with **non-zero** match results (when a direct join is
+   proposed).
+8. Data freshness verified.
+9. Time window aligned to the real data range.
+10. Relevant categorical values confirmed from real data where rules depend on
+    them.
+
+### Steps
+
+1. **Retrieve real schema.** For each table:
+   `TableName | getschema | project ColumnName, ColumnType`. Use authoritative
+   column names/types — not names guessed from screenshots or table names.
+2. **Inspect and sample dynamic fields.** Business join keys are often nested in
+   dynamic columns (`Properties`, `CustomDimensions`, `Details`, `Measurements`,
+   `Payload`, `Context`). Sample rows and inspect keys. See
+   [references/app-insights-dynamic-fields-reference.md](references/app-insights-dynamic-fields-reference.md).
+3. **Extract candidate business identifiers** with explicit KQL
+   (`tostring(Properties.BookingId)`, with casing fallbacks via `coalesce`).
+4. **Validate join keys against real data.** Prove a candidate joins — run the
+   join and confirm non-zero matches:
+
+   ```kusto
+   AppEvents
+   | extend BookingId = tostring(Properties.BookingId)
+   | where isnotempty(BookingId)
+   | join kind=inner (Bookings | project BookingId = tostring(BookingId)) on BookingId
+   | summarize MatchedRows=count(), DistinctBookings=dcount(BookingId)
+   ```
+
+   Non-zero → **direct join, high confidence**. Zero → the key is wrong or data
+   doesn't overlap; find the real one.
+5. **Check freshness and align the window.**
+   `TableName | summarize Rows=count(), MinTime=min(TimeGenerated), MaxTime=max(TimeGenerated)`.
+   Do not assume `ago(1h)`; use a window covering the actual data range and
+   explain it in user terms.
+6. **Confirm categorical values** used by rules
+   (`Table | summarize count() by <field>`) so impact rules use real categories.
+
+### Telemetry source selection framework (REQUIRED)
+
+Telemetry source selection MUST be **data-driven**. Before selecting a correlation
+model, the Skill MUST inspect ALL candidate telemetry sources discovered (e.g.
+AppEvents, AppExceptions, AppRequests, AppDependencies, AppTraces, AppPageViews,
+AppBrowserTimings, AvailabilityResults, and any other telemetry source present) —
+not just one.
+
+Score each candidate telemetry source by:
+
+1. Business identifiers discovered.
+2. Dynamic-field richness.
+3. Direct-join confidence.
+4. Validated match count.
+5. Business-process context.
+6. Relevance to the selected business goal.
+
+Select the highest-scoring telemetry source. The Skill MUST NOT automatically
+prioritize AppExceptions, and MUST NOT automatically prioritize AppEvents — the
+winner is whichever source scores highest against real data.
+
+### Exit criteria (MANDATORY)
+
+Before Stage 14, ALL must hold: schema retrieved via `getschema`; join keys
+validated with non-zero matches (when a direct join is used); freshness verified
+and window aligned; relevant categorical values confirmed. If any fails → STOP,
+do not proceed.
+
+### Handoff (MANDATORY)
+
+Present a concise summary (verified join keys, match results, business impact if
+any, data time window). Then ask: "Do you want to generate Operations Agent
+instructions based on this verified model?" HARD STOP and wait.
+
+## Stage 13 — Business data discovery and scoring
+
+Business tables are **not** expected to exist in Log Analytics. They may live in
+an Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts.
+Absence of business tables in Log Analytics MUST NOT be interpreted as absence of
+business data — discover them across the available Fabric data surfaces.
+
+If the exact business table or join is not known, do **not** fail. Score
+candidate business databases/tables by likely relevance to the stated goal,
+present a ranked list with explanation, propose shortcut creation for the top
+candidates, and ask the user to choose. Never conclude "no correlation is
+possible" without presenting options. Scoring hints are in
+[references/business-correlation-patterns.md](references/business-correlation-patterns.md).
+
+## Stage 14 — Correlation planning
+
+The user should not need to know joins, KQL, thresholds, or bins. Infer
+candidates from verified top-level schema, verified dynamic fields, sampled
+values, business table schema, actual join test results, and data freshness. When
+asking for confirmation, ask about **business meaning**, not SQL/KQL, e.g.:
+
+> "I found `BookingId` inside `AppEvents.Properties` and it matches
+> `Bookings.BookingId`. Should I treat this as the booking identifier for
+> business impact?"
+
+Present a correlation plan (see
+[references/business-insight-modeling-reference.md](references/business-insight-modeling-reference.md))
+including: operational signal; business impact table; verified join keys;
+whether the join came from top-level columns or dynamic fields; match
+count/validation result; time window + freshness status; proposed bin size;
+metrics and thresholds. Then ask for confirmation and STOP.
+
+Default modeling guidance: prefer **direct joins** when verified identifiers
+exist; use **time-window correlation** only when no direct identifier is found
+(and state clearly it shows correlation, not causality); default bin size **5
+minutes** (larger when data is sparse or KPIs are slower); default derived entity
+**IncidentBin**.
+
+### Correlation planning validation (REQUIRED)
+
+When finalizing the correlation model, the Skill MUST explain **why** the selected
+telemetry source was chosen, justified using real data. Include:
+
+- Match counts.
+- Business identifiers discovered.
+- Direct-join confidence.
+- Validation results.
+
+## Stage 15 — Operations Agent instruction generation
+
+Only after the correlation model is confirmed. Produce a single clean copy/paste
+block using the template in
+[references/operations-agent-reference.md](references/operations-agent-reference.md).
+
+> **Wrapper exemption:** deliver the instructions as ONE self-contained fenced
+> block. Put the stage-visibility header and the
+> `Waiting for your confirmation to continue.` line OUTSIDE the block (before and
+> after it) — never inside — so the copy/paste block stays clean. See
+> [Stage visibility](#stage-visibility-required-in-every-user-facing-response).
+
+The instructions MUST include **explicit KQL**, not conceptual descriptions:
+
+- One verbatim **IncidentBin materialization query** whose **output columns are
+  exactly the alert fields** (includes the `tostring(Properties.x)` extraction,
+  the explicit `join`, and the exact aggregations).
+- A per-field KQL definition list mapping each output column to a one-line
+  expression.
+- Alert rules that reference **actual output columns**.
+
+Include **both** threshold sets:
+
+- **Production-like:** e.g. ErrorCount increases by more than 20% versus the
+  previous-hour baseline; AffectedCustomers ≥ configured business threshold;
+  RevenueAtRisk ≥ configured business threshold.
+- **Relaxed POC / debug:** e.g. `ErrorCount >= 1`; `ErrorCount >= 5 and
+  AffectedBusinessRecords >= 1`; `AffectedCustomers >= 1`.
+
+Required sections: Goal, Data sources, Field mapping definitions, Dynamic field
+extraction logic, Derived analysis entity, IncidentBin materialization query,
+Metric definitions, Correlation logic, Impact logic (production + POC), Alert
+behavior, Output requirements, Validation / POC mode.
+
+### PLAYBOOK MATERIALIZATION REQUIREMENT (MANDATORY)
+
+Testing demonstrated that instructions and KQL **text alone are NOT sufficient**
+for playbook generation — the Fabric Playbook Generator must be able to discover
+the alert fields directly from a real schema object. Before generating Operations
+Agent rules, the Skill MUST:
+
+1. **Materialize IncidentBins** as a real, queryable schema object (a physical
+   table or a function-backed table in the KQL database).
+2. **Expose the alert fields as physical output columns** on that object.
+3. **Verify the schema exists** (e.g. `IncidentBins | getschema`).
+
+Required output columns:
+
+- IncidentBin
+- ErrorCount
+- AffectedCustomers
+- AffectedBookings
+- RevenueAtRisk
+- TopImpactedEntities
+- TopImpactedSteps
+
+The Playbook Generator MUST be able to discover these fields directly from the
+materialized schema. KQL instructions alone are NOT sufficient. Business-specific
+column names (for example `AffectedBookings`, `TopImpactedFlights`) adapt to the
+business entities actually discovered in the data.
+
+## Stage 16 — Optional Operations Agent creation / validation
+
+Offer to create the Operations Agent in the user's Fabric workspace and attach the
+Eventhouse / KQL database that holds the verified data. Confirm target workspace
+and KQL database before creating anything. Then guide validation (start with POC
+thresholds so an alert fires on sparse seed data, then switch to production
+thresholds). See
+[references/operations-agent-reference.md](references/operations-agent-reference.md)
+for creation surface and troubleshooting.
+
+## Troubleshooting (user-facing)
+
+- **"No playbook generated" / cannot compute a field** → the instructions
+  described fields conceptually. Add the explicit KQL materialization query, add
+  per-field KQL definitions, ensure alert rules reference actual output columns,
+  add dynamic-field extraction, and clarify join keys/identifiers. Do not just
+  reword prose.
+- **Start succeeds but no Teams alert arrives** → likely no data matched the
+  rule. Switch to POC/debug thresholds; explain no data may have matched. Do not
+  imply platform failure without evidence.
+
+## Must / Prefer / Avoid
+
+### Must
+- Enforce stages, hard stops, and confirmation gates.
+- Keep OAuth (UI-guided) and Service Principal (automated create-or-reuse)
+  strictly separate.
+- Validate Sentinel and permissions before creation.
+- Verify schema, dynamic fields, join matches, and freshness before correlation.
+- Provide explicit KQL in Operations Agent instructions.
+
+### Prefer
+- Direct joins over time-window correlation.
+- Real discovered values over anything guessed.
+- Business-language confirmation over technical questions.
+
+### Avoid
+- Do not depend on or mention MCP in the user-facing flow.
+- Do not present internal/undocumented APIs as supported.
+- Do not claim OAuth connector creation via public API.
+- Do not fabricate workspaces, tables, schema, IDs, or query results.
+- Do not ask for secrets, OAuth codes, tokens, cookies, or nonces.
+- Do not claim causality when only time-window correlation exists.
+
+## Examples
+
+### Example 1 — Onboard Azure Monitor observability data, then check business impact
+**User:** "In my `Observability` workspace, onboard our Azure Monitor / Log Analytics observability data (it holds our Application Insights tables) into Fabric, then tell me whether last week's latency spike hurt checkout conversions."
+
+**Skill behavior:** Runs the staged workflow — confirms the target workspace and checks onboarding prerequisites (a reachable Azure Monitor / Log Analytics source or connection), stopping with an explicit list of what is missing if any prerequisite is absent. Once the observability data (including the Application Insights telemetry tables) is onboarded and queryable, it discovers the real business dataset in the workspace, correlates the latency signal against the conversion KPI using discovered keys, and reports a specific business-impact conclusion (or an error if the required data is unavailable). It never fabricates workspace names, tables, or query results, and never exposes tokens or connection internals.
+
+### Example 2 — Out-of-scope authoring request
+**User:** "Create a new Spark notebook and build a Delta table pipeline to load my business dataset."
+
+**Skill behavior:** Declines the out-of-scope authoring request, creates nothing in Fabric, and directs the user to the appropriate authoring skill (for example `spark-authoring-cli`) rather than taking over the task.

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-dynamic-fields-reference.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-dynamic-fields-reference.md
@@ -1,0 +1,175 @@
+# Application Insights dynamic fields reference
+
+**Critical:** many telemetry-to-business JOIN keys are **not** top-level columns.
+In Application Insights / Azure Monitor tables, business identifiers are often
+nested inside dynamic JSON-like columns. Schema verification MUST include
+dynamic-field inspection — never rely on top-level schema alone.
+
+## Common dynamic / object columns to inspect
+
+- `Properties`
+- `CustomDimensions`
+- `Details`
+- `Measurements`
+- `Payload`
+- `Context`
+- `customDimensions`
+- `customMeasurements`
+
+## Business identifiers that commonly hide inside dynamic fields
+
+`BookingId`, `booking_id`, `OrderId`, `order_id`, `CustomerId`, `customer_id`,
+`UserId`, `user_id`, `UserAuthenticatedId`, `TenantId`, `tenant_id`, `AccountId`,
+`FlightId`, `flight_number`, `PassportId`, `passport`, `SubscriptionId`,
+`CorrelationId`, `OperationId`, `SessionId`, `Region`, `Country`, `ProductId`,
+`ServiceName`.
+
+## High-priority Application Insights tables for dynamic-field inspection
+
+Before falling back to time-window correlation, inspect dynamic fields in the
+following order:
+
+Inspect these tables wherever they are queryable in the target KQL database —
+**including telemetry that is already present as a native table**, not only the
+shortcuts created in Stage 11. A business join key (e.g. `AppEvents.Properties`)
+may already exist in the Eventhouse independently of the mirrored-catalog
+shortcuts, so enumerate all telemetry tables in the database during Stage 12/13.
+
+1. AppEvents
+   - Properties
+   - Measurements
+   - Typical business identifiers:
+     BookingId, OrderId, CustomerId, FlightId, SessionId, UserId
+
+2. AppExceptions
+   - Properties
+   - Details
+   - Typical business identifiers:
+     PassportId, BookingId, CustomerId, TenantId, OperationId
+
+3. AppRequests
+   - Properties
+   - Typical business identifiers:
+     OperationId, SessionId, CustomerId, OrderId
+
+4. AppDependencies
+   - Properties
+   - Typical business identifiers:
+     CorrelationId, OrderId, TenantId, AccountId
+
+5. AppTraces
+   - Properties
+   - Typical business identifiers:
+     BookingId, CustomerId, OrderId, SessionId
+
+6. AppPageViews
+
+7. AppBrowserTimings
+
+Only after inspecting these tables and validating candidate identifiers should
+the Skill fall back to time-window correlation.
+
+## Required dynamic-field verification steps
+
+During schema verification (Stage 12):
+
+1. Retrieve the real table schema with `getschema`.
+2. Identify dynamic/object/string columns that may hold JSON-like business
+   context.
+3. Sample real rows from those columns.
+4. Inspect the keys inside dynamic columns.
+5. Extract candidate business identifiers with explicit KQL.
+6. Validate candidate joins against real business tables (non-zero matches).
+7. Prefer verified **direct joins** over time-window correlation.
+
+## KQL patterns
+
+### Inspect schema
+
+```kusto
+TableName
+| getschema
+| project ColumnName, ColumnType
+```
+
+### Sample dynamic properties
+
+```kusto
+AppEvents
+| take 10
+| project TimeGenerated, Name, Properties
+```
+
+### Extract possible business identifiers
+
+```kusto
+AppEvents
+| extend BookingId = tostring(Properties.BookingId)
+| project TimeGenerated, Name, BookingId
+```
+
+### Alternative casing / naming (coalesce)
+
+```kusto
+AppEvents
+| extend BookingId = coalesce(
+    tostring(Properties.BookingId),
+    tostring(Properties.bookingId),
+    tostring(Properties.booking_id)
+  )
+```
+
+### Typed (bool / numeric) dynamic values
+
+Not every dynamic value is a string. Boolean and numeric fields (e.g. a
+`faulted` / `isError` flag, a `durationMs` or `amount`) are stored with their
+real type and serialize as JSON literals (`true`/`false`, unquoted numbers).
+Comparing them with `tostring(...) == "True"` silently matches **nothing**.
+Cast to the real type and compare to a typed literal:
+
+```kusto
+AppEvents
+| where tobool(Properties.faulted) == true          // NOT tostring(...) == "True"
+| extend amount = toreal(Properties.amount),
+         retries = tolong(Properties.retryCount)
+```
+
+### Diagnose a zero-match filter before concluding "no data"
+
+If a dynamic-field filter or join returns **0 rows**, confirm the value's real
+type and distinct values before assuming the data is absent — a type/casing
+mismatch is the most common cause:
+
+```kusto
+AppEvents
+| extend f = Properties.faulted
+| summarize count() by value = tostring(f), type = gettype(f)
+```
+
+### Validate a direct join
+
+```kusto
+AppEvents
+| extend BookingId = tostring(Properties.BookingId)
+| where isnotempty(BookingId)
+| join kind=inner (
+    Bookings
+    | project BookingId = tostring(BookingId)
+  ) on BookingId
+| summarize MatchedRows=count(), DistinctBookings=dcount(BookingId)
+```
+
+## Confidence classification
+
+- If a valid business identifier is found inside `Properties` / `CustomDimensions`
+  and the join returns **non-zero** matches → classify as a **direct join, high
+  confidence**.
+- If no direct identifier is found after inspecting top-level columns **and**
+  dynamic fields → fall back to **time-window correlation**, and state clearly
+  that time-window correlation shows **correlation, not causality**.
+
+> **Lesson learned:** screenshots can be misleading. A join key nested in
+> `AppExceptions.Properties` (e.g. `passport`, `flight`) can yield a deterministic
+> direct join to a business table even when top-level columns show nothing usable,
+> and the real data window may be weeks older than assumed. Verify schema,
+> dynamic fields, join matches, and freshness against real data first.

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-table-reference.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-table-reference.md
@@ -1,0 +1,168 @@
+# Application Insights / Azure Monitor table reference
+
+Common Application Insights / Azure Monitor (Log Analytics) telemetry tables, what
+signal each contains, the operational questions it answers, and how it can
+correlate with business data.
+
+> **Not a schema guarantee.** These are common shapes only. The **actual** schema
+> must always be verified against the real Eventhouse / KQL database with
+> `getschema` and sampling (see app-insights-dynamic-fields-reference.md). Column
+> names vary by app, SDK, and ingestion settings.
+
+## External references
+
+- [Azure Monitor tables for microsoft.insights/components (learn)](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/microsoft-insights-components)
+- [Azure Monitor Logs table reference](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/)
+
+## Workspace-based Application Insights tables (`App*`)
+
+### AppRequests
+- **Signal:** incoming server requests — success/failure, duration, result code,
+  operation name, endpoint.
+- **Operational questions:** Which endpoints fail or are slow? What is availability
+  / p95 latency? Where are 5xx spikes?
+- **Business correlation:** conversion, booking completion, checkout failures, API
+  SLA.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Id`, `OperationName`, `Url`,
+  `ResultCode`, `Success`, `DurationMs`, `Name`.
+- **Common dynamic fields:** `Properties`.
+
+### AppDependencies
+- **Signal:** outbound/downstream dependency calls (DB, HTTP, queue) — success,
+  duration, target, type.
+- **Operational questions:** Which downstream dependency failed or slowed? Which
+  target/region is degraded?
+- **Business correlation:** payment failures, inventory lookup failures, regional
+  dependency outages.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Target`, `DependencyType`,
+  `Name`, `Success`, `DurationMs`, `ResultCode`.
+- **Common dynamic fields:** `Properties`.
+
+### AppExceptions
+- **Signal:** application exceptions / failures — type, method, outer message,
+  problem id.
+- **Operational questions:** What is failing and where? Which exception types
+  spike during an incident?
+- **Business correlation:** failed bookings, failed orders, customer-impacting
+  errors.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `ProblemId`, `ExceptionType`,
+  `Method`, `OuterMessage`.
+- **Common dynamic fields:** `Properties`, `Details`.
+
+### AppTraces
+- **Signal:** diagnostic traces / structured logs — message, severity.
+- **Operational questions:** What diagnostic evidence supports a failure or
+  degraded behavior?
+- **Business correlation:** supporting evidence for failures or degraded service;
+  business keys sometimes embedded in `Properties`.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Message`, `SeverityLevel`.
+- **Common dynamic fields:** `Properties`.
+
+### AppEvents
+- **Signal:** custom business/product events emitted by the app (e.g.
+  `BookingStarted`, `CheckoutCompleted`).
+- **Operational questions:** Which funnel step dropped? Which product events
+  stopped firing during an incident?
+- **Business correlation:** funnel steps, booking started/completed, checkout,
+  sign-in — often the **richest** source of business keys in `Properties`.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `OperationId`, `UserId`, `SessionId`.
+- **Common dynamic fields:** `Properties`, `Measurements`.
+
+### AppPageViews
+- **Signal:** frontend page views — page name, url, load duration.
+- **Operational questions:** Which pages are slow or abandoned?
+- **Business correlation:** conversion, abandonment, user-journey drop-off.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Url`, `OperationId`, `UserId`,
+  `SessionId`, `DurationMs`.
+- **Common dynamic fields:** `Properties`.
+
+### AppBrowserTimings
+- **Signal:** client-side timing (network, send, receive, processing, total).
+- **Operational questions:** Where is frontend latency introduced?
+- **Business correlation:** conversion / abandonment tied to page latency.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Url`, `OperationId`,
+  `TotalDuration`.
+- **Common dynamic fields:** `Properties`.
+
+### AppAvailabilityResults / AvailabilityResults (if present)
+- **Signal:** synthetic availability tests — success, duration, location.
+- **Operational questions:** Is the service reachable from each test location?
+- **Business correlation:** availability failures → booking/checkout completion,
+  SLA.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Location`, `Success`, `DurationMs`,
+  `OperationId`.
+- **Common dynamic fields:** `Properties`.
+
+### AppMetrics (where useful)
+- **Signal:** custom metrics (name, value, aggregations).
+- **Business correlation:** business-relevant custom metrics (e.g. cart value,
+  active sessions) by time.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Sum`, `Count`, `ItemCount`.
+- **Common dynamic fields:** `Properties`.
+
+### AppPerformanceCounters (where useful)
+- **Signal:** host/process performance counters (CPU, memory, etc.).
+- **Business correlation:** resource saturation preceding user-facing degradation.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Category`, `Value`, `Instance`.
+
+### AppSystemEvents (where useful)
+- **Signal:** SDK/system events about the telemetry pipeline.
+- **Business correlation:** rarely a direct business key; useful for data-quality
+  context.
+- **Common time column:** `TimeGenerated`.
+
+### Usage-related tables (where relevant)
+- **Signal:** usage/volume of events, page views, sessions over time.
+- **Business correlation:** traffic drop → usage KPI degradation (active users,
+  transactions, revenue events).
+
+## Common cloud/role/location fields (across App* tables)
+
+Useful for regional / service-scoping of impact:
+`AppRoleName` / `CloudRoleName`, `AppRoleInstance`, `ClientCountryOrRegion`,
+`ClientCity`, `ClientType`, `OperationName`. Confirm presence via `getschema`.
+
+## Observability → business quick map
+
+| Table | Typical business impact |
+|-------|------------------------|
+| AppRequests | conversion, booking completion, checkout failures, API SLA |
+| AppExceptions | failed bookings/orders, customer-impacting errors |
+| AppDependencies | payment/inventory failures, regional dependency outages |
+| AppEvents | funnel steps, booking/checkout/sign-in events |
+| AppPageViews / AppBrowserTimings | conversion, abandonment, journey drop-off |
+| AppTraces | supporting evidence for failures / degradation |
+| AppAvailabilityResults | availability failures → booking/SLA impact |
+
+Always confirm the real schema before relying on any field above.
+
+## Telemetry source selection (data-driven, REQUIRED)
+
+No telemetry table is "best" by default. The winning source in one environment
+(e.g. AppEvents) is **not** a general rule. Telemetry source selection MUST be
+data-driven.
+
+Before selecting a correlation model, inspect **all** candidate telemetry sources
+discovered (AppEvents, AppExceptions, AppRequests, AppDependencies, AppTraces,
+AppPageViews, AppBrowserTimings, AvailabilityResults, and any others present).
+Score each candidate by:
+
+1. Business identifiers discovered.
+2. Dynamic-field richness.
+3. Direct-join confidence.
+4. Validated match count.
+5. Business-process context.
+6. Relevance to the selected business goal.
+
+Select the highest-scoring source. Do NOT automatically prioritize AppExceptions.
+Do NOT automatically prioritize AppEvents.

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/azmon-fabric-api-reference.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/azmon-fabric-api-reference.md
@@ -1,0 +1,188 @@
+# Azure Monitor → Fabric API reference
+
+Guidance on which flows are **documented/supported** versus **UI-only** or
+**internal/unsupported**, and the rules for the two connector modes. This file is
+agent guidance — do not paste it verbatim to users.
+
+## Supported vs UI-only vs internal — at a glance
+
+| Capability | Status | Notes |
+|-----------|--------|-------|
+| Mirrored Catalog item CRUD | Documented REST API | See mirrored-catalog-reference.md |
+| Mirrored Catalog item definition | Documented REST API | Item definition format |
+| Mirrored Catalog discovery | Documented REST API | Browse scopes/tables |
+| Mirrored Catalog monitoring | Documented REST API | Item/table mirroring status |
+| Mirrored Catalog refresh / sync | Documented REST API | Trigger metadata sync |
+| Operations Agent item CRUD + definition | Documented Fabric item APIs | `type: "OperationsAgent"` |
+| **OAuth** Azure Monitor connector creation | **UI-only** | Created once in Fabric → Manage Connections. **No public API.** Detect + reuse only. |
+| **Service Principal** connector create-or-reuse | Automated | Idempotent create-or-reuse; secrets from env/Key Vault only |
+| OneLake shortcut creation | Documented, but see caveat | Link alone does not register a queryable KQL table — see eventhouse-shortcuts-reference.md |
+
+## Portal fallback boundary
+
+Portal-guided instructions are allowed ONLY for OAuth Azure Monitor connector creation.
+
+Portal guidance must NOT be used as a generic fallback for:
+
+- Log Analytics workspace validation
+- Fabric workspace validation
+- Connection detection
+- Connection reuse
+- Service Principal connector creation
+- Mirrored Catalog item creation
+- Discovery
+- Monitoring
+- Refresh
+- Eventhouse shortcut creation
+- Schema verification
+- Operations Agent creation
+
+Before declaring a capability unavailable, the Skill should determine whether another supported execution path exists:
+
+- Fabric REST APIs
+- Azure REST APIs
+- Fabric Actions
+- Azure CLI
+- Azure Resource Graph
+- Fabric REST **read-only** discovery via authenticated `az rest --method get`
+  against `https://api.fabric.microsoft.com/...`
+
+MCP unavailability does not automatically imply capability unavailability.
+
+### Fabric REST read-only discovery exception (bounded)
+
+Arbitrary shell / CLI / `az` / PowerShell execution remains out of scope. There
+is ONE narrow exception: the Skill MAY use an authenticated `az rest --method
+get` call for Fabric REST **read-only discovery** only, when ALL of these hold:
+
+- Endpoint is `https://api.fabric.microsoft.com/...`.
+- HTTP method is **GET** only.
+- The operation is discovery / read-only only.
+- Nothing is created, updated, deleted, or modified — no Fabric items, shortcuts,
+  mirrored catalog items, or connectors are created through the CLI.
+- No tokens, secrets, raw auth headers, or sensitive payloads are exposed.
+- The Skill clearly states the capability path used.
+
+This exception is limited to Stage 3 (Fabric workspace discovery) and Stage 5
+(Azure Monitor OAuth connection detection). It does not relax any other stage's
+boundary, does not authorize non-GET `az rest` calls, and does not permit use of
+the Kusto / KQL data-plane when disabled.
+
+## Connector rules (authoritative)
+
+Keep the two modes strictly separated. Never route OAuth through Service
+Principal logic and never route Service Principal through OAuth/interactive
+sign-in logic.
+
+### OAuth mode (UI-guided only)
+
+- OAuth connector **creation** is interactive in **Fabric → Manage Connections**.
+- The Skill only **detects** and **reuses** an existing Azure Monitor OAuth
+  connection. Detection is **non-destructive** (never create/update/delete).
+- **Never** claim public-API support for OAuth Azure Monitor connector creation.
+- **Never** document browser-inspected / internal connector endpoints, hidden
+  payloads, `CredentialType` internals, OAuth codes, tokens, cookies, nonces, or
+  redirect URLs as supported public APIs, and never surface them to the user.
+- Reuse a connection ONLY when the data source path / LAW resource id matches the
+  **same** Log Analytics workspace exactly. Any mismatch → treat as no match.
+- If the user explicitly supplies a connection id, validate it (must be an Azure
+  Monitor Mirrored Catalog connection whose data source path matches this
+  workspace) before reusing. Reject mismatches.
+
+User-facing message when no connection exists (keep it this simple):
+
+```text
+I couldn’t find an existing Azure Monitor connection for this workspace.
+Please create it once in Fabric Manage Connections, then come back and continue.
+```
+
+### Service Principal mode (automated create-or-reuse)
+
+- Automated, non-interactive: no user login, no UI step.
+- **Idempotent**: reuse an existing matching Azure Monitor Service Principal
+  connector for the same Log Analytics workspace (same data source path +
+  Service Principal credential type) instead of creating a duplicate.
+- Only **one** connector per run.
+- **Never** reuse a non-Service-Principal (e.g. OAuth) connector in this mode.
+- **Never** ask the user to paste a raw client secret into chat.
+- Secrets come from **environment variables or Key Vault references** only; they
+  are never echoed, logged, exposed, or included in generated instructions.
+- If required inputs are missing, describe **what** is missing (tenant id, app /
+  client id, and a securely-provided secret reference) using presence checks
+  only. Never request the secret value in chat.
+
+## Supported-scope / validation rules
+
+Before creating anything, verify: the workspace exists; it is **not Sentinel** or
+otherwise unsupported; the caller has required Log Analytics access; the caller
+can create the item in the target Fabric workspace. Surface pass/fail in user
+terms; never expose raw API responses.
+
+### Sentinel detection source hierarchy
+
+Sentinel detection is a **control-plane** check and MUST NOT default to requiring
+Kusto / KQL data-plane availability. Before classifying Sentinel status as "not
+verifiable", attempt all available control-plane / metadata checks, in order:
+
+1. Resource group inventory / ARM resource enumeration.
+2. `Microsoft.OperationsManagement/solutions` named `SecurityInsights(<workspaceName>)`.
+3. `Microsoft.SecurityInsights/*` resources, including `onboardingStates` if surfaced.
+4. Workspace / resource feature metadata, if available.
+
+Indicators found → **Sentinel / blocked**. Indicators absent after complete
+enumeration → **Not Sentinel, verified via control-plane**. Only if all these
+checks are unavailable or inconclusive → **not verifiable**. Kusto may be an
+additional path but is never a required dependency for Sentinel detection. This
+hierarchy does NOT generalize to Log Analytics data-plane/query permission (may
+require a KQL/data-plane path) or Fabric item-creation permission (may require a
+Fabric control-plane capability).
+
+## Fabric workspace discovery & capability resolution
+
+Fabric workspaces are **not** Azure Resource Manager resources. They cannot be
+enumerated through Azure resource listing, Azure Resource Graph, or `az`
+resource commands, so an ARM-only environment reaching Azure resources does
+**not** imply a Fabric control-plane path exists — and the reverse also holds:
+lack of automatic enumeration does NOT mean no Fabric workspace exists.
+
+Stage 3 (Fabric workspace selection) MUST follow this policy (SKILL.md links here
+for the full detail):
+
+- Discover all surfaced Fabric mechanisms first: Fabric REST APIs, Fabric
+  Actions, Fabric / OneLake / Power BI execution capabilities, authenticated
+  Fabric REST read-only discovery via `az rest --method get` against
+  `https://api.fabric.microsoft.com/...` (GET-only, read-only, no modifications,
+  no secret/token/header exposure, capability path stated), or any other
+  documented capability provider available to the agent environment.
+- If automatic enumeration is unavailable, do NOT terminate. Distinguish "no
+  Fabric control-plane capability at all" from "enumeration unavailable but the
+  workflow can continue with user-provided workspace info".
+- Ask the user for a **Fabric Workspace Name**, **Workspace ID**, or **Workspace
+  URL**, then validate it as far as the available capabilities allow.
+- Never fabricate a workspace, workspace id, or validation result, and never
+  claim a Fabric action succeeded when the required execution capability is
+  unavailable.
+- Mark Stage 3 BLOCKED only after every programmatic discovery path AND every
+  user-supplied resolution path (Name / ID / URL) is exhausted. UI-guided
+  selection is permitted only as the final fallback.
+
+## Fabric Operations Agent surface
+
+Operations Agent is a first-class Fabric item (`type: "OperationsAgent"`). It can
+be created and populated through documented Fabric item APIs (create item, then
+set the definition with the instructions and the KQL database data source). Teams
+notifications are a built-in action — no custom channel binding is required for
+basic alerts. See operations-agent-reference.md.
+
+## External references
+
+- [Items - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/items)
+- [Mirrored Catalog item definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/mirrored-catalog-definition)
+- [Discovery - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/discovery)
+- [Monitoring - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/monitoring)
+- [Refresh - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/refresh)
+
+> The Mirrored Catalog references above cover item CRUD, item definition,
+> discovery, monitoring, and refresh/sync operations. They do **not** document
+> OAuth Azure Monitor connector creation. Treat OAuth connector creation as
+> UI-guided only.

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/business-correlation-patterns.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/business-correlation-patterns.md
@@ -1,0 +1,101 @@
+# Business correlation patterns reference
+
+Reusable **observability signal → business impact** patterns, candidate join
+keys, and scoring hints for ranking candidate business tables. Use these to guide
+discovery and correlation planning — always confirm business meaning with the
+user and verify keys against real data before relying on them.
+
+## Domain-agnostic rule (examples only)
+
+Every business entity named in this file — bookings, orders, customers, flights,
+revenue, tenants, payments, and similar — is an **EXAMPLE ONLY**. Do NOT infer the
+user's business domain from these examples. Discover the user's actual business
+entities from real Fabric data and confirm them with the user before use.
+
+Business tables are **not** expected to exist in Log Analytics. They may live in
+an Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts.
+Absence of business tables in Log Analytics MUST NOT be read as absence of
+business data.
+
+## Patterns
+
+### 1. Availability → Bookings
+- **Operational signal:** `AppRequests` failures, `AvailabilityResults` failures,
+  `AppExceptions`.
+- **Business impact:** failed / incomplete bookings.
+- **Candidate keys:** `BookingId`, `CustomerId`, `SessionId`, `OperationId`,
+  custom `Properties`.
+
+### 2. Latency → Conversion
+- **Operational signal:** `AppRequests` duration, `AppPageViews`,
+  `AppBrowserTimings`.
+- **Business impact:** conversion drop, abandonment, funnel degradation.
+- **Candidate keys:** `SessionId`, `UserId`, `CustomerId`, funnel event IDs.
+
+### 3. Exceptions → Orders / Revenue
+- **Operational signal:** `AppExceptions`, `AppTraces`.
+- **Business impact:** failed orders, revenue at risk.
+- **Candidate keys:** `OrderId`, `CustomerId`, `TenantId`, `OperationId`,
+  `Properties`.
+
+### 4. Dependency failures → Customer / Tenant impact
+- **Operational signal:** `AppDependencies` failures / latency.
+- **Business impact:** affected customers, tenants, regions, services.
+- **Candidate keys:** `TenantId`, `AccountId`, `Region`, `DependencyTarget`.
+
+### 5. Regional outage → Business KPI impact
+- **Operational signal:** `CloudRoleName`, `Region`, `ClientCountryOrRegion`,
+  location fields.
+- **Business impact:** regional bookings, customers, transactions, SLA.
+- **Candidate keys:** `Region`, `Country`, `Location`, `AirportCode`,
+  `DataCenter`.
+
+### 6. Traffic drop → Usage KPI degradation
+- **Operational signal:** `AppEvents`, `AppPageViews`, `AppRequests` volume drop.
+- **Business impact:** lower active users, reduced transactions, reduced revenue
+  events.
+- **Candidate keys:** `UserId`, `SessionId`, `ProductId`, event names.
+
+## Business data scoring hints
+
+When the exact business table or join is not known, **do not fail**. Score
+candidate business databases/tables by likely relevance to the stated goal,
+present a ranked list with explanation, propose shortcut creation for the top
+candidates, and ask the user to choose. Never conclude "no correlation is
+possible" without options.
+
+| Business goal | Prioritize tables |
+|---------------|-------------------|
+| Booking impact | Bookings, Reservations, Orders, Flights, Customers, Transactions |
+| Revenue impact | Orders, Payments, Revenue, Invoices, Subscriptions |
+| Customer impact | Customers, Accounts, Tenants, Users, Subscriptions |
+| Regional impact | Regions, Locations, Airports, DataCenters, Countries |
+| Service availability | AppRequests, AvailabilityResults, AppExceptions, AppDependencies + business completion tables |
+| Conversion | AppEvents, AppPageViews, AppRequests + funnel/business event tables |
+
+## Candidate key reference
+
+Infer candidates from column/table names; confirm meaning with the user and
+verify against real data before relying on them.
+
+- **Customer identifiers:** `CustomerId`, `UserId`, `PassportRef`, `AccountId`,
+  `TenantId`, `SubscriptionId`.
+- **Entity identifiers:** `FlightId`, `OrderId`, `BookingId`, `SessionId`,
+  `OperationId`, `RequestId`, `ResourceId`.
+- **Timestamps:** `TimeGenerated`, `Timestamp`, `EventTime`, `BookingTime`,
+  `CreatedTime`.
+- **Region/location:** `Region`, `Location`, `originAirport`,
+  `destinationAirport`, `Country`, `DataCenter`.
+
+## Table classification hints
+
+- **Operational telemetry:** AppEvents, AppExceptions, AppRequests, AppPageViews,
+  AppBrowserTimings, AppDependencies, AvailabilityResults, AzureMetrics, Perf,
+  Usage.
+- **Business tables:** Bookings, Customers, Flights, Orders, Payments,
+  CounterCheckins, Subscriptions, Invoices.
+- **Context/enrichment tables:** Flights, Regions, Products, Services, Tenants,
+  Airports.
+
+Confirm business meaning with the user; never fabricate tables the user has not
+confirmed.

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/business-insight-modeling-reference.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/business-insight-modeling-reference.md
@@ -1,0 +1,114 @@
+# Business insight modeling reference
+
+How to turn a **verified** telemetry + business dataset into a correlation model
+without asking the user for joins, KQL, bins, or thresholds. The user confirms
+**business meaning**; the Skill translates it into the technical model.
+
+## Inputs the model is inferred from
+
+- Verified top-level schema (`getschema`).
+- Verified dynamic fields (sampled `Properties` / `CustomDimensions`).
+- Sampled values.
+- Business table schema.
+- Actual join test results (non-zero match counts).
+- Data freshness (real min/max time range).
+
+Never propose a model before these are verified (Stage 12).
+
+## Direct join vs time-window correlation
+
+- **Direct join (preferred, high confidence):** a shared identifier exists and a
+  test join returns non-zero matches. Use it. State the match count.
+- **Time-window correlation (fallback):** no shared identifier after inspecting
+  top-level and dynamic fields. Correlate events within the same time bin. Always
+  state that this shows **correlation, not causality**.
+
+## Bins
+
+- **Default bin size: 5 minutes.** Explain it as granular enough to catch short
+  operational spikes while aggregating enough events to be meaningful and reduce
+  per-event noise.
+- Use a **larger** bin when data is **sparse** (few events → 15–60 min) or when
+  business KPIs are **slower** (e.g. daily bookings). Adjust for very noisy /
+  high-volume data to stabilize the signal.
+
+## Derived entity
+
+- Default derived entity name: **IncidentBin** (unless a better
+  business-specific name exists).
+- Each IncidentBin represents one time window and is the unit of analysis for
+  metrics and alert rules.
+
+## Confirming business meaning (not SQL)
+
+Ask about meaning, e.g.:
+
+> "I found `BookingId` inside `AppEvents.Properties` and it matches
+> `Bookings.BookingId`. Should I treat this as the booking identifier for
+> business impact?"
+
+Do not ask "what join should I use?" or "what bin/threshold do you want?".
+
+## Correlation plan contents (present before generating instructions)
+
+- Operational signal (which table/event indicates the problem).
+- Business impact table.
+- Verified join keys.
+- Whether the join came from **top-level columns** or **dynamic fields**
+  (`Properties` / `CustomDimensions`).
+- Match count / validation result.
+- Time window + freshness status.
+- Proposed bin size.
+- Metrics and thresholds.
+
+Then ask for confirmation and STOP.
+
+### Correlation planning validation (REQUIRED)
+
+When finalizing the correlation model, explain **why** the selected telemetry
+source was chosen, justified with real data. Include: match counts, business
+identifiers discovered, direct-join confidence, and validation results. The
+selected telemetry source must be justified against actual data — never chosen by
+default or by assumption. Candidate telemetry sources must have been inspected and
+scored before selection (see app-insights-table-reference.md).
+
+## Metrics (typical)
+
+- `ErrorCount` — faulted operational events per IncidentBin.
+- `AffectedCustomers` — distinct impacted customers per IncidentBin.
+- `AffectedBusinessRecords` — impacted business records per IncidentBin.
+- `RevenueAtRisk` — summed revenue of impacted records per IncidentBin.
+- `TopImpactedEntities` — top impacted entities by impact.
+- `ImpactBand` — high / low / none.
+
+## Thresholds
+
+Always include **both** sets in the generated instructions.
+
+- **Production-like:**
+  - ErrorCount increases by more than 20% vs previous-hour baseline.
+  - AffectedCustomers ≥ configured business threshold.
+  - RevenueAtRisk ≥ configured business threshold.
+- **Relaxed POC / debug** (validate Start + Teams alert end-to-end):
+  - `ErrorCount >= 1`
+  - `ErrorCount >= 5 and AffectedBusinessRecords >= 1`
+  - `AffectedCustomers >= 1`
+
+## Freshness and time window
+
+Check the real data range before generating instructions:
+
+```kusto
+TableName
+| summarize Rows=count(), MinTime=min(TimeGenerated), MaxTime=max(TimeGenerated)
+```
+
+If data is old or sparse, do not assume `ago(1h)` — use a window covering the
+actual range and explain it in user terms. Watch for locale-formatted timestamps
+(DD/MM vs MM/DD) when reading results.
+
+## Handoff to instruction generation
+
+The materialization query output columns MUST match the alert fields exactly. See
+operations-agent-reference.md for the explicit-KQL requirement and the full
+instruction template.

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/eventhouse-shortcuts-reference.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/eventhouse-shortcuts-reference.md
@@ -1,0 +1,112 @@
+# Eventhouse & OneLake shortcuts reference
+
+How the mirrored Azure Monitor tables become **queryable** in an Eventhouse / KQL
+database, and the queryability requirement that must be verified before any
+correlation logic.
+
+## Eventhouse / KQL database
+
+An Eventhouse hosts one or more KQL databases queried with KQL. The onboarding
+flow lands Azure Monitor telemetry (and, via additional shortcuts, business
+tables) into a KQL database so telemetry and business data can be correlated with
+KQL.
+
+- **Eventhouse / KQL database selection is a user decision.** Always present the
+  discovered options and require explicit confirmation. Never auto-select, even
+  when discovery has a recommended default.
+- The Eventhouse query URI (`queryServiceUri` in Eventhouse properties) is where
+  `getschema`, sampling, and validation queries run during schema verification.
+
+## OneLake shortcuts — the queryability requirement (CRITICAL)
+
+Making a mirrored table queryable requires **two** things:
+
+1. **Exact source table name.** A renamed shortcut (e.g. `LAQS_AppTraces` for
+   source `AppTraces`) creates the OneLake link but may NOT register as a
+   queryable KQL table (e.g. `General_BadRequest: Request is invalid`). Keep the
+   exact source table name.
+2. **The table must be registered as a queryable/external table.** A OneLake link
+   alone is not enough. The Fabric **UI "Add table"** flow both creates the
+   shortcut and registers the external table, so it becomes queryable. Creating
+   only the OneLake link means the table will not appear in
+   `.show external tables` and queries return 400.
+3. **Mirrored AzMon tables live under a `dbo` schema folder.** In the mirrored
+   catalog item's OneLake, tables are nested at `Tables/dbo/<TableName>`, not
+   directly under `Tables/<TableName>`. A shortcut's OneLake target path must
+   therefore include the schema segment (`target.oneLake.path =
+   "Tables/dbo/<TableName>"`). Confirm the exact folder by listing `Tables/`
+   first — it typically contains a single `dbo` directory holding every table.
+
+## Shortcut planning and creation (stage rules)
+
+- **Shortcut planning happens before schema verification or join logic.** Present
+  the plan and STOP for confirmation.
+- **Shortcut creation requires explicit confirmation.**
+- **Handle "already exists" idempotently.** If shortcut creation returns a
+  conflict (e.g. HTTP 409 `EntityConflict` / `ShortcutsOperationNotAllowed` when
+  the conflict policy is `Abort`), do **not** treat it as a failure and do **not**
+  overwrite. A shortcut of that name already exists — verify it points to the
+  intended source and is queryable (`.show external tables` + `TableName | take 1`),
+  then proceed. Only recreate if the existing shortcut targets a different source.
+- After creation, **verify queryability** with a lightweight query before building
+  any correlation logic. Stage 11 validates **queryability, NOT table size**, so
+  use a single-row probe rather than a full scan:
+
+  ```kusto
+  TableName
+  | take 1
+  ```
+
+  (`TableName | limit 1` is equivalent.) Avoid `TableName | count` here — on
+  large external Delta tables a `count` forces an unnecessary full scan, causing
+  long execution times and validation delays.
+
+- If a table is not queryable → **STOP** and return to shortcut planning /
+  creation. Do not build correlation logic on screenshots or assumed schema.
+- A brand-new AzMon item won't surface tables until its mirror has materialized
+  them; wait/refresh before expecting queryable tables.
+
+## Shortcut acceleration policy (SHOULD)
+
+Query acceleration SHOULD be treated as the preferred configuration for newly
+created shortcuts. Testing showed significant performance improvements once
+acceleration was enabled — schema verification, queryability validation,
+telemetry sampling, correlation analysis, and Operations Agent preparation all
+became substantially faster.
+
+When creating ANY shortcut:
+
+1. Determine whether acceleration is **supported**.
+2. Determine the **current** acceleration status.
+3. **Enable** acceleration when supported and appropriate.
+4. **Report** the acceleration status.
+
+During Shortcut Planning (Stage 10), show for each shortcut: Shortcut Name,
+Source, Target, Acceleration Supported (Yes/No), Acceleration Enabled (Yes/No). If
+acceleration is disabled, explain the potential impact on queryability validation,
+schema verification, telemetry sampling, correlation analysis, and Operations
+Agent preparation.
+
+This is a **SHOULD**, not a MUST — do not assume acceleration exists in every
+environment.
+
+## Verify external table registration
+
+After adding tables, confirm registration and queryability:
+
+```kusto
+.show external tables
+```
+
+```kusto
+TableName
+| take 1
+```
+
+Stage 11 validates queryability, NOT table size. Prefer the single-row probe
+`TableName | take 1` (or `TableName | limit 1`). Avoid `TableName | count`, which
+forces a full scan of large external Delta tables and slows validation.
+
+If a table is missing from `.show external tables`, it was linked but not
+registered — re-add it via the UI "Add table" flow (which both links and
+registers), keeping the exact source name.

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/mirrored-catalog-reference.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/mirrored-catalog-reference.md
@@ -1,0 +1,89 @@
+# Mirrored Catalog reference
+
+Supported Fabric Mirrored Catalog operations for onboarding Azure Monitor /
+Application Insights / Log Analytics data as an AzMon item. All operations below
+are documented REST APIs.
+
+> **Preview / beta status:** The Azure Monitor Mirrored Catalog item is in
+> **Preview**, and its Discovery, Monitoring, and Refresh operations are `(beta)`
+> — they require the `beta=true` query parameter. Treat this surface as subject
+> to change and confirm the current shape against Microsoft Learn before relying
+> on it.
+
+## What a Mirrored Catalog (AzMon) item is
+
+A Fabric item that mirrors an external catalog (here, Azure Monitor / Log
+Analytics) into Fabric so its tables become discoverable and, via Eventhouse
+shortcuts, queryable in a KQL database. The item is created in a target Fabric
+workspace and bound to a connection (OAuth or Service Principal) for the source
+Log Analytics workspace.
+
+## Operation groups
+
+### Item CRUD
+
+Create, get, update, list, and delete the Mirrored Catalog item in a Fabric
+workspace. Creating the item requires a valid connection for the source Log
+Analytics workspace and sufficient Fabric workspace permission. Capture the
+returned item id for later monitoring/refresh calls.
+
+- [Items - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/items)
+
+### Item definition
+
+The item definition describes the mirrored catalog configuration (source binding,
+selected scope/tables where applicable). Read the current definition before
+editing; do not fabricate definition fields.
+
+- [Mirrored Catalog item definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/mirrored-catalog-definition)
+
+### Discovery
+
+Browse available source **scopes** (namespaces) and **tables** after the
+connection/item is available. Use only returned scope/table values — never
+fabricate table names. Discovery is read-only.
+
+- [Discovery - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/discovery)
+
+#### Discovery API fallback policy
+
+The Mirrored Catalog Discovery APIs are the **primary** discovery mechanism. If
+discovery appears incomplete, do NOT immediately switch to alternative metadata
+paths. First:
+
+1. Verify mirror status.
+2. Verify refresh / sync status.
+3. Verify discovery scope.
+4. Retry discovery.
+
+Only after these checks may alternative metadata paths be evaluated.
+
+### Monitoring
+
+Report readiness/status of the mirrored item and of individual tables rather than
+guessing readiness. A brand-new item will not surface tables until its mirror has
+materialized them.
+
+- [Monitoring - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/monitoring)
+
+### Refresh / run sync job
+
+Trigger a catalog metadata refresh / sync after item creation to bring table
+metadata up to date. Do not claim refresh completed unless the service confirms
+it.
+
+- [Refresh - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/refresh)
+
+## Guardrails
+
+- These APIs cover item CRUD, definition, discovery, monitoring, and
+  refresh/sync. They do **not** document OAuth Azure Monitor connector creation —
+  treat OAuth connector creation as UI-guided (see azmon-fabric-api-reference.md).
+- Discovery/monitoring output is authoritative for names/status; do not invent
+  values.
+- Mirroring metadata into the catalog is **not** the same as a table being
+  queryable in Eventhouse. Queryability requires an Eventhouse shortcut that
+  registers the table (see eventhouse-shortcuts-reference.md).
+- Business tables are **not** expected in Log Analytics. They may exist in an
+  Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts. Their
+  absence in Log Analytics does NOT mean business data is absent.

--- a/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/operations-agent-reference.md
+++ b/plugins/fabric-skills/skills/azmon-mirroredcatalogs-operations-cli/references/operations-agent-reference.md
@@ -1,0 +1,243 @@
+# Operations Agent reference
+
+Everything needed to generate, create, validate, and troubleshoot a Microsoft
+Fabric **Operations Agent** over the Eventhouse/KQL database holding the verified
+telemetry + business data. The end product is a clean copy/paste block of
+instructions the user pastes into Fabric.
+
+## Core principle
+
+The user is **not** expected to know join logic, time binning, derived-entity
+modeling, metric computation, or thresholds. Never open with "what JOIN should I
+use?" or "what bin/threshold do you want?". Infer candidates from the **verified**
+schema (Stage 12), propose in business language, confirm business meaning, then
+translate to the technical model on the user's behalf.
+
+## Give explicit per-field KQL, not conceptual descriptions (REQUIRED)
+
+The Fabric playbook generator will **not infer** joins, aggregations, or how to
+compute a metric. Conceptual-only field names (e.g. "AffectedCustomers",
+"RevenueAtRisk") cause generation to fail with **"No playbook generated"** and
+"I was not able to determine how to compute X". To avoid this:
+
+- Provide **one verbatim materialization query** whose **output columns ARE the
+  alert fields** (the `summarize`/`extend` produces `ErrorCount`,
+  `AffectedCustomers`, `RevenueAtRisk`, … by `IncidentBin`). Include the
+  `tostring(Properties.x)` extraction, the explicit `join`, and the exact
+  aggregations (`count()`, `dcount()`, `dcountif()`, `sum()`, `make_set()`).
+- Add a **field-definition list** restating each output column's KQL in one line
+  (e.g. `AffectedCustomers = dcount(passport) by IncidentBin`), so message
+  placeholders map 1:1 to columns.
+- Make each **alert rule reference a concrete output column**. If one metric
+  drives both the trigger and the message text (e.g. `RevenueAtRisk >= 1000` and
+  `$<RevenueAtRisk>` in the message), say so explicitly.
+
+## Playbook materialization requirement (MANDATORY)
+
+Operations Agent creation can succeed while **playbook generation still fails**
+until the incident entity is materialized as a real, queryable schema object.
+Testing confirmed that instructions and KQL text alone are NOT sufficient — the
+Playbook Generator discovers alert fields from an actual schema, not from prose.
+
+Before generating Operations Agent rules:
+
+1. **Materialize IncidentBins** as a real, queryable schema object (a physical
+   table, or a stored-function-backed table, in the KQL database).
+2. **Expose the alert fields as physical output columns.**
+3. **Verify the schema exists** (`IncidentBins | getschema`).
+
+Required output columns:
+
+- IncidentBin
+- ErrorCount
+- AffectedCustomers
+- AffectedBookings
+- RevenueAtRisk
+- TopImpactedEntities
+- TopImpactedSteps
+
+The Playbook Generator MUST be able to discover these fields directly from the
+materialized schema. KQL instructions alone are NOT sufficient. Business-specific
+column names adapt to the business entities actually discovered in the data.
+
+## Required sections of the generated instructions
+
+Goal · Data sources · Field mapping definitions · Dynamic field extraction logic ·
+Derived analysis entity · IncidentBin materialization query · Metric definitions ·
+Correlation logic · Impact logic (production + POC) · Alert behavior · Output
+requirements · Validation / POC mode.
+
+## Instruction template
+
+Fill `<...>` placeholders with confirmed table/column names. Leave unknowns as
+explicit placeholders — do not invent schema. Output as one copy/paste block.
+
+```text
+Goal:
+Detect operational incidents and correlate them with business impact.
+
+Data sources:
+Operational telemetry tables:
+- <OperationalTable>
+Business tables:
+- <BusinessTable>
+Context/enrichment tables:
+- <ContextTable>
+
+Field mapping definitions:
+- Customer identifier: <BusinessTable>.<CustomerIdColumn>
+- Operational time:    <OperationalTable>.<OperationalTimestampColumn>
+- Business time:       <BusinessTable>.<BusinessTimestampColumn>
+
+Dynamic field extraction logic:
+- Extract business keys nested in dynamic columns, e.g.
+  BusinessKey = tostring(<OperationalTable>.Properties.<KeyName>)
+- Use coalesce() for casing/naming variants:
+  BusinessKey = coalesce(
+    tostring(Properties.<KeyName>),
+    tostring(Properties.<keyName>),
+    tostring(Properties.<key_name>))
+
+Join keys:
+- Join <OperationalTable> to <BusinessTable> on <JoinKey> when available.
+- If no direct key exists, correlate within the same 5-minute time bin
+  (correlation, not causality).
+
+Derived analysis entity:
+Create IncidentBin. Each IncidentBin is one 5-minute window and is the unit of
+analysis for rules and alerts.
+
+IncidentBin materialization query (output columns == alert fields):
+<OperationalTable>
+| where <OperationalTimestampColumn> between (datetime(<MinTime>) .. datetime(<MaxTime>))
+| extend BusinessKey = tostring(Properties.<KeyName>)
+| where isnotempty(BusinessKey)
+| join kind=inner (
+    <BusinessTable>
+    | project BusinessKey = tostring(<JoinKey>), <CustomerIdColumn>, <RevenueColumn>
+  ) on BusinessKey
+| summarize
+    ErrorCount             = count(),
+    AffectedCustomers      = dcount(<CustomerIdColumn>),
+    AffectedBusinessRecords = dcount(BusinessKey),
+    RevenueAtRisk          = sum(<RevenueColumn>),
+    TopImpactedEntities    = make_set(<ContextColumn>, 3),
+    TopImpactedSteps       = make_set(<OperationStepColumn>, 3)
+    by IncidentBin = bin(<OperationalTimestampColumn>, 5m)
+
+Metric definitions:
+- ErrorCount = count() of faulted operational events by IncidentBin.
+- AffectedCustomers = dcount(<CustomerIdColumn>) by IncidentBin.
+- AffectedBusinessRecords = dcount(BusinessKey) by IncidentBin.
+- RevenueAtRisk = sum(<RevenueColumn>) by IncidentBin.
+- TopImpactedEntities = make_set(<ContextColumn>, 3) by IncidentBin.
+- TopImpactedSteps = make_set(<OperationStepColumn>, 3) by IncidentBin.
+
+Correlation logic:
+Evaluate each IncidentBin for operational degradation and business impact.
+Use direct joins when verified identifiers exist; otherwise time-window
+correlation (correlation, not causality).
+
+Impact logic:
+Production-like thresholds:
+- ErrorCount increases by more than 20% vs previous-hour baseline.
+- AffectedCustomers >= <configured business threshold>.
+- RevenueAtRisk >= <configured business threshold>.
+POC / debug thresholds (validate Start + Teams alert end-to-end):
+- ErrorCount >= 1
+- ErrorCount >= 5 and AffectedBusinessRecords >= 1
+- AffectedCustomers >= 1
+
+Alert behavior:
+- One alert per 5-minute IncidentBin.
+- Include business context and recommended action.
+
+Output requirements:
+Alert title, incident time window, ErrorCount, AffectedCustomers,
+AffectedBusinessRecords, RevenueAtRisk, TopImpactedEntities, business impact
+summary, recommended action, investigation link if available.
+
+Validation / POC mode:
+Start with POC thresholds to confirm Start runs and a Teams alert arrives, then
+switch to production-like thresholds for steady-state monitoring.
+```
+
+## Creating the agent (optional Stage 16)
+
+Operations Agent is a first-class Fabric item (`type: "OperationsAgent"`), so it
+can be created and populated through documented Fabric item APIs.
+
+> **Auth restriction (verified — MUST check before this stage).** The Create
+> OperationsAgent API supports a **User (delegated) identity only** — **service
+> principal and managed identity are NOT supported**
+> ([Microsoft Learn: Create Operations Agent](https://learn.microsoft.com/en-us/rest/api/fabric/operationsagent/items/create-operations-agent)
+> — Microsoft Entra supported identities: User = Yes, Service principal & Managed
+> identities = No). If the current session is authenticated as a service principal
+> or managed identity, STOP and instruct the user to switch to delegated user auth
+> before creating the agent; the create call will otherwise fail. (The
+> OperationsAgent item is in Preview.)
+
+1. Create the agent item in the target workspace (capture the returned item id).
+2. Read the current definition, set `configuration.instructions` to the Instruction template
+   block, and add the KQL database under `configuration.dataSources` as a
+   `KustoDatabase` entry keyed by a friendly alias; then update the definition.
+   Do **not** include an empty `playbook` object (it fails with "No rule
+   definitions available in the playbook.").
+3. Use the real **KQL database** item id (the `KQLDatabase` item whose display
+   name matches the target Eventhouse — not the `Eventhouse` item).
+
+Note (verified behavior): `updateDefinition` reliably saves the **instructions**
+text, but live **bindings** (`dataSources[].id`, `messageDestination`) may read
+back as placeholders (all-zeros / null) even on `200` — the portal Build page is
+authoritative and typically shows the attached KQL database. Have the user open
+the agent's **Build** page to confirm the Knowledge data source, let the playbook
+generate, then **Save** and **Start**. Teams notifications are a built-in action;
+no custom channel binding is required for basic alerts.
+
+## Validation & troubleshooting
+
+- **"No playbook generated" / "cannot compute X"** → conceptual-only fields, or
+  the incident entity was not materialized as a real schema object. Materialize
+  IncidentBins so its output columns are physical, discoverable columns; add the
+  explicit materialization query (output columns == alert fields), the
+  per-field KQL list, dynamic-field extraction, and concrete join keys; ensure
+  each alert rule references an actual output column. Map specific messages:
+  missing thresholds → add numeric thresholds; missing field mapping → add
+  explicit field definitions; missing customer/entity id → add the identifier
+  mapping; missing join key → specify keys or fall back to 5-minute correlation;
+  missing time column → specify the timestamp columns.
+- **Start succeeds but no Teams alert** → likely no data matched (thresholds too
+  strict for the window). Switch to POC thresholds (`ErrorCount >= 1`, or
+  `ErrorCount >= 5 and AffectedCustomers >= 1`), then restore production
+  thresholds. Do not imply platform failure without evidence.
+
+## Guardrails
+
+- Do not fabricate schema — use placeholders when names are unknown.
+- Confirm business meaning before producing final instructions.
+- Say "correlated", not "caused", when only time-window correlation exists.
+- Do not require the user to know KQL or joins.
+- Only recommend adding Actions when the user needs capabilities beyond the
+  built-in Teams alerts.
+
+
+## External References
+
+### Microsoft Learn
+
+Create and Configure Operations Agents - Microsoft Fabric
+
+https://learn.microsoft.com/en-us/fabric/real-time-intelligence/operations-agent
+
+### Microsoft Community Hub
+
+Microsoft Fabric Operations Agent Step by Step Walkthrough
+
+https://techcommunity.microsoft.com/blog/analyticsonazure/microsoft-fabric-operations-agent-step-by-step-walkthrough/4512572
+
+Use these references when:
+- creating new Operations Agents
+- understanding playbook generation behavior
+- troubleshooting rule generation failures
+- validating expected Operations Agent workflow
+

--- a/plugins/fabric-skills/skills/check-updates/SKILL.md
+++ b/plugins/fabric-skills/skills/check-updates/SKILL.md
@@ -1,221 +1,508 @@
 ---
 name: check-updates
 description: >
-  Check for skills-for-fabric marketplace updates at session start. Compares local version 
-  against GitHub releases and shows changelog if updates are available. Use when the 
-  user wants to: (1) check for skill updates, (2) see what's new in skills-for-fabric, 
-  (3) verify current version. Triggers: "check for updates", "am I up to date", 
-  "what version", "update skills", "show changelog".
+  Check an installed skills-for-fabric plugin bundle or git clone for updates,
+  show the matching changelog, and provide host-appropriate update guidance.
+  Use when the user wants to: (1) check for skill updates, (2) see what changed,
+  (3) verify the installed version. Triggers: "check for updates", "am I up to
+  date", "what version", "update skills", "show changelog".
 ---
 
 # Check for Updates
 
-This skill checks for updates to the skills-for-fabric marketplace at the start of each session.
+This is a read-only update checker. It identifies the installation that supplied
+this skill, compares its version with the repository's `main` branch, and shows
+the update path supported by the current agent host. It never updates
+automatically.
 
-## When to Run
+## Cadence
 
-Run this check **once per week** when any skills-for-fabric skill is first invoked. Skip if already checked within the last 7 days.
+Keep these two controls separate:
 
-## Session State
+- **Invocation guard:** Other Fabric skills invoke this skill once per session
+  before continuing.
+- **Network guard:** Automatic invocations perform a remote lookup at most once
+  every 7 days for each detected installation identity.
 
-The update check marker is stored in a **persistent, user-level directory** shared across all sessions and all plugins in the Fabric Skills marketplace:
+If the user's current request directly asks for a version, changelog, or update
+check, treat it as an **explicit invocation** and bypass the 7-day network guard.
+If this skill was invoked only by another skill's session-start notice, treat it
+as an **automatic invocation**.
+
+Always continue with the caller's original task after an automatic invocation,
+including when the check is skipped or fails.
+
+## Procedure
+
+### Step 1: Resolve the Installation Context
+
+Determine one candidate installation root:
+
+1. If the user explicitly supplied an installation path, use that exact path.
+2. Otherwise, start from the active
+   `<skills-root>/check-updates/SKILL.md` file.
+3. When `<skills-root>` is named `skills`, consider its parent as a containing
+   root. Use that containing root only if it has a supported plugin manifest or
+   both `package.json` and a direct `.git` file or directory plus the positive
+   skills-for-fabric Git identity defined below.
+4. Otherwise, use `<skills-root>` as the candidate root. This includes personal
+   copies under `~/.copilot/skills` and `~/.agents/skills`, plus project copies
+   under `.github/skills`, `.agents/skills`, and `.claude/skills`.
+5. If the runtime does not expose the active skill path, report the context as
+   unknown. Do not guess.
+
+Never infer the installation from the shell's current working directory. Never
+walk upward beyond the candidate root. A project containing an unrelated parent
+`.git` directory is not evidence that the skill came from that repository.
+
+Resolve the runtime host independently from the installation channel:
+
+```text
+copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+```
+
+Use the host identity exposed by the current session or runtime. Do not infer it
+from a plugin manifest, install path, or working directory. A deterministic test
+may supply an explicit runtime-host override; normal use may not. If the host
+cannot be established, use `unknown`.
+
+For runtime detection of an already installed plugin, use the first existing
+manifest in this cross-tool precedence:
+
+1. `.plugin/plugin.json`
+2. `plugin.json`
+3. `.github/plugin/plugin.json`
+4. `.claude-plugin/plugin.json`
+
+In this repository, `.github/plugin/plugin.json` is the canonical source
+manifest. `.plugin/plugin.json` and `plugin.json` are compatibility fallbacks
+for other installed layouts or test fixtures. The final location supports
+packages that expose only a Claude-compatible manifest. Do not treat this
+runtime probe order as authoring guidance for this repository.
+
+Then classify the candidate root in this order:
+
+| Channel | Required files at the candidate root | Read |
+|---|---|---|
+| Plugin | one supported plugin manifest | top-level `name`, `version`, `repository` |
+| Git clone | `package.json`, a direct `.git` file or directory, and a positive skills-for-fabric Git identity | top-level `version`, `repository.url` |
+| Copied skills | no plugin or Git layout, plus either a root `SKILL.md` or direct child skill directories containing `SKILL.md` | tentative skill directory names only |
+| Unknown | none of the exact layouts | no identity or update command |
+
+Plugin detection takes precedence if both layouts are present. This lets a
+development fixture retain plugin semantics while using a local Git remote.
+
+A positive Git identity requires both of these checks:
+
+- The final unscoped segment of `package.json` `name` is
+  `skills-for-fabric`. Accepted examples include `skills-for-fabric`,
+  `@microsoft/skills-for-fabric`, and contributor-fork scopes.
+- After removing a trailing slash and `.git`, the final repository path segment
+  is `skills-for-fabric`, compared case-insensitively.
+
+If either check fails, do not promote that containing root to the Git channel
+and do not run Git against it. Continue candidate-root resolution and classify
+the resulting candidate independently; a nested `skills` root may therefore be
+a loose copy. A generic Node repository that happens to contain a `skills/`
+directory is not a skills-for-fabric installation.
+
+A copied channel is terminal until an explicit request confirms its source:
+
+- For an automatic invocation, do not ask a question. Optionally show one short
+  note that the unverified loose copy was skipped and can be checked explicitly,
+  then continue the caller's original task.
+- For an explicit invocation without source confirmation, list the tentative
+  copied skill names, state that source and version are unverified, ask the
+  confirmation question in the copied-channel section, and stop.
+
+Neither path continues to the network guard or remote-version steps.
+
+Build one context object:
+
+```text
+runtimeHost: copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+channel: plugin | git | copy | unknown
+root: exact candidate root
+installKind: marketplace | direct | none
+installScope: user | project | local | managed | none
+manifestName: plugin manifest name | none
+installedName: marketplace entry name | none
+marketplace: marketplace name | none
+sourceId: direct-install source ID | none
+identity: plugin:<marketplace>/<installed-name> | plugin:direct/<source-id> | git:<repository-url-as-stored>|<root>
+localVersion: manifest version
+repository: URL exactly as stored in the selected manifest
+updateTarget: <installed-name>@<marketplace> | <manifest-name> | <root> | none
+copiedSkills: direct skill directory names | none
+```
+
+For a plugin, keep the manifest name separate from the installed marketplace
+entry name. They can differ. Resolve the installed entry from native runtime
+metadata or the native plugin listing when it identifies the candidate root.
+
+For GitHub Copilot CLI marketplace installs, the documented path is
+`~/.copilot/installed-plugins/<marketplace>/<installed-name>`, so those two path
+segments are authoritative.
+
+For a direct Copilot CLI install at
+`~/.copilot/installed-plugins/_direct/<source-id>`, set `installKind` to
+`direct`, use the source ID only for the cache identity, and use the manifest
+name as the bare update target. `_direct` is not a marketplace name.
+
+For Claude Code marketplace installs, resolve the installed entry and scope from
+Claude's native plugin metadata. `claude plugin list --json` can identify the
+entry; the declaring settings file identifies its scope:
+
+- `~/.claude/settings.json` -> `user`
+- `.claude/settings.json` -> `project`
+- `.claude/settings.local.json` -> `local`
+- managed settings -> `managed`
+
+If the same entry exists at more than one scope, list the choices and ask which
+one to update. Do not guess a scope. A plugin loaded only from a skills
+directory, `--plugin-dir`, or `--plugin-url` has no marketplace install record;
+do not fabricate an update command for it.
+
+If native metadata and the installed path are unavailable, use the manifest
+name with marketplace `fabric-collection` only when the mapping is
+unambiguous. The `fabric-skills` manifest is not unambiguous because the legacy
+`skills-for-fabric` marketplace entry uses the same payload. In that case,
+report that the installed entry could not be resolved, ask the user to inspect
+the native plugin list, and do not guess an identity or update command.
+
+For Git `package.json`, accept either a repository object with a `url` property
+or a repository URL string. Keep the repository value exactly as stored and
+append the exact resolved root when building the cache identity. This prevents
+one clone from suppressing checks for another clone of the same repository.
+When parsing a GitHub owner and repository for remote tools, strip only a
+trailing `.git` and trailing slash. Do not alter owner spelling, case,
+underscores, or punctuation.
+
+Validate that required fields are present and that `localVersion` is semantic
+version text. If validation fails, report the malformed field and classify the
+context as unknown rather than using partial metadata.
+
+### Step 2: Apply the Network Guard
+
+Use an exact cache path supplied by the caller only for a deterministic test.
+Otherwise, use this persistent cache file:
 
 ```text
 ~/.config/fabric-collection/last-update-check.json
 ```
-  
-This file contains a JSON object mapping plugin names to the **UTC date** (YYYY-MM-DD) of their last update check:
+
+On Windows, this is:
+
+```text
+$env:USERPROFILE\.config\fabric-collection\last-update-check.json
+```
+
+The file is a flat JSON object keyed by installation identity:
 
 ```json
 {
-  "fabric-skills": "2026-02-17",
-  "another-plugin": "2026-02-16"
+  "plugin:fabric-collection/fabric-consumption": "2026-07-15",
+  "plugin:direct/github-com-example-skills": "2026-07-15",
+  "git:https://github.com/example/skills-for-fabric.git|C:\\repos\\skills-for-fabric": "2026-07-14"
 }
 ```
 
-Before checking, read `~/.config/fabric-collection/last-update-check.json`:
-- If the file exists and the entry for the current plugin is within the last **7 days** (compared to the current **UTC date**), skip the check.
-- If the file is missing, the plugin entry is absent, or the date is more than 7 days old (compared to the current **UTC date**), run the update check.
+Use UTC dates in `YYYY-MM-DD` format.
 
-> **IMPORTANT — use UTC consistently**: Always use the current UTC date when saving and comparing the last-update-check timestamp. Do not use the local system timezone, as it varies across environments and can cause the check to run too often or be skipped. In shell, use `date -u +%Y-%m-%d` (Linux/macOS) or `(Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")` (PowerShell).
+- For an automatic invocation, skip the remote lookup when this identity has a
+  valid date within the last 7 days.
+- For an explicit invocation, perform the remote lookup even when a fresh cache
+  entry exists.
+- Entries for different installed plugin entries or Git clone roots do not
+  suppress each other.
+- Preserve every unrelated entry when writing the file.
+- If the file contains malformed JSON, warn and do not overwrite it.
+- Do not read or write a cache entry for a copied or unknown context.
 
-> **Note**: Create the `~/.config/fabric-collection/` directory if it does not exist. On Windows, use `$env:USERPROFILE\.config\fabric-collection\`.
+After a remote attempt completes, record today's UTC date for the detected
+identity whether the attempt found an update, found no update, or failed, unless
+the cache file was malformed. This prevents an automatic network failure from
+repeating in every session. Do not rewrite the marker when the network guard
+skipped the attempt.
 
-## Update Check Procedure
+### Step 3: Read the Remote Version
 
-### Step 1: Get Local Version
+Read `package.json` and `CHANGELOG.md` from the same repository and the same
+`main` ref. Try these methods in order and stop after the first successful one:
 
-Read the `version` field from the local plugin manifest. Two install layouts exist:
+1. **Git CLI:** Only when the candidate root itself has a direct `.git` file or
+   directory. Do not use `git rev-parse` as the availability check because it
+   can discover an unrelated parent repository.
 
-- **GitHub Copilot CLI plugin install** (`~/.copilot/installed-plugins/fabric-collection/fabric-skills/`): the manifest is `.github/plugin/plugin.json` — there is no `package.json` here.
-- **Manual git clone**: the manifest is `package.json` at the repo root.
+   ```bash
+   git -C "<root>" fetch origin main --quiet
+   git -C "<root>" show origin/main:package.json
+   git -C "<root>" show origin/main:CHANGELOG.md
+   ```
 
-Read whichever is present. Both files contain a top-level `"version": "<semver>"` field.
+2. **Authenticated GitHub tools:** Use GitHub MCP file tools or `gh api` with
+   the owner and repository parsed exactly from the manifest URL. Read
+   `package.json` and `CHANGELOG.md` at ref `main`.
+3. **Public raw content:** For a public repository, read both files from
+   `https://raw.githubusercontent.com/<owner>/<repo>/main/`.
 
-### Step 2: Determine Repository Owner and Name
+Do not use the latest GitHub Release tag as the remote version. Plugin
+marketplace updates follow repository content, and a release tag can lag behind
+the version available to plugin users.
 
-Read the `repository` field from the same manifest you used in Step 1, and parse the URL to get `owner` and `repo`. The two layouts store the field differently:
+If version retrieval fails, show the detected channel, identity, and local
+version with a concise warning. Do not fabricate a remote version. If only the
+changelog retrieval fails, still report the version comparison and note that
+the changelog was unavailable.
 
-- **Copilot CLI plugin install** (`.github/plugin/plugin.json`) — plain URL string:
-  ```text
-  "repository": "https://github.com/<owner>/<repo>"
-  ```
-- **Manual git clone** (`package.json` at the repo root) — object whose `url` ends with `.git`:
-  ```text
-  "repository": { "type": "git", "url": "https://github.com/<owner>/<repo>.git" }
-  ```
+### Step 4: Compare and Report
 
-There is no bare `plugin.json` at the repo root in either layout, and there is no top-level `package.json` in the Copilot CLI plugin install — always use the path that matches your actual layout.
+Compare semantic versions:
 
-> **CRITICAL**: Use the owner string **exactly as it appears** in the URL. Do NOT alter, normalize, or "correct" the owner name — including underscores, mixed case, or any other punctuation. Whatever the manifest's `repository` URL says, that is the correct owner. (LLMs sometimes "auto-correct" underscores to hyphens — don't.)
+- `remoteVersion > localVersion`: update available.
+- `remoteVersion <= localVersion`: up to date.
 
-### Step 3: Fetch Latest Release
+For an update, show the relevant `CHANGELOG.md` entries between the local and
+remote versions, then provide only guidance verified for both the detected
+channel and `runtimeHost`.
 
-Use the available tools in your environment to get the latest version. **Try methods in strict order — only fall back to the next method if the previous one fails or is unavailable.**
+**Plugin channel**
 
-> **IMPORTANT**: Methods A and B work with both public and private repositories. Method C only works with public repos. Always attempt A or B first.
+Never emit one host's plugin command for another host.
 
-**Method A — Git CLI (preferred for git-clone installs)**
+| Runtime host | Verified guidance |
+|---|---|
+| GitHub Copilot CLI | For a marketplace install, show `/plugin update <installed-name>@<marketplace>`. For a direct install, show `/plugin update <manifest-name>`. |
+| Claude Code | For a marketplace install with a resolved scope, show `claude plugin update <installed-name>@<marketplace> --scope <scope>`, then tell the user to run `/reload-plugins` or restart Claude Code. |
+| Cursor | Direct the user to **Customize > Plugins**. For a team marketplace, an administrator can use **Refresh** or **Enable Auto Refresh**. Do not emit a plugin CLI command. |
+| Windsurf, Codex, other, or unknown | Report the available version and repository, but provide no executable plugin command because none is verified for this layout. |
 
-Only available if the skills-for-fabric directory is a Git working tree (i.e. it has a `.git` entry — either a directory in a normal clone, or a file in a worktree/submodule). The Copilot CLI plugin install at `~/.copilot/installed-plugins/fabric-collection/fabric-skills/` has no `.git` entry — for that install layout, skip to Method B. If you want a tool-agnostic check, run `git rev-parse --is-inside-work-tree` and only proceed if it prints `true`.
-
-If you do have a Git clone, fetch the remote `package.json` without pulling:
-
-```bash
-git fetch origin main --quiet
-git show origin/main:package.json
-```
-
-Extract the `version` field from the JSON output. This method is the most reliable because it uses the already-configured remote URL and authentication, and avoids any owner/repo name parsing.
-
-**Method B — GitHub MCP tools (preferred for agentic environments)**
-
-If you have access to GitHub MCP server tools (e.g., `get_file_contents`), use them to read the remote `package.json`. Use the owner and repo extracted in Step 2 **exactly as parsed** (do not modify the strings):
-
-```text
-get_file_contents(owner: "<owner>", repo: "<repo>", path: "package.json")
-```
-
-Extract the `version` field from the response. This method works with private repositories because MCP tools use authenticated GitHub access.
-
-**Method C — GitHub REST API (fallback only, public repos)**
-
-> ⚠️ **Only use this method if Methods A and B both fail or are unavailable.** This method does not work with private repositories.
-
-If the repository is public, make a GET request using the owner/repo from Step 2:
-
-```text
-GET https://api.github.com/repos/<owner>/<repo>/releases/latest
-```
-
-Extract the `tag_name` field (e.g., `v0.2.0`) and remove the `v` prefix.
-
-> **Note**: This method returns 404 for private repositories. If you receive a 404 error, do NOT assume the repository doesn't exist — retry with Method A or B.
-
-### Step 4: Compare Versions
-
-Compare the local version with the remote version using semantic versioning:
-- If remote > local: Update available
-- If remote <= local: Up to date
-
-### Step 5: Display Results
-
-#### If Up to Date
-
-Show a brief confirmation and proceed:
-```text
-✅ skills-for-fabric v0.1.0 is up to date.
-```
-
-#### If Update Available
-
-Show detailed information:
+GitHub Copilot CLI marketplace install:
 
 ```text
-╔══════════════════════════════════════════════════════════════════╗
-║  🔄 skills-for-fabric Update Available                                ║
-║                                                                  ║
-║  Current: v0.1.0  →  Latest: v0.2.0                             ║
-╚══════════════════════════════════════════════════════════════════╝
-
-## What's New in v0.2.0
-
-[Display relevant CHANGELOG.md entries here]
-
-## Update Commands
-
-Choose the update method based on how you installed skills-for-fabric.
-
-### GitHub Copilot CLI (recommended)
-/plugin update fabric-skills@fabric-collection
-
-If you originally installed the plugin under the legacy id, this also works:
-  /plugin update skills-for-fabric@fabric-collection
-
-The plugin was renamed in 0.3.0 (skills-for-fabric → fabric-skills),
-but the legacy id is kept as a deprecated alias of fabric-skills, so
-either /plugin update command pulls the canonical payload.
-
-(Optional cleanup) To migrate your installed entry from the legacy id
-to the canonical fabric-skills id:
-  /plugin uninstall skills-for-fabric@fabric-collection
-  /plugin install fabric-skills@fabric-collection
-
-### Manual (Git clone)
-cd /path/to/skills-for-fabric
-git pull
-
-(There are no installation scripts to re-run on 0.3.0+.)
-
-─────────────────────────────────────────────────────────────────
-Would you like to update now? (The current skill will still work)
+/plugin update <installed-name>@<marketplace>
 ```
 
-### Step 6: Set Update Marker
+The installed marketplace entry is authoritative. For example, an installed
+`fabric-consumption@fabric-collection` entry produces:
 
-After completing the check (regardless of result), update `~/.config/fabric-collection/last-update-check.json` with today's **UTC date** (YYYY-MM-DD) for the current plugin. Create the directory and file if they don't exist. Preserve entries for other plugins already in the file.
+```text
+/plugin update fabric-consumption@fabric-collection
+```
+
+If the installed entry is the legacy `skills-for-fabric` alias, update that
+alias first so the installed entry can receive the current payload, even though
+its copied manifest is named `fabric-skills`:
+
+```text
+/plugin update skills-for-fabric@fabric-collection
+```
+
+Afterward, optional migration to the canonical entry is:
+
+```text
+/plugin uninstall skills-for-fabric@fabric-collection
+/plugin install fabric-skills@fabric-collection
+```
+
+GitHub Copilot CLI direct install:
+
+```text
+/plugin update <manifest-name>
+```
+
+The native CLI update target for a direct install is the bare manifest name.
+Do not append `@_direct` or use the opaque source ID as the update target.
+
+Claude Code marketplace install:
+
+```text
+claude plugin update <installed-name>@<marketplace> --scope <scope>
+```
+
+The entry name and scope must come from Claude's installed-plugin metadata. Do
+not reuse Copilot's `_direct` behavior for Claude Code.
+
+**Git channel**
+
+```text
+git -C "<detected-root>" pull --ff-only
+```
+
+**Unknown channel**
+
+State which expected files were absent and provide no update command. Never
+default to `fabric-skills`.
+
+**Copied-skill channel**
+
+A loose copy has no trustworthy repository, installed version, or native update
+target. This includes a skill materialized from a local file or URL by
+`copilot skill add` when no source metadata accompanies it.
+
+For an automatic invocation, do not interrupt the caller with a source question.
+Skip the copied-skill update flow, optionally state that an explicit update
+check can identify a supported replacement, and continue the caller's task.
+Do not list an executable command.
+
+For an explicit invocation, list the tentative skill names found at the
+candidate root, state that their provenance cannot be verified from the files
+alone, and ask:
+
+```text
+Were these skills copied from https://github.com/microsoft/skills-for-fabric?
+If yes, I can inspect the official public repository and show the supported
+plugin bundle that will refresh them. I will not install or remove anything
+without your confirmation.
+```
+
+Before the user confirms the source, do not contact the network, compare
+versions, write cache state, or offer an executable install/update command.
+
+After explicit confirmation:
+
+1. Read `.github/plugin/marketplace.json` from the `main` ref of
+   `microsoft/skills-for-fabric`, using authenticated GitHub tools first and
+   public raw content second.
+2. Match the tentative skill directory names against the skill paths inside
+   each marketplace plugin source. Treat only exact path matches as evidence.
+3. Prefer a focused plugin that covers all matched non-utility skills. If more
+   than one plugin qualifies, list the valid choices and ask the user to choose.
+   Never choose `fabric-skills` merely because `check-updates` appears in it.
+4. Offer only the replacement path supported by `runtimeHost`:
+
+   GitHub Copilot CLI:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   /plugin install <matched-plugin>@fabric-collection
+   ```
+
+   Claude Code, using `user` for a personal copied-skills root or `project` for
+   a project copied-skills root:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   claude plugin install <matched-plugin>@fabric-collection --scope <scope>
+   ```
+
+   Tell the user to run `/reload-plugins` or restart Claude Code after the
+   install. If the Claude scope cannot be resolved, ask instead of guessing.
+
+   For Cursor, Windsurf, Codex, other, or unknown hosts, link to the official
+   repository's installation instructions and provide no executable replacement
+   command. The current public repository does not expose a verified native
+   plugin marketplace for those hosts.
+
+This installs a complete current bundle instead of overwriting loose files and
+leaving mixed-version dependencies. Keep the loose copy until the native plugin
+is installed and verified. Ask separately before removing it. If no exact
+official mapping exists or the public repository is unavailable, report that
+and do not fabricate a bundle or copy individual files.
+
+## Examples
+
+### Focused plugin bundle
+
+```text
+Host: copilot-cli
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: /plugin update fabric-consumption@fabric-collection
+```
+
+### Claude Code plugin bundle
+
+```text
+Host: claude-code
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: claude plugin update fabric-consumption@fabric-collection --scope user
+Reload: /reload-plugins
+```
+
+### Git clone
+
+```text
+Detected: git:https://github.com/example/skills-for-fabric.git|C:\repos\skills-for-fabric
+Current: 0.3.7
+Latest: 0.3.8
+Update: git -C "C:\repos\skills-for-fabric" pull --ff-only
+```
+
+### Unknown layout
+
+```text
+Could not determine the skills-for-fabric installation at <candidate-root>.
+Expected a supported plugin manifest, or a positively identified
+skills-for-fabric package.json plus a direct .git entry.
+No update command was guessed.
+```
+
+### Confirmed official loose copy
+
+```text
+Host: copilot-cli
+Detected loose skills: check-updates, powerbi-report-planning
+Confirmed source: https://github.com/microsoft/skills-for-fabric
+Supported refresh:
+  /plugin marketplace add microsoft/skills-for-fabric
+  /plugin install powerbi-authoring@fabric-collection
+The loose files were not changed or removed.
+```
 
 ## Must
 
-- Check for updates only once per week (based on UTC calendar date, not session lifetime or local timezone)
-- Always proceed with the requested skill after the check (non-blocking)
-- Handle network errors gracefully (show warning, continue with skill)
-- Display the CHANGELOG.md content for versions between current and latest
+- Resolve identity from the active skill root or an explicit user path.
+- Resolve the runtime host independently from the installation layout.
+- Keep once-per-session invocation separate from the 7-day network guard.
+- Use the installed marketplace entry, not merely the manifest name, in plugin
+  identities and update commands.
+- Keep direct installs distinct from marketplace installs.
+- Require positive package and repository identity before using the Git channel.
+- Isolate Git cache entries by repository and exact clone root.
+- Preserve unrelated cache entries and use UTC dates.
+- Require source confirmation before looking up a loose copy in the official
+  public repository.
+- Match copied skill names to exact public marketplace skill paths.
+- Emit only update or replacement commands verified for the runtime host.
+- Continue non-blockingly after automatic checks.
 
 ## Prefer
 
-- Use Git CLI (Method A) or GitHub MCP tools (Method B) for version checking — these work with private repos
-- Fall back to the public GitHub REST API (Method C) **only** if Methods A and B both fail
-- Show a concise summary rather than overwhelming detail
-- Cache the check result in `~/.config/fabric-collection/last-update-check.json`
-- Provide copy-pasteable update commands
+- Use a root-local Git remote before authenticated GitHub tools.
+- Fetch version and changelog from the same repository ref.
+- Replace confirmed official loose copies through a complete native plugin
+  bundle rather than overwriting individual files.
+- Show concise, copy-pasteable output.
 
 ## Avoid
 
-- Blocking the user from using skills if update check fails
-- Checking on every skill invocation (once per week is sufficient)
-- Attempting Method C (public API) before trying Methods A or B
-- Relying solely on unauthenticated public API calls (will fail for private repos)
-- Auto-updating without user consent
+- Inferring installation context from the current working directory.
+- Letting `git` discover a parent repository.
+- Treating an unrelated package plus `.git` as a skills-for-fabric clone.
+- Inferring the runtime host from a manifest or install path.
+- Showing Copilot or Claude plugin commands to another host.
+- Defaulting focused bundles to `fabric-skills`.
+- Using GitHub Release tags as the plugin marketplace version.
+- Repeating failed automatic network checks every session.
+- Treating a same-named loose folder as proof that it came from the official
+  repository.
+- Replacing individual copied files without their complete bundle dependencies.
+- Updating without explicit user consent.
 
 ## Error Handling
 
-If the update check fails (network error, API rate limit, etc.):
+On failure, report the operation that failed and continue:
 
 ```text
-⚠️ Could not check for skills-for-fabric updates (network error).
-   Continuing with current version (v0.1.0).
-   Run '/skill check-updates' manually to retry.
+Could not check plugin:fabric-collection/fabric-consumption for updates: remote package.json was unavailable.
+Current installed version: 0.3.7
+The automatic check is non-blocking; continuing with the requested task.
 ```
 
-## Manual Invocation
-
-Users can manually check for updates at any time:
-- GitHub Copilot CLI: `/skill check-updates`
-- Other tools: Invoke the check-updates skill directly
-
-## Reference
-
-- **GitHub Repository**: https://github.com/microsoft/skills-for-fabric
-- **Releases**: https://github.com/microsoft/skills-for-fabric/releases
-- **CHANGELOG**: See `CHANGELOG.md` in repository root
+If the user says only "update my skills", clarify whether they want to check for
+an update or execute the detected native update command. Do not execute an
+update based on ambiguous intent.

--- a/plugins/fabric-skills/skills/databricks-migration/SKILL.md
+++ b/plugins/fabric-skills/skills/databricks-migration/SKILL.md
@@ -2,7 +2,7 @@
 name: databricks-migration
 description: >
   Port Databricks notebooks and jobs to Microsoft Fabric. Provides an exhaustive dbutils
-  to notebookutils substitution table: fs operations (mount removal via OneLake Shortcuts),
+  to notebookutils substitution table: fs operations (runtime mounts or OneLake Shortcuts),
   secret scope to Key Vault URL conversion, notebook run and exit, widget replacement with
   parameter-tagged cells, and library install replacement with Fabric Environments.
   Covers Unity Catalog three-level namespace reduction to Lakehouse two-level schemas,
@@ -24,9 +24,11 @@ description: >
 > **CRITICAL NOTES**
 > 1. To find workspace details (including its ID) from a workspace name: list all workspaces, then use JMESPath filtering
 > 2. To find item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace, then use JMESPath filtering
-> 3. `dbutils.widgets` has **no direct equivalent** in Fabric — use notebook parameters (cell tag `parameters`) or `notebookutils.runtime.context` for context injection
+> 3. `dbutils.widgets` has **no direct equivalent** in Fabric — use notebook parameters (cell tag `parameters`); `notebookutils.runtime.context` is execution metadata, not parameter storage. If showing context fields, use documented names such as `currentWorkspaceId`, `currentWorkspaceName`, `currentNotebookId`, `currentNotebookName`, `isForPipeline`, and `isForInteractive`; `activityId` is the Livy job ID
 > 4. `dbutils.library` (runtime library install) has **no equivalent** — use Fabric Environments for reproducible library management
 > 5. Unity Catalog uses a 3-level namespace (`catalog.schema.table`); Fabric Lakehouse uses 2-level (`schema.table` within a named Lakehouse)
+> 6. For an under-specified workspace-wide migration, ask focused questions about inventory, workload topology, security, data locations, and runtime constraints before recommending a Fabric topology
+> 7. A completed Fabric migration must not retain executable `dbutils.*` calls in dual-runtime branches or `try/except` guards — replace the calls and Databricks paths outright
 
 # Databricks → Microsoft Fabric Migration
 
@@ -53,7 +55,7 @@ For Fabric Warehouse DDL/DML authoring, see [sqldw-authoring-cli](../sqldw-autho
 | Before/After Code Patterns | [code-patterns.md](resources/code-patterns.md) |
 | Cluster Config → Fabric Spark Pools | [§ Cluster Config → Fabric Spark Pools](#cluster-config--fabric-spark-pools) |
 | Databricks Jobs → Spark Job Definitions | [§ Databricks Jobs → Spark Job Definitions](#databricks-jobs--spark-job-definitions) |
-| Delta Sharing → OneLake Shortcuts | [§ Delta Sharing → OneLake Shortcuts](#delta-sharing--onelake-shortcuts) |
+| Delta Sharing → Fabric External Data Sharing and OneLake Shortcuts | [§ Delta Sharing → Fabric External Data Sharing and OneLake Shortcuts](#delta-sharing--fabric-external-data-sharing-and-onelake-shortcuts) |
 | MLflow → Fabric ML Experiments | [§ MLflow → Fabric ML Experiments](#mlflow--fabric-ml-experiments) |
 | Must / Prefer / Avoid | [§ Must / Prefer / Avoid](#must--prefer--avoid) |
 | Authentication & Token Acquisition | [COMMON-CORE.md § Authentication](../../common/COMMON-CORE.md#authentication--token-acquisition) |
@@ -73,7 +75,7 @@ For Fabric Warehouse DDL/DML authoring, see [sqldw-authoring-cli](../sqldw-autho
 | **Delta Live Tables (DLT)** | **Fabric Notebooks** + **Data Pipelines** | No DLT equivalent — rewrite DLT datasets as parameterized notebook cells with pipeline orchestration |
 | **Databricks SQL Warehouses** | **Fabric Warehouse** or **Lakehouse SQL Endpoint** | SQL warehouse sessions → Warehouse (for write) or SQL Endpoint (for read-only) |
 | **MLflow Tracking** | **Fabric ML Experiments** | MLflow SDK is supported in Fabric — see [§ MLflow](#mlflow--fabric-ml-experiments) |
-| **Delta Sharing** | **OneLake Shortcuts** + **Fabric external data sharing** | See [§ Delta Sharing → OneLake Shortcuts](#delta-sharing--onelake-shortcuts) |
+| **Delta Sharing** | **OneLake Shortcuts** + **Fabric external data sharing** | See [§ Delta Sharing → Fabric External Data Sharing and OneLake Shortcuts](#delta-sharing--fabric-external-data-sharing-and-onelake-shortcuts) |
 | **Databricks Feature Store** | **Fabric Feature Store** (preview) | Direct conceptual equivalent; APIs differ |
 | **dbutils** (all sub-modules) | **`notebookutils`** (most sub-modules) | See [dbutils-to-notebookutils.md](resources/dbutils-to-notebookutils.md) for full mapping |
 
@@ -145,14 +147,16 @@ The complete side-by-side API table is in [dbutils-to-notebookutils.md](resource
 
 ---
 
-## Delta Sharing → OneLake Shortcuts
+## Delta Sharing → Fabric External Data Sharing and OneLake Shortcuts
 
 | Databricks Delta Sharing Pattern | Fabric Equivalent |
 |---|---|
-| Provider publishes a Delta share | Fabric **external data sharing** (preview) or OneLake Shortcut to ADLS Gen2 where Delta data resides |
-| Recipient reads shared data | Create a **OneLake Shortcut** pointing to the ADLS Gen2 Delta table; access via Lakehouse |
+| Provider publishes a Delta share | Fabric **external data sharing** for cross-tenant Fabric data, or a OneLake Shortcut to ADLS Gen2 where the Delta data resides |
+| Recipient reads shared data | Accept the external data share into a Lakehouse (Fabric creates a read-only OneLake Shortcut), or create a direct **OneLake Shortcut** to accessible ADLS Gen2 data |
 | Cross-workspace table sharing within org | **OneLake Shortcuts** pointing to another workspace's Lakehouse tables — no data copy |
-| Cross-tenant sharing | Fabric **external data sharing** (GA roadmap) — use ADLS Gen2 shortcut as interim |
+| Cross-tenant sharing | Fabric **external data sharing** — live, read-only, in-place access through a shortcut in the recipient tenant |
+
+When producing a migration workload map, include both paths: direct OneLake Shortcuts for accessible ADLS or same-tenant OneLake data, and Fabric external data sharing for native cross-tenant recipient sharing.
 
 ---
 
@@ -175,6 +179,7 @@ Fabric ML Experiments are built on the MLflow SDK — most code is directly port
 ## Must / Prefer / Avoid
 
 ### MUST DO
+- **Inventory before prescribing a workspace topology** — for workspace-wide requests that omit workload inventory, dependencies, security requirements, data locations, or runtime constraints, ask focused clarifying questions and present conditional choices before selecting a Fabric design
 - **Replace all `dbutils.*` calls** using the mapping in [dbutils-to-notebookutils.md](resources/dbutils-to-notebookutils.md) — `dbutils` is not available in Fabric notebooks
 - **Migrate `dbutils.fs.mount()` to `notebookutils.fs.mount()`** (✅ supported — Microsoft Entra default, or `accountKey` / `sasToken` from Key Vault). For cross-workspace or persistent sharing, prefer **OneLake Shortcuts** instead. Always pair `mount()` with `unmount()` in `try/finally` — Fabric mounts are not released automatically on session end
 - **Replace `dbutils.secrets.get(scope, key)`** with `notebookutils.credentials.getSecret(keyVaultUrl, secretName)` — secret scopes map to Azure Key Vault URLs
@@ -192,7 +197,9 @@ Fabric ML Experiments are built on the MLflow SDK — most code is directly port
 - **Starter Pool** for migrating interactive notebook workflows — eliminates cluster startup time that was a common pain point in Databricks job clusters
 
 ### AVOID
-- **Do not import `dbutils` or attempt `dbutils = ...` assignments** in Fabric notebooks — this will raise `NameError`; always use `notebookutils`
+- **Do not prescribe a one-size-fits-all workspace topology** when the source inventory and migration constraints are missing
+- **Do not import `dbutils` or attempt `dbutils = ...` assignments** in Fabric notebooks — import attempts fail with `ModuleNotFoundError`, while unresolved `dbutils` references raise `NameError`; always use `notebookutils`
+- **Do not retain `dbutils.*` calls behind runtime-detection guards** (`try/except`, `if IS_DATABRICKS`) — replace the calls and Databricks paths outright with `notebookutils` and Fabric paths
 - **Do not assume Unity Catalog governance policies transfer automatically** — RBAC, row-level security, and column masking must be reconfigured in Fabric using workspace roles and Lakehouse permissions
 - **Do not use `%pip install` in production Fabric notebooks** at runtime — use Fabric Environments for stable, versioned library management
 - **Do not attempt to port Delta Live Tables (DLT) pipelines verbatim** — DLT has no Fabric equivalent; rewrite as parameterized notebooks orchestrated by Fabric Pipelines

--- a/plugins/fabric-skills/skills/databricks-migration/resources/code-patterns.md
+++ b/plugins/fabric-skills/skills/databricks-migration/resources/code-patterns.md
@@ -125,15 +125,15 @@ environment = dbutils.widgets.get("environment")
 
 # AFTER — Fabric: use a "parameters" tagged cell
 # Tag the cell below as "parameters" in the notebook UI
+# Pipeline Base parameters or parent-notebook arguments override these defaults
+# by injecting the runtime values into a generated cell.
 batch_date = "2024-01-01"   # overridden by pipeline or parent notebook at runtime
 environment = "dev"
-
-# Read pipeline-injected values programmatically (if needed):
-ctx = notebookutils.runtime.context
-params = ctx.get("parameters", {})
-batch_date = params.get("batch_date", "2024-01-01")
-environment = params.get("environment", "dev")
 ```
+
+`notebookutils.runtime.context` contains execution metadata such as workspace,
+notebook, activity, and user identifiers. It does **not** store notebook
+parameter values; use the variables overridden from the marked parameters cell.
 
 ---
 

--- a/plugins/fabric-skills/skills/dataflows-authoring-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/dataflows-authoring-cli/SKILL.md
@@ -1,22 +1,21 @@
 ---
 name: dataflows-authoring-cli
 description: >
-  Create, update, delete, and refresh Fabric Dataflows Gen2 via write-side CLI
-  against Fabric Items and Connections APIs. Builds mashup.pq + queryMetadata
-  definitions, triggers parameterized refreshes, manages connections, and
-  configures output destinations (Lakehouse, Warehouse, ADX, Azure SQL).
-  Includes preview-driven authoring loop (executeQuery + customMashupDocument).
-  Lists `supportedConnectionTypes`/`credentialType` per connector.
-  For executing saved queries or reading refresh status, use
-  `dataflows-consumption-cli`.
-  Triggers: "create dataflow", "update dataflow", "delete dataflow",
-  "trigger dataflow refresh", "refresh dataflow", "preview Power Query M",
-  "preview mashup", "preview before save", "iterate dataflow M",
-  "create Fabric data source connection", "create dataflow connection",
-  "bind connection", "list supportedConnectionTypes",
-  "dataflow output destination", "dataflow write to lakehouse",
-  "dataflow write to warehouse", "dataflow write to ADX",
-  "DataDestinations annotation".
+  Create, update, delete, and refresh Fabric Dataflows Gen2 with write-side CLI
+  via Fabric APIs. Build mashup.pq and queryMetadata.json,
+  preview candidate M with executeQuery/customMashupDocument, bind connections,
+  and configure output destinations. For saved
+  query execution or refresh-status reads, use `dataflows-consumption-cli`. If
+  a request explicitly insists on the Dataflows consumption or read-only path
+  for a mutation, do not route here; let consumption refuse before any
+  separately confirmed authoring handoff. Triggers: "create dataflow", "update
+  dataflow", "delete dataflow", "trigger dataflow refresh", "preview Power
+  Query M", "preview before save", "customMashupDocument", "create Fabric data
+  source connection", "create SQL Server source REST", "POST /v1/connections",
+  "supportedConnectionTypes", "passwordReference", "bind
+  connection", "dataflow output destination", "dataflow write to lakehouse",
+  "dataflow write to warehouse", "dataflow write to ADX", "DataDestinations
+  annotation".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -28,6 +27,16 @@ description: >
 > **CRITICAL NOTES**
 > 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering
 > 2. To find the item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace and, then, use JMESPath filtering
+
+> **PRE-MUTATION REQUIREMENTS GATE (mandatory)**
+> Before any mutation, confirm enough user intent for the requested operation.
+> For create or update requests, establish the source, query/schema and
+> transformation, destination behavior, and refresh behavior (including an
+> explicit choice of no destination or no refresh). If the request is generic,
+> such as "set up the Dataflow I need for reporting," ask a structured
+> clarifying question and stop before mutation. Do not infer requirements from
+> unrelated workspace items or create a best-guess source, connection, or
+> Dataflow.
 
 # dataflows-authoring-cli — Dataflows Gen2 Authoring via CLI
 
@@ -52,7 +61,7 @@ description: >
 | [authoring-cli-quickref.md](references/authoring-cli-quickref.md) | One-liner recipes, status enums, base64 helpers, connection-binding quick patterns |
 | [authoring-script-templates.md](references/authoring-script-templates.md) | Full bash + PowerShell templates; end-to-end smoke test; LRO polling pattern |
 | [connection-management.md](references/connection-management.md) | List/create/inspect connections; `supportedConnectionTypes`; resolve `ClusterId`; ID format cheat sheet |
-| [connectors.md](references/connectors.md) | M-side source connectors: live-verified function inventory, Lakehouse deep navigation, runtime-disabled functions (`Web.Page`, `Web.BrowserContents`), `Html.Table` / `Csv.Document` / `Json.Document` patterns |
+| [connectors.md](references/connectors.md) | M-side source connectors: live-verified function inventory, Lakehouse deep navigation, gateway scope for `Web.Page` / `Web.BrowserContents`, and `Html.Table` / `Csv.Document` / `Json.Document` patterns |
 | [m-language.md](references/m-language.md) | M language semantics for Dataflow Gen2: `try` record shapes, per-cell error wrapping in column transforms, `each` scoping in row vs sub-table contexts, optional field access `[?]` / `Record.FieldOrDefault`, quoted identifiers, sandbox-disabled symbols (`File.Contents`) |
 | [mashup-preview.md](references/mashup-preview.md) | `executeQuery` contract: bootstrap branch, auto-wrap rule, hard avoid for unbounded preview |
 | [output-destinations.md](references/output-destinations.md) | Output destination patterns: Lakehouse Table, Lakehouse Files, Warehouse, ADX, Azure SQL. `DataDestinations` annotation, hidden query, `loadEnabled` rules, connection limitations |

--- a/plugins/fabric-skills/skills/dataflows-authoring-cli/references/connectors.md
+++ b/plugins/fabric-skills/skills/dataflows-authoring-cli/references/connectors.md
@@ -27,18 +27,28 @@ All functions below have their symbol registered in the Fabric mashup engine (`V
 | `Snowflake.Databases`, `AzureStorage.DataLake`, `Excel.Workbook` | 🔑 Symbol present; not exercised end-to-end here |
 | `Html.Table`, `Csv.Document`, `Json.Document`, `Lines.FromBinary`, `#table` | ✅ Pure parsers — no binding — see [Pure-data parsers](#pure-data-parsers) |
 | `Variable.Value` | 🔑 Symbol present; requires a Variable Library on the dataflow — see [Variable.Value](#variablevalue) |
-| `Web.Page`, `Web.BrowserContents` | ❌ Disabled at runtime — see [Runtime-disabled functions](#runtime-disabled-functions) |
+| `Web.Page`, `Web.BrowserContents` | Gateway-backed in cloud dataflows; disabled in the direct `executeQuery` runtime tested here - see [Browser functions and gateway scope](#browser-functions-and-gateway-scope) |
 
 Full enumeration at runtime via [`#shared`](#shared).
 
-## Runtime-disabled functions
+## Browser functions and gateway scope
+
+Microsoft Learn documents `Web.Page` and `Web.BrowserContents` as available in
+cloud dataflows through an on-premises data gateway. See
+[Using a gateway with the Web connector](https://learn.microsoft.com/en-us/power-query/connectors/web/web-troubleshoot#using-a-gateway-with-the-web-connector).
+
+The direct, gateway-free `executeQuery` runtime probed for this skill returned
+the following errors, even for inline literals:
 
 | Function | Verbatim engine error |
 |---|---|
 | `Web.BrowserContents` | `The module named 'WebBrowserContents' has been disabled in this context.` |
 | `Web.Page` | `The module named 'Html' has been disabled in this context.` |
 
-Both fail even on inline literals (no network or credential dependency). For HTML parsing in Fabric Dataflow Gen2 use [`Html.Table`](#pure-data-parsers) — different module, fully enabled.
+For gateway-free authoring and preview, use `Web.Contents` plus
+[`Html.Table`](#pure-data-parsers). If browser rendering is required, use a
+gateway-backed Web connection and validate through the supported cloud-dataflow
+path rather than direct `executeQuery`.
 
 ## Lakehouse navigation
 
@@ -220,7 +230,7 @@ Without it the privacy firewall blocks evaluation when two or more sources are r
 ### MUST
 
 1. **Match the M function kind to the binding kind.** REST casing differs (REST `"SQL"` ↔ M `Sql.Database`) — see [connection-management.md § Step 1](connection-management.md#step-1--list-supported-connection-types).
-2. **Use `Html.Table` for HTML parsing.** `Web.Page` and `Web.BrowserContents` are disabled at runtime.
+2. **Use `Html.Table` for gateway-free HTML parsing.** `Web.Page` and `Web.BrowserContents` require an on-premises gateway in cloud dataflows and are disabled in the direct `executeQuery` runtime tested here.
 3. **For combined-source documents, add `[AllowCombine = true]`** before `section Section1;`.
 4. **Decode the Arrow stream and inspect `PQ Arrow Metadata`** when reading `executeQuery` results — 200 OK is not success.
 
@@ -232,8 +242,8 @@ Without it the privacy firewall blocks evaluation when two or more sources are r
 
 ### AVOID
 
-1. **`Web.BrowserContents`** — `module 'WebBrowserContents' has been disabled`.
-2. **`Web.Page`** — `module 'Html' has been disabled`.
+1. **`Web.BrowserContents` in direct `executeQuery`** - use a gateway-backed Web connection when browser rendering is required.
+2. **`Web.Page` in direct `executeQuery`** - use a gateway-backed Web connection when the legacy browser function is required.
 3. **`Sql.Database("server")`** (1-arg form) — engine rejects with arity error. Always supply the database name.
 4. **`{[Id="Tables"]}` at the lakehouse-`[Data]` level** — there is no `Tables` folder; tables are listed directly. (`{[Id="Files"]}` IS valid — it's the only folder entry.)
 

--- a/plugins/fabric-skills/skills/dataflows-authoring-cli/references/m-language.md
+++ b/plugins/fabric-skills/skills/dataflows-authoring-cli/references/m-language.md
@@ -165,7 +165,7 @@ Use the record form when downstream code (`try ... otherwise` chains, `Table.Rep
 Credentials are required to connect to the File source. (Source at <path>.)
 ```
 
-There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a Lakehouse, Warehouse, OData feed, or `Web.Contents` instead — see [connectors.md § Function inventory](connectors.md#function-inventory). For runtime-disabled `Web.Page` / `Web.BrowserContents`, see [connectors.md § Runtime-disabled functions](connectors.md#runtime-disabled-functions).
+There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a Lakehouse, Warehouse, OData feed, or `Web.Contents` instead -- see [connectors.md Function inventory](connectors.md#function-inventory). For the gateway and direct-`executeQuery` boundary of `Web.Page` / `Web.BrowserContents`, see [connectors.md Browser functions and gateway scope](connectors.md#browser-functions-and-gateway-scope).
 
 ## MUST / PREFER / AVOID
 
@@ -184,7 +184,7 @@ There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a L
 **AVOID**
 
 1. Treating an Arrow-null cell value as "the column has nulls" without testing — it may be an errored cell. Probe with `try Conv{i}[Col]` to disambiguate.
-2. `File.Contents`, `Web.Page`, `Web.BrowserContents` — see [§ `File.Contents`](#filecontents--exposed-but-unusable) and [connectors.md § Runtime-disabled functions](connectors.md#runtime-disabled-functions).
+2. `File.Contents`, plus `Web.Page` / `Web.BrowserContents` in direct `executeQuery` - see [`File.Contents`](#filecontents--exposed-but-unusable) and [connectors.md Browser functions and gateway scope](connectors.md#browser-functions-and-gateway-scope).
 3. Discriminating on `Error.Reason` without setting it explicitly. Both built-in errors and `error "msg"` use `Reason = "Expression.Error"`. For custom reasons use the record form: `error [Reason = "...", Message = "..."]`.
 
 ## See also

--- a/plugins/fabric-skills/skills/dataflows-consumption-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/dataflows-consumption-cli/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: dataflows-consumption-cli
 description: >
-  Monitor, inspect, and query saved Fabric Dataflows Gen2 via read-only CLI.
-  List dataflows, decode base64 definitions (mashup.pq, queryMetadata.json,
-  .platform), discover parameters, retrieve refresh status and job history,
-  classify queries by staging, and execute queries against saved dataflows via
-  the read-side `executeQuery` mashup engine (Arrow IPC response). Runs
-  persisted or ad-hoc read-only executeQuery requests; parses/renders Arrow
-  results. For previewing
-  candidate M before persisting, or for `supportedConnectionTypes`/`credentialType`
-  discovery and connection configuration, use `dataflows-authoring-cli`
-  (not this skill).
-  Triggers: "list dataflows", "inspect dataflow", "decode dataflow definition",
-  "dataflow parameters", "dataflow refresh status", "refresh history",
+  Monitor, inspect, and query saved Fabric Dataflows Gen2 with read-only CLI.
+  List dataflows, decode mashup.pq/queryMetadata.json/.platform, inspect parameters,
+  refresh status, job history, staging, and destinations, or run saved/ad-hoc
+  read-only executeQuery requests and parse Arrow. Handle explicit
+  requests to mutate through the Dataflows consumption or read-only path by
+  refusing the write; offer `dataflows-authoring-cli` only after separate
+  confirmation. For candidate M before persistence or connection configuration, use
+  `dataflows-authoring-cli`. Triggers: "list dataflows", "inspect dataflow",
+  "decode dataflow definition", "dataflow parameters", "refresh history",
   "last refresh status", "dataflow job history", "execute dataflow query",
-  "executeQuery saved query", "executeQuery fetch rows", "ad-hoc dataflow query",
-  "parse Arrow response", "Arrow IPC", "dataflow staging analysis".
+  "executeQuery saved query", "executeQuery fetch rows", "ad-hoc dataflow
+  query", "parse Arrow response", "Arrow IPC", "dataflow staging analysis",
+  "use Dataflows consumption path to delete", "Dataflows read-only mutation
+  refusal", "separate Dataflows authoring handoff".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -36,9 +35,12 @@ description: >
 > call (e.g. `az rest --method delete/put/patch` against a dataflow, or a POST that
 > creates/overwrites). The only permitted POSTs are the explicitly read-side
 > `getDefinition` and `executeQuery` operations documented below.
-> If the user asks to delete, create, modify, or persist a dataflow, **refuse the
-> mutation** and route them to `dataflows-authoring-cli` — do not run the destructive
-> command, even if the user provides the exact API call.
+> If the user asks to delete, create, modify, or persist a dataflow, **explicitly
+> refuse the mutation in the final response** and name
+> `dataflows-authoring-cli` only as a future handoff. Do not invoke that skill,
+> perform discovery in preparation for the write, or continue the write workflow
+> in the same turn. A mutation may begin only after the user explicitly confirms
+> a separate authoring request.
 
 # dataflows-consumption-cli — Dataflows Gen2 Consumption via CLI
 

--- a/plugins/fabric-skills/skills/dataflows-save-as-authoring-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/dataflows-save-as-authoring-cli/SKILL.md
@@ -23,6 +23,18 @@ description: >
 > 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering
 > 2. To find the item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace and, then, use JMESPath filtering
 
+> **GENERATION BOUNDARY -- HARD STOP (mandatory)**
+> This skill executes save-as only from Gen1 to Gen2.1. For an execution
+> request whose source is Gen2, or whose source generation is not established,
+> state that no public save-as or in-place upgrade endpoint is available and
+> stop before API calls. This does not block a read-only readiness scan whose
+> purpose is to discover and classify Gen1 candidates.
+> Do not interpret "choose the closest endpoint and proceed" as approval to
+> export a definition and create a copy, do not invoke the authoring skill
+> automatically, and do not mutate anything. Ask the user to clarify the
+> intended outcome and explicitly approve any separately documented
+> alternative.
+
 # dataflows-save-as-authoring-cli — Dataflow Save-As Gen1 → Gen2.1 CI/CD via CLI
 
 A save-as companion for creating upgraded Gen2.1 copies from Power BI Gen1 dataflows using readiness assessment and guarded execution.

--- a/plugins/fabric-skills/skills/eventstream-authoring-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/eventstream-authoring-cli/SKILL.md
@@ -5,15 +5,16 @@ description: >
   the Items REST API. Build definitions with 25 source types (Event Hubs, IoT Hub,
   CDC, Kafka, SampleData), 8 operators (Filter, Aggregate, GroupBy, Join,
   ManageFields, Union, Expand, SQL), 4 destinations (Lakehouse, Eventhouse,
-  Activator, Custom Endpoint), DefaultStream/DerivedStream routing. Use to:
-  (1) author Eventstream topology, (2) add Event Hub source, (3) add filter
-  operator, (4) add CDC source with Debezium flattening, (5) wire destinations,
-  (6) modify/delete Eventstream definitions. Triggers: "create eventstream",
-  "deploy eventstream", "eventstream topology", "add source to eventstream",
-  "add event hub source", "add filter operator", "eventstream filter",
-  "eventstream destination", "CDC source", "eventstream operator",
-  "eventstream definition", "update eventstream", "wire eventstream",
-  "real-time ingestion pipeline", "eventstream topology deployment".
+  Activator, Custom Endpoint), DefaultStream/DerivedStream routing. **Invoke this
+  skill** to: (1) author Eventstream topology, (2) add Event Hub source, (3) add
+  filter operator, (4) add CDC source with Debezium flattening, (5) wire
+  destinations, (6) modify/delete Eventstream definitions. Invoke before making
+  topology changes. Triggers: "create eventstream", "deploy eventstream",
+  "eventstream topology", "add source to eventstream", "add event hub source",
+  "add filter operator", "eventstream filter", "eventstream destination",
+  "CDC source", "eventstream operator", "eventstream definition",
+  "update eventstream", "wire eventstream", "real-time ingestion pipeline",
+  "eventstream topology deployment".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -181,8 +182,8 @@ The Update Definition API returns `202 Accepted` for long-running operations. Po
 **Required structure for ALL operator condition fields:**
 - `column` → object with `{node, columnName, columnPath, expressionType: "ColumnReference"}`
 - `value` → object with `{dataType, value, expressionType: "Literal"}`
-- `operatorType` → string: `GreaterThan`, `LessThan`, `Equals`, `NotEquals`, `GreaterThanOrEqual`, `LessThanOrEqual`
-- `dataType` → `Float`, `Int`, `Long`, `String`, `DateTime`
+- `operatorType` → string: `Equals`, `NotEquals`, `GreaterThan`, `GreaterThanOrEquals`, `LessThan`, `LessThanOrEquals`, `Contains`, `DoesNotContain`, `StartsWith`, `DoesNotStartWith`, `EndsWith`, `DoesNotEndWith`, `IsEmpty`, `IsNull`, `IsNotNull`, `IsNotNullOrEmpty`
+- `dataType` → `BigInt`, `Float`, `Nvarchar(max)`, `DateTime`, `Bit`
 
 This same nested-object pattern applies to **all operators** that reference columns (Filter, Aggregate, GroupBy, Join, ManageFields).
 
@@ -227,3 +228,352 @@ Returns `200 OK` on success.
 - Do NOT exceed 11 combined CustomEndpoint sources and CustomEndpoint/Eventhouse-direct-ingestion destinations
 - Do NOT confuse Eventstream with Eventhouse — they are separate Fabric workloads
 - Do NOT hardcode workspace or item IDs — always discover them via the API
+
+---
+
+## Examples
+
+> **Platform note** — examples use PowerShell. Always write the JSON body to
+> a temp file via `[IO.File]::WriteAllText()` (no BOM) and pass
+> `--body "@$file"` to `az rest`, rather than inline `--body "..."` which
+> `cmd.exe` can mangle. Use `-Compress` with `ConvertTo-Json` to avoid
+> newline issues. The one safe inline exception is `--body '{}'` for empty bodies.
+
+### Example 1: Create an Eventstream with a Source
+
+**Prompt**: "Create an Eventstream called SensorIngestion in my dev workspace with a sample data source."
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+# 2. Create empty Eventstream
+$esBody = @{ displayName = "SensorIngestion"; description = "IoT sensor pipeline" } | ConvertTo-Json -Compress
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) "es_create.json"
+[IO.File]::WriteAllText($bodyFile, $esBody, [System.Text.UTF8Encoding]::new($false))
+$created = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$bodyFile" | ConvertFrom-Json
+
+# 3. Get the created Eventstream ID from response
+$esId = $created.id
+if (-not $esId) { throw "Eventstream creation did not return an ID" }
+
+# 4. Build topology — DefaultStream uses inputNodes (not parentName)
+$topology = @{
+    compatibilityLevel = "1.0"
+    sources = @(@{
+        name = "SampleSource"
+        type = "SampleData"
+        properties = @{ type = "Bicycles" }
+    })
+    streams = @(@{
+        name = "SensorIngestion-stream"
+        type = "DefaultStream"
+        properties = @{}
+        inputNodes = @(@{ name = "SampleSource" })
+    })
+    operators = @()
+    destinations = @()
+}
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+
+# 5. Deploy definition
+$defBody = @{
+    definition = @{
+        parts = @(@{
+            path = "eventstream.json"
+            payload = $topologyB64
+            payloadType = "InlineBase64"
+        })
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+$defFile = Join-Path ([IO.Path]::GetTempPath()) "es_def.json"
+[IO.File]::WriteAllText($defFile, $defBody, [System.Text.UTF8Encoding]::new($false))
+# Note: updateDefinition returns 202 Accepted (LRO). Poll until completion.
+$updateJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/updateDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$defFile"
+if ($LASTEXITCODE -ne 0) { throw "updateDefinition request failed" }
+
+$updateResp = $updateJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($updateResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($updateResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Update succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "updateDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 2: Add a Filter Operator with a DerivedStream
+
+**Prompt**: "Add a filter to my SensorIngestion Eventstream that keeps only events where No_Bikes > 5 and expose the filtered output as a DerivedStream."
+
+> **Important**: Adding a Filter operator node alone does not redirect the DefaultStream.
+> To make the filtered output consumable, wire a DerivedStream (or destination) to the
+> filter's output via `inputNodes`.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get current definition (handles LRO if API returns 202)
+$respJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/getDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body '{}'
+if ($LASTEXITCODE -ne 0 -or -not $respJson) { throw "getDefinition request failed" }
+$resp = $respJson | ConvertFrom-Json
+
+if ($resp.definition) {
+    $def = $resp  # Synchronous — got definition immediately
+} elseif ($resp.operationId) {
+    # Asynchronous (LRO) — poll operation status
+    $def = $null
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') {
+            $def = (az rest --method get `
+              --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)/result" `
+              --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+            break
+        } elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "getDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+    if (-not $def.definition) { throw "getDefinition LRO timed out (last status: $($status.status))" }
+} else {
+    throw "getDefinition returned neither a definition nor an operationId"
+}
+
+# 3. Decode existing topology
+$esPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstream.json' } | Select-Object -First 1
+if (-not $esPart) { throw "eventstream.json part not found in definition" }
+$topology = [Text.Encoding]::UTF8.GetString(
+  [Convert]::FromBase64String($esPart.payload)) | ConvertFrom-Json
+
+# 4. Add Filter operator (PascalCase name — no underscores or hyphens)
+#    Column: expressionType + columnName; Value: expressionType + dataType + value
+$filter = @{
+    name = "FilterLowBikes"
+    type = "Filter"
+    inputNodes = @(@{ name = "SensorIngestion-stream" })
+    properties = @{
+        conditions = @(@{
+            operatorType = "GreaterThan"
+            column = @{
+                expressionType = "ColumnReference"
+                node = $null
+                columnName = "No_Bikes"
+                columnPath = $null
+            }
+            value = @{
+                expressionType = "Literal"
+                dataType = "BigInt"
+                value = "5"
+            }
+        })
+    }
+}
+$existingOps = @($topology.operators | Where-Object { $_ -ne $null })
+$topology.operators = $existingOps + @($filter)
+
+# 5. Add DerivedStream wired to filter output (makes filtered data available)
+$derivedStream = @{
+    name = "FilteredOutput"
+    type = "DerivedStream"
+    properties = @{
+        inputSerialization = @{ type = "Json"; properties = @{ encoding = "UTF8" } }
+    }
+    inputNodes = @(@{ name = "FilterLowBikes" })
+}
+$existingStreams = @($topology.streams | Where-Object { $_ -ne $null })
+$topology.streams = $existingStreams + @($derivedStream)
+
+# 6. Re-encode and update
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+$esPart.payload = $topologyB64
+
+$defBody = @{ definition = @{ parts = $def.definition.parts } } | ConvertTo-Json -Depth 5 -Compress
+$defFile = Join-Path ([IO.Path]::GetTempPath()) "es_def.json"
+[IO.File]::WriteAllText($defFile, $defBody, [System.Text.UTF8Encoding]::new($false))
+# Note: updateDefinition returns 202 Accepted (LRO). Poll until completion.
+$updateJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/updateDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$defFile"
+if ($LASTEXITCODE -ne 0) { throw "updateDefinition request failed" }
+
+$updateResp = $updateJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($updateResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($updateResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Update succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "updateDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 3: Deploy Full Topology (Create with Inline Definition)
+
+**Prompt**: "Create a complete Eventstream called EventPipeline with a Custom Endpoint source, a filter for high-value events, and a DerivedStream for the filtered output."
+
+> **Note**: This uses the Fabric Items API (`POST /items`) to create the Eventstream with its
+> definition in a single call, rather than create-then-update.
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+# 2. Build complete topology with filter + DerivedStream
+$topology = @{
+    compatibilityLevel = "1.0"
+    sources = @(@{
+        name = "CustomSource"
+        type = "CustomEndpoint"
+        properties = @{}
+    })
+    streams = @(
+        @{
+            name = "EventPipeline-stream"
+            type = "DefaultStream"
+            properties = @{}
+            inputNodes = @(@{ name = "CustomSource" })
+        }
+        @{
+            name = "FilteredEvents"
+            type = "DerivedStream"
+            properties = @{
+                inputSerialization = @{ type = "Json"; properties = @{ encoding = "UTF8" } }
+            }
+            inputNodes = @(@{ name = "FilterPremium" })
+        }
+    )
+    operators = @(@{
+        name = "FilterPremium"
+        type = "Filter"
+        inputNodes = @(@{ name = "EventPipeline-stream" })
+        properties = @{
+            conditions = @(@{
+                operatorType = "GreaterThan"
+                column = @{
+                    expressionType = "ColumnReference"
+                        node = $null
+                        columnName = "Amount"
+                        columnPath = $null
+                    }
+                value = @{
+                    expressionType = "Literal"
+                    dataType = "BigInt"
+                    value = "100"
+                }
+            })
+        }
+    })
+    destinations = @()
+}
+
+# 3. Create with inline definition (single API call)
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+
+$body = @{
+    displayName = "EventPipeline"
+    type = "Eventstream"
+    definition = @{
+        parts = @(@{
+            path = "eventstream.json"
+            payload = $topologyB64
+            payloadType = "InlineBase64"
+        })
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) "es_create_full.json"
+[IO.File]::WriteAllText($bodyFile, $body, [System.Text.UTF8Encoding]::new($false))
+
+# Create-with-definition returns 202 Accepted (LRO). Poll until completion.
+$createJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/items" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$bodyFile"
+if ($LASTEXITCODE -ne 0) { throw "Create Eventstream request failed" }
+
+$createResp = $createJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($createResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($createResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Create succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "Create LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 4: Delete an Eventstream
+
+**Prompt**: "Delete the SensorIngestion Eventstream from my dev workspace."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Delete
+az rest --method delete `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId" `
+  --resource "https://api.fabric.microsoft.com"
+```

--- a/plugins/fabric-skills/skills/eventstream-consumption-cli/SKILL.md
+++ b/plugins/fabric-skills/skills/eventstream-consumption-cli/SKILL.md
@@ -5,16 +5,16 @@ description: >
   the Items REST API. Discover Eventstreams across workspaces, decode base64 graph
   topologies tracing event flow from source through operators to destination nodes.
   Validate connection IDs, wiring, retention policies (1-90 days), and throughput
-  levels. Retrieve Custom Endpoint Kafka credentials via Topology API. Use to:
-  (1) list Eventstreams, (2) inspect Eventstream topology showing sources and
-  destinations, (3) validate Eventstream configurations, (4) check Eventstream
-  retention policy and throughput level, (5) get connection strings. Triggers:
-  "list eventstreams", "inspect eventstream", "inspect eventstream topology",
-  "eventstream sources and destinations",
-  "eventstream health", "eventstream configuration", "eventstream retention",
-  "eventstream retention policy", "eventstream throughput level",
-  "eventstream connection string", "custom endpoint credentials",
-  "kafka connection", "check eventstream".
+  levels. Retrieve Custom Endpoint Kafka credentials via Topology API. **Invoke
+  this skill** to: (1) list Eventstreams, (2) inspect Eventstream topology showing
+  sources and destinations, (3) validate Eventstream configurations, (4) check
+  Eventstream retention policy and throughput level, (5) get connection strings.
+  Triggers: "list eventstreams", "inspect eventstream",
+  "describe eventstream topology", "eventstream operator nodes",
+  "eventstream sources and destinations", "eventstream health",
+  "eventstream status", "eventstream configuration", "eventstream retention",
+  "eventstream throughput level", "eventstream connection string",
+  "custom endpoint credentials", "check eventstream".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -284,3 +284,247 @@ Decode `eventstreamProperties.json` and check:
 - Do NOT assume all source types appear in API enums — preview sources exist only in the UI
 - Do NOT modify Eventstream topology with this consumption skill — use `eventstream-authoring-cli` for writes
 - Do NOT attempt to query event data through the Eventstream API — use downstream skills (eventhouse-consumption-cli, sqldw-consumption-cli) for querying landed data
+
+---
+
+## Examples
+
+> **Platform note** — examples use PowerShell. Always write the JSON body to
+> a temp file via `[IO.File]::WriteAllText()` (no BOM) and pass
+> `--body "@$file"` to `az rest`, rather than inline `--body "..."` which
+> `cmd.exe` can mangle. Use `-Compress` with `ConvertTo-Json` to avoid
+> newline issues. The one safe inline exception is `--body '{}'` for empty bodies.
+> For large workspaces, check for `continuationUri` in list responses to handle
+> pagination.
+
+### Example 1: List All Eventstreams in a Workspace
+
+**Prompt**: "List all Eventstreams in my analytics workspace showing their names and IDs."
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+# 2. List Eventstreams (handles pagination)
+$allItems = @()
+$resp = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+$allItems += $resp.value
+while ($resp.continuationUri) {
+    $resp = az rest --method get `
+      --url $resp.continuationUri `
+      --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+    $allItems += $resp.value
+}
+$allItems | Select-Object displayName, id, description | Format-Table
+```
+
+### Example 2: Inspect Eventstream Topology
+
+**Prompt**: "Show me the topology of my SensorIngestion Eventstream — all sources, operators, and destinations."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get topology (returns JSON directly — no base64 decoding needed)
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+# 3. Summarize nodes (filter nulls from arrays)
+Write-Host "Sources:"
+@($topo.sources | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type), id: $($_.id))"
+}
+Write-Host "Operators:"
+@($topo.operators | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+Write-Host "Destinations:"
+@($topo.destinations | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+Write-Host "Streams:"
+@($topo.streams | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+```
+
+### Example 3: Check Retention and Throughput Settings
+
+**Prompt**: "What are the retention and throughput settings for my SensorIngestion Eventstream?"
+
+> **Note**: Retention and throughput settings are stored in the `eventstreamProperties.json`
+> part of the definition (not `eventstream.json`). If this part is absent, the Eventstream
+> uses platform defaults.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/items?type=Eventstream" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get definition (handles LRO if API returns 202)
+$respJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/getDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body '{}'
+if ($LASTEXITCODE -ne 0 -or -not $respJson) { throw "getDefinition request failed" }
+$resp = $respJson | ConvertFrom-Json
+
+if ($resp.definition) {
+    $def = $resp  # Synchronous — got definition immediately
+} elseif ($resp.operationId) {
+    # Asynchronous (LRO) — poll operation status
+    $def = $null
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') {
+            $def = (az rest --method get `
+              --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)/result" `
+              --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+            break
+        } elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "getDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+    if (-not $def.definition) { throw "getDefinition LRO timed out (last status: $($status.status))" }
+} else {
+    throw "getDefinition returned neither a definition nor an operationId"
+}
+
+# 3. Decode eventstreamProperties.json part (holds retention + throughput)
+$propsPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstreamProperties.json' } | Select-Object -First 1
+if ($propsPart) {
+    $props = [Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String($propsPart.payload)) | ConvertFrom-Json
+    Write-Host "Retention: $($props.retentionTimeInDays) days"
+    Write-Host "Throughput Level: $($props.eventThroughputLevel)"
+} else {
+    # Fall back to topology-level properties (older format)
+    $esPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstream.json' } | Select-Object -First 1
+    if (-not $esPart) { throw "eventstream.json part not found in definition" }
+    $topology = [Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String($esPart.payload)) | ConvertFrom-Json
+    if ($topology.properties.retentionTimeInDays) {
+        Write-Host "Retention: $($topology.properties.retentionTimeInDays) days"
+    } else {
+        Write-Host "Retention: (platform default — not explicitly configured)"
+    }
+    if ($topology.properties.eventThroughputLevel) {
+        Write-Host "Throughput Level: $($topology.properties.eventThroughputLevel)"
+    } else {
+        Write-Host "Throughput Level: (platform default — not explicitly configured)"
+    }
+}
+```
+
+### Example 4: Get Custom Endpoint Connection Metadata
+
+**Prompt**: "Get the Kafka connection metadata for the Custom Endpoint source in my SensorIngestion Eventstream."
+
+> **Security**: The connection endpoint returns access keys. Get user confirmation before
+> calling it and avoid logging raw credentials.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs (omitted for brevity)
+
+# 2. Get topology to find Custom Endpoint source ID
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+$ceSource = @($topo.sources | Where-Object { $_.type -eq 'CustomEndpoint' }) | Select-Object -First 1
+if (-not $ceSource) { throw "No CustomEndpoint source found in this Eventstream" }
+$sourceId = $ceSource.id
+
+# 3. Get connection metadata
+$conn = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/sources/$sourceId/connection" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+Write-Host "Fully Qualified Namespace: $($conn.fullyQualifiedNamespace)"
+Write-Host "Event Hub Name:            $($conn.eventHubName)"
+Write-Host "Kafka Bootstrap Server:    $($conn.fullyQualifiedNamespace):9093"
+```
+
+### Example 5: Validate Eventstream Configuration
+
+**Prompt**: "Check if my SensorIngestion Eventstream has any configuration issues."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs (omitted for brevity)
+
+# 2. Get topology
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+# 3. Validate sources
+@($topo.sources | Where-Object { $_ -ne $null }) | ForEach-Object {
+    $src = $_
+    Write-Host "Source: $($src.name) (type: $($src.type))"
+    if ($src.properties.dataConnectionId) {
+        Write-Host "  Cloud connection: $($src.properties.dataConnectionId)"
+    }
+    if ($src.type -in @('AzureEventHub','AzureEventHubExtended','AzureIoTHub','ConfluentCloud','ApacheKafka','AmazonMSKKafka') -and
+        -not $src.properties.consumerGroupName) {
+        Write-Host "  WARNING: No consumer group set (required for $($src.type))"
+    }
+}
+
+# 4. Validate destinations
+@($topo.destinations | Where-Object { $_ -ne $null }) | ForEach-Object {
+    $dst = $_
+    Write-Host "Destination: $($dst.name) (type: $($dst.type))"
+    if (-not $dst.inputNodes -or $dst.inputNodes.Count -eq 0) {
+        Write-Host "  WARNING: No input wired — destination will receive no events"
+    }
+    if ($dst.type -eq 'Eventhouse' -and -not $dst.properties.tableName) {
+        Write-Host "  WARNING: No target table configured"
+    }
+    if ($dst.type -eq 'Eventhouse' -and $dst.properties.dataIngestionMode -eq 'DirectIngestion') {
+        if (-not $dst.properties.connectionName -or -not $dst.properties.mappingRuleName) {
+            Write-Host "  WARNING: DirectIngestion requires connectionName and mappingRuleName"
+        }
+    }
+}
+
+# 5. Check node count limits
+$ceCount = @($topo.sources | Where-Object { $_.type -eq 'CustomEndpoint' }).Count +
+           @($topo.destinations | Where-Object { $_.type -eq 'CustomEndpoint' }).Count +
+           @($topo.destinations | Where-Object { $_.type -eq 'Eventhouse' -and
+             $_.properties.dataIngestionMode -eq 'DirectIngestion' }).Count
+Write-Host "CustomEndpoint + DI count: $ceCount / 11 limit"
+if ($ceCount -gt 11) {
+    Write-Host "WARNING: Exceeds limit of 11 CustomEndpoint + DirectIngestion nodes"
+}
+```

--- a/plugins/fabric-skills/skills/semantic-model-authoring/SKILL.md
+++ b/plugins/fabric-skills/skills/semantic-model-authoring/SKILL.md
@@ -4,14 +4,15 @@ description: >
   Develops and manages Power BI semantic models across Desktop, PBIP projects, and Fabric Service. Handles:
   (1) creating new models (Import, DirectQuery, Direct Lake),
   (2) editing existing models (e.g. measures, tables, columns, relationships),
-  (3) deploying models to Fabric workspaces,
-  (4) working with PBIP project files,
-  (5) refreshing semantic models,
-  (6) configuring data sources and permissions,
-  (7) DAX performance optimization.
+  (3) preparing semantic models for AI/Copilot consumption,
+  (4) deploying models to Fabric workspaces,
+  (5) working with PBIP project files,
+  (6) refreshing semantic models,
+  (7) configuring data sources and permissions,
+  (8) DAX performance optimization.
   Supports both Power BI Desktop and Fabric Service development workflows. For read-only DAX queries, use `semantic-model-consumption`.
   Does NOT handle report layout/visual authoring, workspace administration, or RLS/OLS role membership management.
-  Triggers: "create semantic model", "edit semantic model", "add a DAX measure to semantic model", "refresh semantic model", "set semantic model permissions", "Prepare semantic model for AI/Copilot".
+  Triggers: "create semantic model", "edit semantic model", "add a DAX measure to semantic model", "refresh semantic model", "set semantic model permissions", "Prepare semantic model for AI or Copilot".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -182,7 +183,7 @@ Steps:
 
 ## Workflow: Semantic Model AI Readiness
 
-**When this applies:** User asks to make a semantic model ready for Microsoft Fabric Copilot, a Power BI Data Agent, or any conversational BI experience. Triggers include "Copilot readiness", "AI readiness", "prep for AI", "prepare model for Copilot".
+**When this applies:** User asks to make a semantic model ready for Microsoft Fabric Copilot, a Power BI Data Agent, or any conversational BI experience. Triggers include "Copilot readiness", "AI readiness", "Prep for AI", "prepare model for Copilot".
 
 Load [semantic-model-ai-readiness.md](./references/semantic-model-ai-readiness.md) before starting.
 
@@ -190,9 +191,9 @@ Steps:
 
 1. **Confirm scope & gather context** - via `ask_user`, confirm consumption mode (reports only / conversational BI / both) and model stability per the *When to Apply* section. Collect business context (process, key metrics, common natural-language questions, vocabulary). Do not invent.
 2. **Connect & inventory** - per [Connecting to a Semantic Model](#connecting-to-a-semantic-model). Capture model contents and the source location (PBIP / Fabric workspace / Desktop-only).
-3. **Evaluate & route** - walk the [Readiness Checklist](./references/semantic-model-ai-readiness.md#readiness-checklist) in order; for each gap, classify the fix per [Editing Capability by Source and Tier](./references/semantic-model-ai-readiness.md#editing-capability-by-source-and-tier) (MCP-editable TOM metadata vs PBIP-only artifact).
+3. **Evaluate & route** - walk the [Readiness Checklist](./references/semantic-model-ai-readiness.md#readiness-checklist) in order; for each gap, classify the fix per [Editing Capability](./references/semantic-model-ai-readiness.md#editing-capability) (agent-editable TOM metadata vs AI-specific artifacts the user configures in the Power BI "Prep data for AI" UI).
 4. **Present findings** grouped by severity, each tagged with routing (agent-applicable vs user-action-required). Wait for approval.
-5. **Apply approved changes** - TOM metadata via [Modify an Existing Model](#workflow-modify-an-existing-model); PBIP-only artifacts via direct file edits or Fabric `getDefinition`/`updateDefinition` round-trip; Desktop-only PBIX -> instruct user.
+5. **Apply approved changes** - apply TOM metadata fixes via [Modify an Existing Model](#workflow-modify-an-existing-model); for AI instructions, AI Data Schema, and Verified Answers, instruct the user to configure them in the Power BI "Prep data for AI" UI and, only if the user agrees, offer suggestions per the readiness reference; Desktop-only PBIX -> instruct user.
 6. **Save, validate, recommend live testing** - per [Saving Changes to a Semantic Model](#saving-changes-to-a-semantic-model) and [Validation Checklist](#validation-checklist); advise the user to test representative natural-language prompts in Copilot or the Data Agent and iterate.
 
 ---

--- a/plugins/fabric-skills/skills/semantic-model-authoring/references/pbip.md
+++ b/plugins/fabric-skills/skills/semantic-model-authoring/references/pbip.md
@@ -10,14 +10,6 @@ It can include a Semantic Model + Report or just a Report (live connect).
 PBIPFolder/
 ├── [Name].SemanticModel/
 |   ├── /definition # The semantic model definition using TMDL language [REQUIRED]
-│   ├── Copilot/ # Copilot tooling [OPTIONAL]
-│   │   ├── Instructions/ # Contains the AI instructions configured for the semantic model, stored as a single markdown file.
-│   │   │   ├── instructions.md 
-│   │   ├── VerifiedAnswers/ # Contains the configured Verified answers for the semantic model, using PBIR format.
-│   │   │   ├── definitions/
-│   │   ├── schema.json # Contains the schema selection and field synonyms configured for the semantic model. 
-│   │   ├── settings.json # Contains top level Copilot tooling settings. 
-│   │   ├── examplePrompts.json # Contains zero prompts set up for the semantic model.
 |   ├── definition.pbism # The semantic model definition file [REQUIRED]
 |   ├── * # Other semantic model metadata files and folders
 ├── [Name].Report/        
@@ -117,91 +109,6 @@ Example of a `[name].pbip` file:
 ```
 
 Refer to [JSON Schema](https://github.com/microsoft/json-schemas/blob/main/fabric/pbip/pbipProperties/1.0.0/schema.json) for more details.
-
-## Copilot/Instructions/instructions.md
-
-```markdown
-# AI Instructions for Semantic Model
-
-## Business Context & Terminology
-- You are a sales analyst for a retail company analyzing sales performance, customer behavior, and product trends
-...
-```
-
-### Copilot/schema.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/schema/1.0.0/schema.json",
-  "tables": [
-    {
-      "id": "[lineage tag]",
-      "name": "[Table name 1]",
-      "visibility": "Visible",
-      "columns": [
-        {
-          "id": "[lineage tag]",
-          "name": "[Column name 1]",
-          "visibility": "Visible",
-          "synonyms": ["[synonym 1]", "[synonym 2]"]
-        },
-        {
-          "id": "[lineage tag]",
-          "name": "[Column name 2]",
-          "visibility": "Hidden",
-          "synonyms": []
-        }
-      ],
-      "measures": [
-        {
-          "id": "[lineage tag]",
-          "name": "[measure name]",
-          "visibility": "Visible",
-          "synonyms": []
-        }
-      ],
-      "hierarchies": [
-        {
-          "id": "[lineage tag]",
-          "name": "[Hierarchy name]",
-          "visibility": "Visible",
-          "levels": [
-            {
-              "id": "[lineage tag]",
-              "name": "[Level name]",
-              "visibility": "Visible",
-              "synonyms": []
-            }
-          ],
-          "synonyms": []
-        }
-      ],
-      "synonyms": []
-    }
-  ]
-}
-```
-
-### Copilot/settings.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/settings/1.0.0/schema.json",
-  "indexingEnabled": true
-}
-```
-
-### Copilot/examplePrompts.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/examplePrompts/1.0.0/schema.json",
-  "prompts": [
-    "Top 5 customers by Sales Amount",
-    "Margin % by product category"
-  ]
-}
-```
 
 ## References
 

--- a/plugins/fabric-skills/skills/semantic-model-authoring/references/semantic-model-ai-readiness.md
+++ b/plugins/fabric-skills/skills/semantic-model-authoring/references/semantic-model-ai-readiness.md
@@ -21,14 +21,14 @@ Ask the user which consumption methods are planned before scoping the readiness 
 
 ## Editing Capability
 
-The agent's ability to *apply* a Copilot readiness item depends on (a) whether the item lives in TOM model metadata or in PBIP-only artifacts, and (b) where the model lives. 
+The agent's ability to *apply* a Copilot readiness item depends on whether the item lives in TOM model metadata (agent-editable) or is an AI-specific artifact that must be configured by the user in the Power BI "Prep data for AI" UI.
 
 | Semantic Model Objects                                                                                   | Editing path                                                                                                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **TOM metadata** - names, descriptions, relationships, measures, hidden flags, data types, summarization | **Prioritize MCP** (any source).                                                                                                                                                                                       |
-| **Everything else** - synonyms, AI instructions, AI Data Schema selection, Verified Answers              | **Edit PBIP files** under `<Name>.SemanticModel/Copilot/`. Edit directly on a PBIP project, or via Fabric workspace `getDefinition`/`updateDefinition` round-trip. Not via MCP. PBIX files cannot be edited by Agents. Load [pbip.md](pbip.md) to understand the file structure. |
+| **TOM metadata** - names, descriptions, relationships, measures, hidden flags, data types, summarization | **Edit via MCP or TMDL** (any source). The agent applies these changes directly.                                                                                                                                       |
+| **AI-specific artifacts** - AI instructions, AI Data Schema selection & synonyms, Verified Answers       | **Not editable by the agent.** Instruct the user to configure these in the Power BI "Prep data for AI" UI. The agent may *offer* suggestions only when appropriate - see sections [4](#4-ai-instructions), [5](#5-ai-data-schema), and [6](#6-verified-answers). |
 
-When presenting findings to the user, tag each item with its routing so the user knows which fixes the agent can apply and which require Desktop work.
+When presenting findings to the user, tag each item with its routing so the user knows which fixes the agent can apply to the model metadata and which the user must configure in the "Prep data for AI" UI.
 
 **Important:** When incapable of editing any metadata, refer the user to [copilot-prepare-data-ai](https://learn.microsoft.com/power-bi/create-reports/copilot-prepare-data-ai) documentation.
 
@@ -57,6 +57,8 @@ Without this, Copilot will produce poor results regardless of any other configur
 - Anticipate common questions: include predefined measures users are most likely to request (e.g., `YTD Sales`, `MoM Growth`, `ROI`, `CAC`, `LTV`). Copilot answers more reliably when the metric already exists as an explicit measure.
 - Consolidate or clearly differentiate duplicate or overlapping measures.
 - Define logical hierarchies on dimension tables to support drill-down (e.g., `Year > Quarter > Month > Day` on a date dimension; `Country > State > City` on a geography dimension).
+- Set `summarizeBy` correctly on numeric columns - especially `None` for IDs, year, month number, postal codes, etc., to prevent accidental sums.
+- Set the `isDefaultLabel` on the column that defines the natural label for each dimension table, allowing Copilot to identify the table's default "name" column (for example, **Product Name** in the **Product** table).
 
 **DON'T:**
 - Leave unused columns or tables in the model - they pollute the schema Copilot sees and increase the chance of wrong field selection.
@@ -68,8 +70,6 @@ Business-friendly naming is one of the highest-impact changes for Copilot readin
 **DO:**
 - Use human-readable names on every visible table, column, and measure (e.g., `Transaction Amount`, not `TR_AMT` or `tr_amt`).
 - Use the language Copilot will be queried in (typically English) for visible names, even if the source system uses another language.
-- Set `summarizeBy` correctly on numeric columns - especially `None` for IDs, year, month number, postal codes, etc., to prevent accidental sums.
-- Set the `isDefaultLabel` (or equivalent default field) on dimension tables so Copilot can identify the natural "name" column.
 
 **DON'T:**
 - Ship CamelCase, snake_case, UPPER_CASE, or technical abbreviations on visible objects.
@@ -95,7 +95,7 @@ Descriptions provide context that names alone cannot convey. Descriptions writte
 
 AI instructions are freeform text that Copilot reads automatically. They are one of the most impactful controls for conversational BI quality.
 
-> **Editing path:** PBIP-level artifact. See [Editing Capability](#editing-capability).
+> **Editing path:** Not editable by the agent - the user configures AI instructions in the Power BI "Prep data for AI" UI. After the model-metadata changes are applied, prompt the user to ask whether they want the agent to draft suggested AI instructions. See [Editing Capability](#editing-capability).
 
 **DO:**
 - Metric routing for ambiguous terms ("when users ask about margin, use `[Standard Margin]`").
@@ -114,22 +114,21 @@ AI instructions are freeform text that Copilot reads automatically. They are one
 **DON'T:**
 - Duplicate large blocks of business logic that already live in descriptions.
 - Encode information that should instead be a measure, a synonym, or a relationship.
-- Rely on instructions to enforce hard rules - the LLM may still ignore them. For non-negotiable behaviour, fix the model itself.
-- Exceed 10.000 characters
+- Restate what descriptions and model metadata already convey.
+- Rely on instructions to enforce hard rules - the LLM may still ignore them. For non-negotiable behavior, fix the model itself.
+- Exceed 10,000 characters
 
 ### 5. AI Data Schema
 
 The AI data schema controls which tables, columns, and measures are exposed to Copilot. It also defines synonyms for tables/columns/measures. Scoping this correctly prevents Copilot from getting confused by helper objects.
 
-> **Editing path:** PBIP-level artifact. See [Editing Capability](#editing-capability).
+> **Editing path:** Not editable by the agent - the user configures the AI Data Schema in the Power BI "Prep data for AI" UI. Prompt the user to ask whether they want suggestions, but only recommend an AI-schema visibility change when the desired AI visibility differs from the model's default visibility (e.g., a measure that should stay visible for reports and ad-hoc exploration but be excluded from AI agents). Do not mirror the report-model visibility as an AI-schema change. See [Editing Capability](#editing-capability).
 
 **DO:**
 - Include only tables, columns, and measures that a business user would meaningfully ask about.
 - Include all dependent objects for selected measures (any column or measure referenced by a selected measure must also be visible to Copilot).
 - Exclude helper measures, intermediate calculations, and technical bridge tables.
 - Exclude duplicate or overlapping measures.
-- Keep the AI schema selection consistent across "Prep for AI" and any Data Agent configuration that points to this model.
-- Configure `synonyms` on tables, columns, and measures for alternative terms users employ (e.g., `Revenue`, `Sales`, `Turnover` for the same measure).
   
 **DON'T:**
 - Default to "expose everything" - it dilutes the signal Copilot uses to pick the right field.
@@ -141,7 +140,6 @@ Verified Answers are pre-built report visuals that Copilot can return for specif
 > **Editing path:** Don't edit verified answers automatically. Instead suggest good candidates for verified answers and ask the user to configure manually in the tool. See [copilot-prepare-data-ai](https://learn.microsoft.com/power-bi/create-reports/copilot-prepare-data-ai-verified-answers) documentation.
 
 **DO:**
-- When reviewing a PBIP, check whether a Verified Answers definition exists in the project. Note its presence in the readiness summary.
-- If absent and the user is interested, point them to the Power BI Desktop authoring experience - do not attempt to author Verified Answers from this skill.
-- Inspect the model measures, based on the measure names, descriptions recommend the top five questions worth setting as verified answers
+- Inspect the model measures and, based on the measure names and descriptions, recommend the top five questions worth setting as Verified Answers.
+- Prompt the user to configure Verified Answers in the Power BI "Prep data for AI" UI - do not attempt to author Verified Answers from this skill.
 

--- a/plugins/powerbi-authoring/.github/plugin/plugin.json
+++ b/plugins/powerbi-authoring/.github/plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema",
   "name": "powerbi-authoring",
   "description": "Developer skills for authoring Microsoft Power BI solutions.",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "MIT",
   "repository": "https://github.com/microsoft/skills-for-fabric",
   "keywords": [

--- a/plugins/powerbi-authoring/skills/check-updates/SKILL.md
+++ b/plugins/powerbi-authoring/skills/check-updates/SKILL.md
@@ -1,221 +1,508 @@
 ---
 name: check-updates
 description: >
-  Check for skills-for-fabric marketplace updates at session start. Compares local version 
-  against GitHub releases and shows changelog if updates are available. Use when the 
-  user wants to: (1) check for skill updates, (2) see what's new in skills-for-fabric, 
-  (3) verify current version. Triggers: "check for updates", "am I up to date", 
-  "what version", "update skills", "show changelog".
+  Check an installed skills-for-fabric plugin bundle or git clone for updates,
+  show the matching changelog, and provide host-appropriate update guidance.
+  Use when the user wants to: (1) check for skill updates, (2) see what changed,
+  (3) verify the installed version. Triggers: "check for updates", "am I up to
+  date", "what version", "update skills", "show changelog".
 ---
 
 # Check for Updates
 
-This skill checks for updates to the skills-for-fabric marketplace at the start of each session.
+This is a read-only update checker. It identifies the installation that supplied
+this skill, compares its version with the repository's `main` branch, and shows
+the update path supported by the current agent host. It never updates
+automatically.
 
-## When to Run
+## Cadence
 
-Run this check **once per week** when any skills-for-fabric skill is first invoked. Skip if already checked within the last 7 days.
+Keep these two controls separate:
 
-## Session State
+- **Invocation guard:** Other Fabric skills invoke this skill once per session
+  before continuing.
+- **Network guard:** Automatic invocations perform a remote lookup at most once
+  every 7 days for each detected installation identity.
 
-The update check marker is stored in a **persistent, user-level directory** shared across all sessions and all plugins in the Fabric Skills marketplace:
+If the user's current request directly asks for a version, changelog, or update
+check, treat it as an **explicit invocation** and bypass the 7-day network guard.
+If this skill was invoked only by another skill's session-start notice, treat it
+as an **automatic invocation**.
+
+Always continue with the caller's original task after an automatic invocation,
+including when the check is skipped or fails.
+
+## Procedure
+
+### Step 1: Resolve the Installation Context
+
+Determine one candidate installation root:
+
+1. If the user explicitly supplied an installation path, use that exact path.
+2. Otherwise, start from the active
+   `<skills-root>/check-updates/SKILL.md` file.
+3. When `<skills-root>` is named `skills`, consider its parent as a containing
+   root. Use that containing root only if it has a supported plugin manifest or
+   both `package.json` and a direct `.git` file or directory plus the positive
+   skills-for-fabric Git identity defined below.
+4. Otherwise, use `<skills-root>` as the candidate root. This includes personal
+   copies under `~/.copilot/skills` and `~/.agents/skills`, plus project copies
+   under `.github/skills`, `.agents/skills`, and `.claude/skills`.
+5. If the runtime does not expose the active skill path, report the context as
+   unknown. Do not guess.
+
+Never infer the installation from the shell's current working directory. Never
+walk upward beyond the candidate root. A project containing an unrelated parent
+`.git` directory is not evidence that the skill came from that repository.
+
+Resolve the runtime host independently from the installation channel:
+
+```text
+copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+```
+
+Use the host identity exposed by the current session or runtime. Do not infer it
+from a plugin manifest, install path, or working directory. A deterministic test
+may supply an explicit runtime-host override; normal use may not. If the host
+cannot be established, use `unknown`.
+
+For runtime detection of an already installed plugin, use the first existing
+manifest in this cross-tool precedence:
+
+1. `.plugin/plugin.json`
+2. `plugin.json`
+3. `.github/plugin/plugin.json`
+4. `.claude-plugin/plugin.json`
+
+In this repository, `.github/plugin/plugin.json` is the canonical source
+manifest. `.plugin/plugin.json` and `plugin.json` are compatibility fallbacks
+for other installed layouts or test fixtures. The final location supports
+packages that expose only a Claude-compatible manifest. Do not treat this
+runtime probe order as authoring guidance for this repository.
+
+Then classify the candidate root in this order:
+
+| Channel | Required files at the candidate root | Read |
+|---|---|---|
+| Plugin | one supported plugin manifest | top-level `name`, `version`, `repository` |
+| Git clone | `package.json`, a direct `.git` file or directory, and a positive skills-for-fabric Git identity | top-level `version`, `repository.url` |
+| Copied skills | no plugin or Git layout, plus either a root `SKILL.md` or direct child skill directories containing `SKILL.md` | tentative skill directory names only |
+| Unknown | none of the exact layouts | no identity or update command |
+
+Plugin detection takes precedence if both layouts are present. This lets a
+development fixture retain plugin semantics while using a local Git remote.
+
+A positive Git identity requires both of these checks:
+
+- The final unscoped segment of `package.json` `name` is
+  `skills-for-fabric`. Accepted examples include `skills-for-fabric`,
+  `@microsoft/skills-for-fabric`, and contributor-fork scopes.
+- After removing a trailing slash and `.git`, the final repository path segment
+  is `skills-for-fabric`, compared case-insensitively.
+
+If either check fails, do not promote that containing root to the Git channel
+and do not run Git against it. Continue candidate-root resolution and classify
+the resulting candidate independently; a nested `skills` root may therefore be
+a loose copy. A generic Node repository that happens to contain a `skills/`
+directory is not a skills-for-fabric installation.
+
+A copied channel is terminal until an explicit request confirms its source:
+
+- For an automatic invocation, do not ask a question. Optionally show one short
+  note that the unverified loose copy was skipped and can be checked explicitly,
+  then continue the caller's original task.
+- For an explicit invocation without source confirmation, list the tentative
+  copied skill names, state that source and version are unverified, ask the
+  confirmation question in the copied-channel section, and stop.
+
+Neither path continues to the network guard or remote-version steps.
+
+Build one context object:
+
+```text
+runtimeHost: copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+channel: plugin | git | copy | unknown
+root: exact candidate root
+installKind: marketplace | direct | none
+installScope: user | project | local | managed | none
+manifestName: plugin manifest name | none
+installedName: marketplace entry name | none
+marketplace: marketplace name | none
+sourceId: direct-install source ID | none
+identity: plugin:<marketplace>/<installed-name> | plugin:direct/<source-id> | git:<repository-url-as-stored>|<root>
+localVersion: manifest version
+repository: URL exactly as stored in the selected manifest
+updateTarget: <installed-name>@<marketplace> | <manifest-name> | <root> | none
+copiedSkills: direct skill directory names | none
+```
+
+For a plugin, keep the manifest name separate from the installed marketplace
+entry name. They can differ. Resolve the installed entry from native runtime
+metadata or the native plugin listing when it identifies the candidate root.
+
+For GitHub Copilot CLI marketplace installs, the documented path is
+`~/.copilot/installed-plugins/<marketplace>/<installed-name>`, so those two path
+segments are authoritative.
+
+For a direct Copilot CLI install at
+`~/.copilot/installed-plugins/_direct/<source-id>`, set `installKind` to
+`direct`, use the source ID only for the cache identity, and use the manifest
+name as the bare update target. `_direct` is not a marketplace name.
+
+For Claude Code marketplace installs, resolve the installed entry and scope from
+Claude's native plugin metadata. `claude plugin list --json` can identify the
+entry; the declaring settings file identifies its scope:
+
+- `~/.claude/settings.json` -> `user`
+- `.claude/settings.json` -> `project`
+- `.claude/settings.local.json` -> `local`
+- managed settings -> `managed`
+
+If the same entry exists at more than one scope, list the choices and ask which
+one to update. Do not guess a scope. A plugin loaded only from a skills
+directory, `--plugin-dir`, or `--plugin-url` has no marketplace install record;
+do not fabricate an update command for it.
+
+If native metadata and the installed path are unavailable, use the manifest
+name with marketplace `fabric-collection` only when the mapping is
+unambiguous. The `fabric-skills` manifest is not unambiguous because the legacy
+`skills-for-fabric` marketplace entry uses the same payload. In that case,
+report that the installed entry could not be resolved, ask the user to inspect
+the native plugin list, and do not guess an identity or update command.
+
+For Git `package.json`, accept either a repository object with a `url` property
+or a repository URL string. Keep the repository value exactly as stored and
+append the exact resolved root when building the cache identity. This prevents
+one clone from suppressing checks for another clone of the same repository.
+When parsing a GitHub owner and repository for remote tools, strip only a
+trailing `.git` and trailing slash. Do not alter owner spelling, case,
+underscores, or punctuation.
+
+Validate that required fields are present and that `localVersion` is semantic
+version text. If validation fails, report the malformed field and classify the
+context as unknown rather than using partial metadata.
+
+### Step 2: Apply the Network Guard
+
+Use an exact cache path supplied by the caller only for a deterministic test.
+Otherwise, use this persistent cache file:
 
 ```text
 ~/.config/fabric-collection/last-update-check.json
 ```
-  
-This file contains a JSON object mapping plugin names to the **UTC date** (YYYY-MM-DD) of their last update check:
+
+On Windows, this is:
+
+```text
+$env:USERPROFILE\.config\fabric-collection\last-update-check.json
+```
+
+The file is a flat JSON object keyed by installation identity:
 
 ```json
 {
-  "fabric-skills": "2026-02-17",
-  "another-plugin": "2026-02-16"
+  "plugin:fabric-collection/fabric-consumption": "2026-07-15",
+  "plugin:direct/github-com-example-skills": "2026-07-15",
+  "git:https://github.com/example/skills-for-fabric.git|C:\\repos\\skills-for-fabric": "2026-07-14"
 }
 ```
 
-Before checking, read `~/.config/fabric-collection/last-update-check.json`:
-- If the file exists and the entry for the current plugin is within the last **7 days** (compared to the current **UTC date**), skip the check.
-- If the file is missing, the plugin entry is absent, or the date is more than 7 days old (compared to the current **UTC date**), run the update check.
+Use UTC dates in `YYYY-MM-DD` format.
 
-> **IMPORTANT — use UTC consistently**: Always use the current UTC date when saving and comparing the last-update-check timestamp. Do not use the local system timezone, as it varies across environments and can cause the check to run too often or be skipped. In shell, use `date -u +%Y-%m-%d` (Linux/macOS) or `(Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")` (PowerShell).
+- For an automatic invocation, skip the remote lookup when this identity has a
+  valid date within the last 7 days.
+- For an explicit invocation, perform the remote lookup even when a fresh cache
+  entry exists.
+- Entries for different installed plugin entries or Git clone roots do not
+  suppress each other.
+- Preserve every unrelated entry when writing the file.
+- If the file contains malformed JSON, warn and do not overwrite it.
+- Do not read or write a cache entry for a copied or unknown context.
 
-> **Note**: Create the `~/.config/fabric-collection/` directory if it does not exist. On Windows, use `$env:USERPROFILE\.config\fabric-collection\`.
+After a remote attempt completes, record today's UTC date for the detected
+identity whether the attempt found an update, found no update, or failed, unless
+the cache file was malformed. This prevents an automatic network failure from
+repeating in every session. Do not rewrite the marker when the network guard
+skipped the attempt.
 
-## Update Check Procedure
+### Step 3: Read the Remote Version
 
-### Step 1: Get Local Version
+Read `package.json` and `CHANGELOG.md` from the same repository and the same
+`main` ref. Try these methods in order and stop after the first successful one:
 
-Read the `version` field from the local plugin manifest. Two install layouts exist:
+1. **Git CLI:** Only when the candidate root itself has a direct `.git` file or
+   directory. Do not use `git rev-parse` as the availability check because it
+   can discover an unrelated parent repository.
 
-- **GitHub Copilot CLI plugin install** (`~/.copilot/installed-plugins/fabric-collection/fabric-skills/`): the manifest is `.github/plugin/plugin.json` — there is no `package.json` here.
-- **Manual git clone**: the manifest is `package.json` at the repo root.
+   ```bash
+   git -C "<root>" fetch origin main --quiet
+   git -C "<root>" show origin/main:package.json
+   git -C "<root>" show origin/main:CHANGELOG.md
+   ```
 
-Read whichever is present. Both files contain a top-level `"version": "<semver>"` field.
+2. **Authenticated GitHub tools:** Use GitHub MCP file tools or `gh api` with
+   the owner and repository parsed exactly from the manifest URL. Read
+   `package.json` and `CHANGELOG.md` at ref `main`.
+3. **Public raw content:** For a public repository, read both files from
+   `https://raw.githubusercontent.com/<owner>/<repo>/main/`.
 
-### Step 2: Determine Repository Owner and Name
+Do not use the latest GitHub Release tag as the remote version. Plugin
+marketplace updates follow repository content, and a release tag can lag behind
+the version available to plugin users.
 
-Read the `repository` field from the same manifest you used in Step 1, and parse the URL to get `owner` and `repo`. The two layouts store the field differently:
+If version retrieval fails, show the detected channel, identity, and local
+version with a concise warning. Do not fabricate a remote version. If only the
+changelog retrieval fails, still report the version comparison and note that
+the changelog was unavailable.
 
-- **Copilot CLI plugin install** (`.github/plugin/plugin.json`) — plain URL string:
-  ```text
-  "repository": "https://github.com/<owner>/<repo>"
-  ```
-- **Manual git clone** (`package.json` at the repo root) — object whose `url` ends with `.git`:
-  ```text
-  "repository": { "type": "git", "url": "https://github.com/<owner>/<repo>.git" }
-  ```
+### Step 4: Compare and Report
 
-There is no bare `plugin.json` at the repo root in either layout, and there is no top-level `package.json` in the Copilot CLI plugin install — always use the path that matches your actual layout.
+Compare semantic versions:
 
-> **CRITICAL**: Use the owner string **exactly as it appears** in the URL. Do NOT alter, normalize, or "correct" the owner name — including underscores, mixed case, or any other punctuation. Whatever the manifest's `repository` URL says, that is the correct owner. (LLMs sometimes "auto-correct" underscores to hyphens — don't.)
+- `remoteVersion > localVersion`: update available.
+- `remoteVersion <= localVersion`: up to date.
 
-### Step 3: Fetch Latest Release
+For an update, show the relevant `CHANGELOG.md` entries between the local and
+remote versions, then provide only guidance verified for both the detected
+channel and `runtimeHost`.
 
-Use the available tools in your environment to get the latest version. **Try methods in strict order — only fall back to the next method if the previous one fails or is unavailable.**
+**Plugin channel**
 
-> **IMPORTANT**: Methods A and B work with both public and private repositories. Method C only works with public repos. Always attempt A or B first.
+Never emit one host's plugin command for another host.
 
-**Method A — Git CLI (preferred for git-clone installs)**
+| Runtime host | Verified guidance |
+|---|---|
+| GitHub Copilot CLI | For a marketplace install, show `/plugin update <installed-name>@<marketplace>`. For a direct install, show `/plugin update <manifest-name>`. |
+| Claude Code | For a marketplace install with a resolved scope, show `claude plugin update <installed-name>@<marketplace> --scope <scope>`, then tell the user to run `/reload-plugins` or restart Claude Code. |
+| Cursor | Direct the user to **Customize > Plugins**. For a team marketplace, an administrator can use **Refresh** or **Enable Auto Refresh**. Do not emit a plugin CLI command. |
+| Windsurf, Codex, other, or unknown | Report the available version and repository, but provide no executable plugin command because none is verified for this layout. |
 
-Only available if the skills-for-fabric directory is a Git working tree (i.e. it has a `.git` entry — either a directory in a normal clone, or a file in a worktree/submodule). The Copilot CLI plugin install at `~/.copilot/installed-plugins/fabric-collection/fabric-skills/` has no `.git` entry — for that install layout, skip to Method B. If you want a tool-agnostic check, run `git rev-parse --is-inside-work-tree` and only proceed if it prints `true`.
-
-If you do have a Git clone, fetch the remote `package.json` without pulling:
-
-```bash
-git fetch origin main --quiet
-git show origin/main:package.json
-```
-
-Extract the `version` field from the JSON output. This method is the most reliable because it uses the already-configured remote URL and authentication, and avoids any owner/repo name parsing.
-
-**Method B — GitHub MCP tools (preferred for agentic environments)**
-
-If you have access to GitHub MCP server tools (e.g., `get_file_contents`), use them to read the remote `package.json`. Use the owner and repo extracted in Step 2 **exactly as parsed** (do not modify the strings):
-
-```text
-get_file_contents(owner: "<owner>", repo: "<repo>", path: "package.json")
-```
-
-Extract the `version` field from the response. This method works with private repositories because MCP tools use authenticated GitHub access.
-
-**Method C — GitHub REST API (fallback only, public repos)**
-
-> ⚠️ **Only use this method if Methods A and B both fail or are unavailable.** This method does not work with private repositories.
-
-If the repository is public, make a GET request using the owner/repo from Step 2:
-
-```text
-GET https://api.github.com/repos/<owner>/<repo>/releases/latest
-```
-
-Extract the `tag_name` field (e.g., `v0.2.0`) and remove the `v` prefix.
-
-> **Note**: This method returns 404 for private repositories. If you receive a 404 error, do NOT assume the repository doesn't exist — retry with Method A or B.
-
-### Step 4: Compare Versions
-
-Compare the local version with the remote version using semantic versioning:
-- If remote > local: Update available
-- If remote <= local: Up to date
-
-### Step 5: Display Results
-
-#### If Up to Date
-
-Show a brief confirmation and proceed:
-```text
-✅ skills-for-fabric v0.1.0 is up to date.
-```
-
-#### If Update Available
-
-Show detailed information:
+GitHub Copilot CLI marketplace install:
 
 ```text
-╔══════════════════════════════════════════════════════════════════╗
-║  🔄 skills-for-fabric Update Available                                ║
-║                                                                  ║
-║  Current: v0.1.0  →  Latest: v0.2.0                             ║
-╚══════════════════════════════════════════════════════════════════╝
-
-## What's New in v0.2.0
-
-[Display relevant CHANGELOG.md entries here]
-
-## Update Commands
-
-Choose the update method based on how you installed skills-for-fabric.
-
-### GitHub Copilot CLI (recommended)
-/plugin update fabric-skills@fabric-collection
-
-If you originally installed the plugin under the legacy id, this also works:
-  /plugin update skills-for-fabric@fabric-collection
-
-The plugin was renamed in 0.3.0 (skills-for-fabric → fabric-skills),
-but the legacy id is kept as a deprecated alias of fabric-skills, so
-either /plugin update command pulls the canonical payload.
-
-(Optional cleanup) To migrate your installed entry from the legacy id
-to the canonical fabric-skills id:
-  /plugin uninstall skills-for-fabric@fabric-collection
-  /plugin install fabric-skills@fabric-collection
-
-### Manual (Git clone)
-cd /path/to/skills-for-fabric
-git pull
-
-(There are no installation scripts to re-run on 0.3.0+.)
-
-─────────────────────────────────────────────────────────────────
-Would you like to update now? (The current skill will still work)
+/plugin update <installed-name>@<marketplace>
 ```
 
-### Step 6: Set Update Marker
+The installed marketplace entry is authoritative. For example, an installed
+`fabric-consumption@fabric-collection` entry produces:
 
-After completing the check (regardless of result), update `~/.config/fabric-collection/last-update-check.json` with today's **UTC date** (YYYY-MM-DD) for the current plugin. Create the directory and file if they don't exist. Preserve entries for other plugins already in the file.
+```text
+/plugin update fabric-consumption@fabric-collection
+```
+
+If the installed entry is the legacy `skills-for-fabric` alias, update that
+alias first so the installed entry can receive the current payload, even though
+its copied manifest is named `fabric-skills`:
+
+```text
+/plugin update skills-for-fabric@fabric-collection
+```
+
+Afterward, optional migration to the canonical entry is:
+
+```text
+/plugin uninstall skills-for-fabric@fabric-collection
+/plugin install fabric-skills@fabric-collection
+```
+
+GitHub Copilot CLI direct install:
+
+```text
+/plugin update <manifest-name>
+```
+
+The native CLI update target for a direct install is the bare manifest name.
+Do not append `@_direct` or use the opaque source ID as the update target.
+
+Claude Code marketplace install:
+
+```text
+claude plugin update <installed-name>@<marketplace> --scope <scope>
+```
+
+The entry name and scope must come from Claude's installed-plugin metadata. Do
+not reuse Copilot's `_direct` behavior for Claude Code.
+
+**Git channel**
+
+```text
+git -C "<detected-root>" pull --ff-only
+```
+
+**Unknown channel**
+
+State which expected files were absent and provide no update command. Never
+default to `fabric-skills`.
+
+**Copied-skill channel**
+
+A loose copy has no trustworthy repository, installed version, or native update
+target. This includes a skill materialized from a local file or URL by
+`copilot skill add` when no source metadata accompanies it.
+
+For an automatic invocation, do not interrupt the caller with a source question.
+Skip the copied-skill update flow, optionally state that an explicit update
+check can identify a supported replacement, and continue the caller's task.
+Do not list an executable command.
+
+For an explicit invocation, list the tentative skill names found at the
+candidate root, state that their provenance cannot be verified from the files
+alone, and ask:
+
+```text
+Were these skills copied from https://github.com/microsoft/skills-for-fabric?
+If yes, I can inspect the official public repository and show the supported
+plugin bundle that will refresh them. I will not install or remove anything
+without your confirmation.
+```
+
+Before the user confirms the source, do not contact the network, compare
+versions, write cache state, or offer an executable install/update command.
+
+After explicit confirmation:
+
+1. Read `.github/plugin/marketplace.json` from the `main` ref of
+   `microsoft/skills-for-fabric`, using authenticated GitHub tools first and
+   public raw content second.
+2. Match the tentative skill directory names against the skill paths inside
+   each marketplace plugin source. Treat only exact path matches as evidence.
+3. Prefer a focused plugin that covers all matched non-utility skills. If more
+   than one plugin qualifies, list the valid choices and ask the user to choose.
+   Never choose `fabric-skills` merely because `check-updates` appears in it.
+4. Offer only the replacement path supported by `runtimeHost`:
+
+   GitHub Copilot CLI:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   /plugin install <matched-plugin>@fabric-collection
+   ```
+
+   Claude Code, using `user` for a personal copied-skills root or `project` for
+   a project copied-skills root:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   claude plugin install <matched-plugin>@fabric-collection --scope <scope>
+   ```
+
+   Tell the user to run `/reload-plugins` or restart Claude Code after the
+   install. If the Claude scope cannot be resolved, ask instead of guessing.
+
+   For Cursor, Windsurf, Codex, other, or unknown hosts, link to the official
+   repository's installation instructions and provide no executable replacement
+   command. The current public repository does not expose a verified native
+   plugin marketplace for those hosts.
+
+This installs a complete current bundle instead of overwriting loose files and
+leaving mixed-version dependencies. Keep the loose copy until the native plugin
+is installed and verified. Ask separately before removing it. If no exact
+official mapping exists or the public repository is unavailable, report that
+and do not fabricate a bundle or copy individual files.
+
+## Examples
+
+### Focused plugin bundle
+
+```text
+Host: copilot-cli
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: /plugin update fabric-consumption@fabric-collection
+```
+
+### Claude Code plugin bundle
+
+```text
+Host: claude-code
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: claude plugin update fabric-consumption@fabric-collection --scope user
+Reload: /reload-plugins
+```
+
+### Git clone
+
+```text
+Detected: git:https://github.com/example/skills-for-fabric.git|C:\repos\skills-for-fabric
+Current: 0.3.7
+Latest: 0.3.8
+Update: git -C "C:\repos\skills-for-fabric" pull --ff-only
+```
+
+### Unknown layout
+
+```text
+Could not determine the skills-for-fabric installation at <candidate-root>.
+Expected a supported plugin manifest, or a positively identified
+skills-for-fabric package.json plus a direct .git entry.
+No update command was guessed.
+```
+
+### Confirmed official loose copy
+
+```text
+Host: copilot-cli
+Detected loose skills: check-updates, powerbi-report-planning
+Confirmed source: https://github.com/microsoft/skills-for-fabric
+Supported refresh:
+  /plugin marketplace add microsoft/skills-for-fabric
+  /plugin install powerbi-authoring@fabric-collection
+The loose files were not changed or removed.
+```
 
 ## Must
 
-- Check for updates only once per week (based on UTC calendar date, not session lifetime or local timezone)
-- Always proceed with the requested skill after the check (non-blocking)
-- Handle network errors gracefully (show warning, continue with skill)
-- Display the CHANGELOG.md content for versions between current and latest
+- Resolve identity from the active skill root or an explicit user path.
+- Resolve the runtime host independently from the installation layout.
+- Keep once-per-session invocation separate from the 7-day network guard.
+- Use the installed marketplace entry, not merely the manifest name, in plugin
+  identities and update commands.
+- Keep direct installs distinct from marketplace installs.
+- Require positive package and repository identity before using the Git channel.
+- Isolate Git cache entries by repository and exact clone root.
+- Preserve unrelated cache entries and use UTC dates.
+- Require source confirmation before looking up a loose copy in the official
+  public repository.
+- Match copied skill names to exact public marketplace skill paths.
+- Emit only update or replacement commands verified for the runtime host.
+- Continue non-blockingly after automatic checks.
 
 ## Prefer
 
-- Use Git CLI (Method A) or GitHub MCP tools (Method B) for version checking — these work with private repos
-- Fall back to the public GitHub REST API (Method C) **only** if Methods A and B both fail
-- Show a concise summary rather than overwhelming detail
-- Cache the check result in `~/.config/fabric-collection/last-update-check.json`
-- Provide copy-pasteable update commands
+- Use a root-local Git remote before authenticated GitHub tools.
+- Fetch version and changelog from the same repository ref.
+- Replace confirmed official loose copies through a complete native plugin
+  bundle rather than overwriting individual files.
+- Show concise, copy-pasteable output.
 
 ## Avoid
 
-- Blocking the user from using skills if update check fails
-- Checking on every skill invocation (once per week is sufficient)
-- Attempting Method C (public API) before trying Methods A or B
-- Relying solely on unauthenticated public API calls (will fail for private repos)
-- Auto-updating without user consent
+- Inferring installation context from the current working directory.
+- Letting `git` discover a parent repository.
+- Treating an unrelated package plus `.git` as a skills-for-fabric clone.
+- Inferring the runtime host from a manifest or install path.
+- Showing Copilot or Claude plugin commands to another host.
+- Defaulting focused bundles to `fabric-skills`.
+- Using GitHub Release tags as the plugin marketplace version.
+- Repeating failed automatic network checks every session.
+- Treating a same-named loose folder as proof that it came from the official
+  repository.
+- Replacing individual copied files without their complete bundle dependencies.
+- Updating without explicit user consent.
 
 ## Error Handling
 
-If the update check fails (network error, API rate limit, etc.):
+On failure, report the operation that failed and continue:
 
 ```text
-⚠️ Could not check for skills-for-fabric updates (network error).
-   Continuing with current version (v0.1.0).
-   Run '/skill check-updates' manually to retry.
+Could not check plugin:fabric-collection/fabric-consumption for updates: remote package.json was unavailable.
+Current installed version: 0.3.7
+The automatic check is non-blocking; continuing with the requested task.
 ```
 
-## Manual Invocation
-
-Users can manually check for updates at any time:
-- GitHub Copilot CLI: `/skill check-updates`
-- Other tools: Invoke the check-updates skill directly
-
-## Reference
-
-- **GitHub Repository**: https://github.com/microsoft/skills-for-fabric
-- **Releases**: https://github.com/microsoft/skills-for-fabric/releases
-- **CHANGELOG**: See `CHANGELOG.md` in repository root
+If the user says only "update my skills", clarify whether they want to check for
+an update or execute the detected native update command. Do not execute an
+update based on ambiguous intent.

--- a/plugins/powerbi-authoring/skills/semantic-model-authoring/SKILL.md
+++ b/plugins/powerbi-authoring/skills/semantic-model-authoring/SKILL.md
@@ -4,14 +4,15 @@ description: >
   Develops and manages Power BI semantic models across Desktop, PBIP projects, and Fabric Service. Handles:
   (1) creating new models (Import, DirectQuery, Direct Lake),
   (2) editing existing models (e.g. measures, tables, columns, relationships),
-  (3) deploying models to Fabric workspaces,
-  (4) working with PBIP project files,
-  (5) refreshing semantic models,
-  (6) configuring data sources and permissions,
-  (7) DAX performance optimization.
+  (3) preparing semantic models for AI/Copilot consumption,
+  (4) deploying models to Fabric workspaces,
+  (5) working with PBIP project files,
+  (6) refreshing semantic models,
+  (7) configuring data sources and permissions,
+  (8) DAX performance optimization.
   Supports both Power BI Desktop and Fabric Service development workflows. For read-only DAX queries, use `semantic-model-consumption`.
   Does NOT handle report layout/visual authoring, workspace administration, or RLS/OLS role membership management.
-  Triggers: "create semantic model", "edit semantic model", "add a DAX measure to semantic model", "refresh semantic model", "set semantic model permissions", "Prepare semantic model for AI/Copilot".
+  Triggers: "create semantic model", "edit semantic model", "add a DAX measure to semantic model", "refresh semantic model", "set semantic model permissions", "Prepare semantic model for AI or Copilot".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -182,7 +183,7 @@ Steps:
 
 ## Workflow: Semantic Model AI Readiness
 
-**When this applies:** User asks to make a semantic model ready for Microsoft Fabric Copilot, a Power BI Data Agent, or any conversational BI experience. Triggers include "Copilot readiness", "AI readiness", "prep for AI", "prepare model for Copilot".
+**When this applies:** User asks to make a semantic model ready for Microsoft Fabric Copilot, a Power BI Data Agent, or any conversational BI experience. Triggers include "Copilot readiness", "AI readiness", "Prep for AI", "prepare model for Copilot".
 
 Load [semantic-model-ai-readiness.md](./references/semantic-model-ai-readiness.md) before starting.
 
@@ -190,9 +191,9 @@ Steps:
 
 1. **Confirm scope & gather context** - via `ask_user`, confirm consumption mode (reports only / conversational BI / both) and model stability per the *When to Apply* section. Collect business context (process, key metrics, common natural-language questions, vocabulary). Do not invent.
 2. **Connect & inventory** - per [Connecting to a Semantic Model](#connecting-to-a-semantic-model). Capture model contents and the source location (PBIP / Fabric workspace / Desktop-only).
-3. **Evaluate & route** - walk the [Readiness Checklist](./references/semantic-model-ai-readiness.md#readiness-checklist) in order; for each gap, classify the fix per [Editing Capability by Source and Tier](./references/semantic-model-ai-readiness.md#editing-capability-by-source-and-tier) (MCP-editable TOM metadata vs PBIP-only artifact).
+3. **Evaluate & route** - walk the [Readiness Checklist](./references/semantic-model-ai-readiness.md#readiness-checklist) in order; for each gap, classify the fix per [Editing Capability](./references/semantic-model-ai-readiness.md#editing-capability) (agent-editable TOM metadata vs AI-specific artifacts the user configures in the Power BI "Prep data for AI" UI).
 4. **Present findings** grouped by severity, each tagged with routing (agent-applicable vs user-action-required). Wait for approval.
-5. **Apply approved changes** - TOM metadata via [Modify an Existing Model](#workflow-modify-an-existing-model); PBIP-only artifacts via direct file edits or Fabric `getDefinition`/`updateDefinition` round-trip; Desktop-only PBIX -> instruct user.
+5. **Apply approved changes** - apply TOM metadata fixes via [Modify an Existing Model](#workflow-modify-an-existing-model); for AI instructions, AI Data Schema, and Verified Answers, instruct the user to configure them in the Power BI "Prep data for AI" UI and, only if the user agrees, offer suggestions per the readiness reference; Desktop-only PBIX -> instruct user.
 6. **Save, validate, recommend live testing** - per [Saving Changes to a Semantic Model](#saving-changes-to-a-semantic-model) and [Validation Checklist](#validation-checklist); advise the user to test representative natural-language prompts in Copilot or the Data Agent and iterate.
 
 ---

--- a/plugins/powerbi-authoring/skills/semantic-model-authoring/references/pbip.md
+++ b/plugins/powerbi-authoring/skills/semantic-model-authoring/references/pbip.md
@@ -10,14 +10,6 @@ It can include a Semantic Model + Report or just a Report (live connect).
 PBIPFolder/
 ├── [Name].SemanticModel/
 |   ├── /definition # The semantic model definition using TMDL language [REQUIRED]
-│   ├── Copilot/ # Copilot tooling [OPTIONAL]
-│   │   ├── Instructions/ # Contains the AI instructions configured for the semantic model, stored as a single markdown file.
-│   │   │   ├── instructions.md 
-│   │   ├── VerifiedAnswers/ # Contains the configured Verified answers for the semantic model, using PBIR format.
-│   │   │   ├── definitions/
-│   │   ├── schema.json # Contains the schema selection and field synonyms configured for the semantic model. 
-│   │   ├── settings.json # Contains top level Copilot tooling settings. 
-│   │   ├── examplePrompts.json # Contains zero prompts set up for the semantic model.
 |   ├── definition.pbism # The semantic model definition file [REQUIRED]
 |   ├── * # Other semantic model metadata files and folders
 ├── [Name].Report/        
@@ -117,91 +109,6 @@ Example of a `[name].pbip` file:
 ```
 
 Refer to [JSON Schema](https://github.com/microsoft/json-schemas/blob/main/fabric/pbip/pbipProperties/1.0.0/schema.json) for more details.
-
-## Copilot/Instructions/instructions.md
-
-```markdown
-# AI Instructions for Semantic Model
-
-## Business Context & Terminology
-- You are a sales analyst for a retail company analyzing sales performance, customer behavior, and product trends
-...
-```
-
-### Copilot/schema.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/schema/1.0.0/schema.json",
-  "tables": [
-    {
-      "id": "[lineage tag]",
-      "name": "[Table name 1]",
-      "visibility": "Visible",
-      "columns": [
-        {
-          "id": "[lineage tag]",
-          "name": "[Column name 1]",
-          "visibility": "Visible",
-          "synonyms": ["[synonym 1]", "[synonym 2]"]
-        },
-        {
-          "id": "[lineage tag]",
-          "name": "[Column name 2]",
-          "visibility": "Hidden",
-          "synonyms": []
-        }
-      ],
-      "measures": [
-        {
-          "id": "[lineage tag]",
-          "name": "[measure name]",
-          "visibility": "Visible",
-          "synonyms": []
-        }
-      ],
-      "hierarchies": [
-        {
-          "id": "[lineage tag]",
-          "name": "[Hierarchy name]",
-          "visibility": "Visible",
-          "levels": [
-            {
-              "id": "[lineage tag]",
-              "name": "[Level name]",
-              "visibility": "Visible",
-              "synonyms": []
-            }
-          ],
-          "synonyms": []
-        }
-      ],
-      "synonyms": []
-    }
-  ]
-}
-```
-
-### Copilot/settings.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/settings/1.0.0/schema.json",
-  "indexingEnabled": true
-}
-```
-
-### Copilot/examplePrompts.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/examplePrompts/1.0.0/schema.json",
-  "prompts": [
-    "Top 5 customers by Sales Amount",
-    "Margin % by product category"
-  ]
-}
-```
 
 ## References
 

--- a/plugins/powerbi-authoring/skills/semantic-model-authoring/references/semantic-model-ai-readiness.md
+++ b/plugins/powerbi-authoring/skills/semantic-model-authoring/references/semantic-model-ai-readiness.md
@@ -21,14 +21,14 @@ Ask the user which consumption methods are planned before scoping the readiness 
 
 ## Editing Capability
 
-The agent's ability to *apply* a Copilot readiness item depends on (a) whether the item lives in TOM model metadata or in PBIP-only artifacts, and (b) where the model lives. 
+The agent's ability to *apply* a Copilot readiness item depends on whether the item lives in TOM model metadata (agent-editable) or is an AI-specific artifact that must be configured by the user in the Power BI "Prep data for AI" UI.
 
 | Semantic Model Objects                                                                                   | Editing path                                                                                                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **TOM metadata** - names, descriptions, relationships, measures, hidden flags, data types, summarization | **Prioritize MCP** (any source).                                                                                                                                                                                       |
-| **Everything else** - synonyms, AI instructions, AI Data Schema selection, Verified Answers              | **Edit PBIP files** under `<Name>.SemanticModel/Copilot/`. Edit directly on a PBIP project, or via Fabric workspace `getDefinition`/`updateDefinition` round-trip. Not via MCP. PBIX files cannot be edited by Agents. Load [pbip.md](pbip.md) to understand the file structure. |
+| **TOM metadata** - names, descriptions, relationships, measures, hidden flags, data types, summarization | **Edit via MCP or TMDL** (any source). The agent applies these changes directly.                                                                                                                                       |
+| **AI-specific artifacts** - AI instructions, AI Data Schema selection & synonyms, Verified Answers       | **Not editable by the agent.** Instruct the user to configure these in the Power BI "Prep data for AI" UI. The agent may *offer* suggestions only when appropriate - see sections [4](#4-ai-instructions), [5](#5-ai-data-schema), and [6](#6-verified-answers). |
 
-When presenting findings to the user, tag each item with its routing so the user knows which fixes the agent can apply and which require Desktop work.
+When presenting findings to the user, tag each item with its routing so the user knows which fixes the agent can apply to the model metadata and which the user must configure in the "Prep data for AI" UI.
 
 **Important:** When incapable of editing any metadata, refer the user to [copilot-prepare-data-ai](https://learn.microsoft.com/power-bi/create-reports/copilot-prepare-data-ai) documentation.
 
@@ -57,6 +57,8 @@ Without this, Copilot will produce poor results regardless of any other configur
 - Anticipate common questions: include predefined measures users are most likely to request (e.g., `YTD Sales`, `MoM Growth`, `ROI`, `CAC`, `LTV`). Copilot answers more reliably when the metric already exists as an explicit measure.
 - Consolidate or clearly differentiate duplicate or overlapping measures.
 - Define logical hierarchies on dimension tables to support drill-down (e.g., `Year > Quarter > Month > Day` on a date dimension; `Country > State > City` on a geography dimension).
+- Set `summarizeBy` correctly on numeric columns - especially `None` for IDs, year, month number, postal codes, etc., to prevent accidental sums.
+- Set the `isDefaultLabel` on the column that defines the natural label for each dimension table, allowing Copilot to identify the table's default "name" column (for example, **Product Name** in the **Product** table).
 
 **DON'T:**
 - Leave unused columns or tables in the model - they pollute the schema Copilot sees and increase the chance of wrong field selection.
@@ -68,8 +70,6 @@ Business-friendly naming is one of the highest-impact changes for Copilot readin
 **DO:**
 - Use human-readable names on every visible table, column, and measure (e.g., `Transaction Amount`, not `TR_AMT` or `tr_amt`).
 - Use the language Copilot will be queried in (typically English) for visible names, even if the source system uses another language.
-- Set `summarizeBy` correctly on numeric columns - especially `None` for IDs, year, month number, postal codes, etc., to prevent accidental sums.
-- Set the `isDefaultLabel` (or equivalent default field) on dimension tables so Copilot can identify the natural "name" column.
 
 **DON'T:**
 - Ship CamelCase, snake_case, UPPER_CASE, or technical abbreviations on visible objects.
@@ -95,7 +95,7 @@ Descriptions provide context that names alone cannot convey. Descriptions writte
 
 AI instructions are freeform text that Copilot reads automatically. They are one of the most impactful controls for conversational BI quality.
 
-> **Editing path:** PBIP-level artifact. See [Editing Capability](#editing-capability).
+> **Editing path:** Not editable by the agent - the user configures AI instructions in the Power BI "Prep data for AI" UI. After the model-metadata changes are applied, prompt the user to ask whether they want the agent to draft suggested AI instructions. See [Editing Capability](#editing-capability).
 
 **DO:**
 - Metric routing for ambiguous terms ("when users ask about margin, use `[Standard Margin]`").
@@ -114,22 +114,21 @@ AI instructions are freeform text that Copilot reads automatically. They are one
 **DON'T:**
 - Duplicate large blocks of business logic that already live in descriptions.
 - Encode information that should instead be a measure, a synonym, or a relationship.
-- Rely on instructions to enforce hard rules - the LLM may still ignore them. For non-negotiable behaviour, fix the model itself.
-- Exceed 10.000 characters
+- Restate what descriptions and model metadata already convey.
+- Rely on instructions to enforce hard rules - the LLM may still ignore them. For non-negotiable behavior, fix the model itself.
+- Exceed 10,000 characters
 
 ### 5. AI Data Schema
 
 The AI data schema controls which tables, columns, and measures are exposed to Copilot. It also defines synonyms for tables/columns/measures. Scoping this correctly prevents Copilot from getting confused by helper objects.
 
-> **Editing path:** PBIP-level artifact. See [Editing Capability](#editing-capability).
+> **Editing path:** Not editable by the agent - the user configures the AI Data Schema in the Power BI "Prep data for AI" UI. Prompt the user to ask whether they want suggestions, but only recommend an AI-schema visibility change when the desired AI visibility differs from the model's default visibility (e.g., a measure that should stay visible for reports and ad-hoc exploration but be excluded from AI agents). Do not mirror the report-model visibility as an AI-schema change. See [Editing Capability](#editing-capability).
 
 **DO:**
 - Include only tables, columns, and measures that a business user would meaningfully ask about.
 - Include all dependent objects for selected measures (any column or measure referenced by a selected measure must also be visible to Copilot).
 - Exclude helper measures, intermediate calculations, and technical bridge tables.
 - Exclude duplicate or overlapping measures.
-- Keep the AI schema selection consistent across "Prep for AI" and any Data Agent configuration that points to this model.
-- Configure `synonyms` on tables, columns, and measures for alternative terms users employ (e.g., `Revenue`, `Sales`, `Turnover` for the same measure).
   
 **DON'T:**
 - Default to "expose everything" - it dilutes the signal Copilot uses to pick the right field.
@@ -141,7 +140,6 @@ Verified Answers are pre-built report visuals that Copilot can return for specif
 > **Editing path:** Don't edit verified answers automatically. Instead suggest good candidates for verified answers and ask the user to configure manually in the tool. See [copilot-prepare-data-ai](https://learn.microsoft.com/power-bi/create-reports/copilot-prepare-data-ai-verified-answers) documentation.
 
 **DO:**
-- When reviewing a PBIP, check whether a Verified Answers definition exists in the project. Note its presence in the readiness summary.
-- If absent and the user is interested, point them to the Power BI Desktop authoring experience - do not attempt to author Verified Answers from this skill.
-- Inspect the model measures, based on the measure names, descriptions recommend the top five questions worth setting as verified answers
+- Inspect the model measures and, based on the measure names and descriptions, recommend the top five questions worth setting as Verified Answers.
+- Prompt the user to configure Verified Answers in the Power BI "Prep data for AI" UI - do not attempt to author Verified Answers from this skill.
 

--- a/skills/activator-authoring-cli/SKILL.md
+++ b/skills/activator-authoring-cli/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: activator-authoring-cli
 description: >
-  Create alerts, notifications, and automated actions on Fabric data and events
-  via Fabric REST API and `az rest` CLI. **Invoke this skill** whenever the user
-  wants to:
-  (1) create, update, or delete an alert or notification flow,
-  (2) send a Teams message, email, or run a Fabric item when something happens,
-  (3) connect alert logic to Eventhouse, Eventstream, Real-time Hub, or DTB / Ontology data,
-  (4) adjust thresholds, filters, event triggers, or actions,
-  (5) troubleshoot or change an existing Activator/Reflex definition.
-  Invoke this skill **before** asking clarifying questions — clarification is part of this skill, not a preamble to it.
+  Author Fabric Activator rules and Reflex items through Fabric REST API and `az rest`.
+  Invoke for write intents: create or delete items; add or update rule definitions;
+  configure thresholds, filters, Teams/email notifications, Fabric item actions, and
+  Eventhouse/Eventstream/Real-Time Hub/DTB/Ontology sources. Pure GET/explain prompts
+  belong to `activator-consumption-cli`. Clarification for missing sources, thresholds,
+  recipients, and action targets happens inside this skill.
   Triggers: "create an alert", "create an activator", "create a reflex",
   "create an activator item", "create an alert item",
   "notify me when", "let me know when",
@@ -201,6 +198,17 @@ Example rule entity:
 - In the rule's `FabricItemBinding`, set `fabricJobConnectionDocumentId` to the standalone `fabricItemAction-v1.uniqueIdentifier`
 - See [action-types.md](references/action-types.md) for per-target schemas and UDF-specific gotchas (`itemType` vs readback `FunctionSet`, `subitemId`, canonical `parameterType` mapping, dynamic parameter shape)
 
+### Reference Integrity Preflight
+
+Before every `updateDefinition`, validate the exact entity array you will send:
+
+1. Build the set of every top-level `uniqueIdentifier` in `ReflexEntities.json`.
+2. Confirm every `parentContainer.targetUniqueIdentifier`, `parentObject.targetUniqueIdentifier`, `SourceReference.entityId`, `EventReference.entityId`, `AttributeReference.entityId`, and `fabricJobConnectionDocumentId` resolves to an entity in that same array (or to an unchanged entity from the latest decoded readback that is included in the re-encoded array).
+3. Confirm each reference points to the expected entity type: containers to `container-v1`, source/event/attribute/rule/object references to `timeSeriesView-v1` when the template expects a view, source references to the source entity, and Fabric item action bindings to `fabricItemAction-v1`.
+4. If any reference is missing, rebuild the graph from the latest `getDefinition` output and do not call `updateDefinition`.
+
+`FailedToResolveEntity` with `DocumentType timeSeriesView not found` means a rule, attribute, split event, or event reference points at a `timeSeriesView-v1` GUID that is not present in the submitted definition. Treat that as an entity-wiring bug to fix before retrying, not as a transient backend failure.
+
 ### Entity Wiring Summary
 
 ```text
@@ -277,11 +285,23 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 
 ---
 
+## Source Validation Gate
+
+Before authoring **any** rule that references a signal (a measurement, field, or event property), confirm the source is real. A requested source only counts as **real** after all three checks pass:
+
+1. **Resolve** the source in the **requested** workspace only -- do not search or substitute another workspace.
+2. **Validate** that the requested signal column/field exists on that source (KQL table/column, Eventstream field, Real-Time Hub event property, or DTB / Ontology property).
+3. **Observe** at least one representative row/event/sample carrying that signal -- run the KQL / DTB query or inspect the stream and confirm it actually returns data.
+
+Treat **schema-only**, **zero-row**, **non-emitting**, or **stale** evidence as **missing source data**, not a real source. When the source is missing, **stop and ask** which source and fields provide the signal (plus any missing threshold, recipient, or action details). Do **not** create a Reflex or call `updateDefinition` on any existing Activator / Eventstream to force-fit the request, and state plainly that **no Activator / Reflex / Eventstream was created or updated**. The only exception is when the user explicitly instructs you to author against a future / not-yet-emitting source.
+
+---
+
 ## Must / Prefer / Avoid
 
 ### MUST DO
 
-- **Confirm a real source before authoring** -- when the request targets a specific signal or measurement (for example "temperature > 30"), first resolve the workspace and verify that a discoverable source (Eventhouse/KQL table, Eventstream, Real-Time Hub, or DTB / Ontology) actually exposes that signal. If none does, **stop and ask** which source and fields provide it (plus any missing threshold, recipient, or action details) instead of authoring the rule
+- **Confirm a real source before authoring** -- follow the [Source Validation Gate](#source-validation-gate): resolve the source in the requested workspace, validate the requested signal column/field, and observe at least one representative row/event/sample before authoring. Schema-only, zero-row, non-emitting, or stale evidence is **missing source data** -- **stop and ask** which source and fields provide it (plus any missing threshold, recipient, or action details), and state that no Activator/Reflex/Eventstream was created or updated, instead of authoring the rule. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming the source was observed.
 - **Always use `--resource https://api.fabric.microsoft.com`** with `az rest` — without it, token audience is wrong
 - **Always send `--body '{}'`** for `getDefinition` — it is a POST and omitting the body can cause 411 errors
 - **Always Base64-encode** `ReflexEntities.json` payload when calling `updateDefinition`
@@ -289,6 +309,7 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 - **Always use the correct template type** — `AttributeTrigger` for value-based conditions (has ScalarSelectStep + ScalarDetectStep), `EventTrigger` for event-based firing (has FieldsDefaultsStep + EventDetectStep, no ScalarDetectStep)
 - **Always use new GUIDs** for `uniqueIdentifier` when adding entities — duplicate GUIDs cause corruption
 - **Always update all cross-references** when changing a `uniqueIdentifier` — other entities reference it via `targetUniqueIdentifier`
+- **Always run the Reference Integrity Preflight before `updateDefinition`** -- every `targetUniqueIdentifier`, `entityId`, and `fabricJobConnectionDocumentId` in the payload must resolve to an entity included in the submitted `ReflexEntities.json`
 - **Handle LRO responses** — `create`, `getDefinition`, and `updateDefinition` may return 202; poll the `Location` header
 
 ### PREFER
@@ -308,7 +329,8 @@ Use `json.dumps()` to stringify. **Do NOT use PowerShell's `ConvertTo-Json`.**
 - **Pre-filtering conditions in the KQL query** — return all data from KQL and let the Activator rule steps handle thresholds, text conditions, and dimensional filters. KQL is the data source, not the rule engine
 - **Inline JSON in PowerShell `az rest --body`** — PowerShell mangles quotes and special characters. Always write JSON to a temp file with `[System.IO.File]::WriteAllText($path, $json, [System.Text.UTF8Encoding]::new($false))` and pass `--body @$path`
 - **Reusing display names after deletion** — soft-deleted items hold their name for several minutes. Use a unique name or hard-delete first
-- **Force-fitting a request onto unrelated existing items** -- when no source exposes the requested signal, do NOT create a Reflex or call `updateDefinition` on an unrelated existing Activator / Eventstream to satisfy it; ask for the missing source first
+- **Force-fitting a request onto unrelated existing items** -- when no source clears the [Source Validation Gate](#source-validation-gate) (missing, schema-only, zero-row, non-emitting, or stale), do NOT create a Reflex or call `updateDefinition` on an unrelated existing Activator / Eventstream to satisfy it; ask for the missing source first
+- **Read-only listing or inspection** -- use [activator-consumption-cli](../activator-consumption-cli/SKILL.md) for prompts like "show me all Activators", "list Activators", "show the rules", "inspect this alert", or "decode the definition". This authoring skill should only run when the user asks to create, update, delete, configure, or change something.
 
 ---
 

--- a/skills/activator-authoring-cli/references/dtb-source.md
+++ b/skills/activator-authoring-cli/references/dtb-source.md
@@ -6,7 +6,7 @@ Queries an existing **Digital Twin Builder** or **Ontology** Fabric item on a sc
 
 > **Time-axis default:** If the DTB query results include a reasonable datetime field, prefer `eventTimeSettings` plus `DURATION_START` / `DURATION_END` query parameters. Only use snapshot mode when the query returns current-state rows with no reasonable event-time field.
 
-> **Validate first:** Before creating or updating the Activator, run the DTB / Ontology query directly first and confirm the returned columns, key fields, and timestamp field are correct.
+> **Validate first:** Before creating or updating the Activator, run the DTB / Ontology query directly first and confirm the returned columns, key fields, timestamp field, requested signal field, and at least one representative row are correct. If the query returns no rows or the requested field is missing, treat the source as missing and ask for the correct source and fields rather than authoring against an empty source. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming rows were observed.
 
 ```json
 {

--- a/skills/activator-authoring-cli/references/kql-source.md
+++ b/skills/activator-authoring-cli/references/kql-source.md
@@ -6,7 +6,7 @@ Queries a KQL database (Eventhouse or ADX/Kusto cluster) on a configurable sched
 
 > **Time-axis default:** If the query results include a reasonable datetime column, always configure `eventTimeSettings` and `queryParameters` so the source runs with a time axis. Only fall back to **snapshot mode** when the underlying data has no reasonable timestamp column and each row represents the latest state.
 
-> **Validate first:** Before creating or updating the Activator, run the KQL directly against the target KQL source and confirm the returned columns, timestamp field, and row shape are correct.
+> **Validate first:** Before creating or updating the Activator, run the KQL directly against the target KQL source and confirm the returned columns, timestamp field, and row shape are correct. If the query returns **no rows** (or the table/column does not exist), treat the source as **missing** -- stop and ask for the correct source and fields rather than authoring against an empty source. If the user explicitly instructs authoring against a future / not-yet-emitting source, state that assumption and continue without claiming rows were observed.
 
 ```json
 {

--- a/skills/activator-authoring-cli/references/source-types.md
+++ b/skills/activator-authoring-cli/references/source-types.md
@@ -37,6 +37,12 @@ Every entity in `ReflexEntities.json`:
 | `payload` | object | yes | Entity-specific configuration |
 | `type` | string | yes | Entity type (see below) |
 
+## Reference Integrity Preflight
+
+Before submitting `updateDefinition`, validate the full `ReflexEntities.json` array, not just the entity you changed. Every `parentContainer.targetUniqueIdentifier`, `parentObject.targetUniqueIdentifier`, `SourceReference.entityId`, `EventReference.entityId`, and `AttributeReference.entityId` must resolve to a top-level `uniqueIdentifier` in that same submitted array. Fabric item action rules must also resolve `fabricJobConnectionDocumentId` to a `fabricItemAction-v1.uniqueIdentifier` in the same array.
+
+If Fabric returns `FailedToResolveEntity` with `DocumentType timeSeriesView not found`, one of those references points at a `timeSeriesView-v1` GUID that is absent from the payload. Re-read the definition, preserve existing entities, fix the missing reference, and retry only after the preflight passes.
+
 ---
 
 ## Container (`container-v1`)

--- a/skills/activator-consumption-cli/SKILL.md
+++ b/skills/activator-consumption-cli/SKILL.md
@@ -12,7 +12,7 @@ description: >
   **Invoke this skill before answering questions** about an Activator/Reflex item
   in a Fabric workspace — the listing, lookup, and decoding workflows are part of
   this skill, not preamble to it.
-  Triggers: "show my alerts", "what alerts do I have", "inspect this alert",
+  Triggers: "show my alerts", "what alerts do I have", "show me all activators", "inspect this alert",
   "show me the rule", "show me the action", "show me the source",
   "get reflex definition", "list activators", "list alerts",
   "list reflex items", "show activator items", "activator details",

--- a/skills/azmon-mirroredcatalogs-operations-cli/SKILL.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/SKILL.md
@@ -1,0 +1,876 @@
+---
+name: azmon-mirroredcatalogs-operations-cli
+description: "Onboard Log Analytics, Application Insights, and Azure Monitor telemetry into Microsoft Fabric as a Mirrored Catalog, then turn it into business-impact insights by correlating telemetry with business data via Eventhouse shortcuts, verified schemas, and ready-to-use Operations Agent instructions. Triggers: onboard Log Analytics telemetry, connect Application Insights to a Mirrored Catalog, correlate App Insights telemetry with business data, build an Operations Agent for business-impact alerting, determine if availability or latency impacted bookings orders or revenue."
+---
+
+> **Update Check — ONCE PER SESSION (mandatory)**
+> The first time this skill is used in a session, run the **check-updates** skill before proceeding.
+> - **GitHub Copilot CLI / VS Code**: invoke the `check-updates` skill.
+> - **Claude Code / Cowork / Cursor / Windsurf / Codex**: compare local vs remote package.json version.
+> - Skip if the check was already performed earlier in this session.
+
+# azmon-mirroredcatalogs-operations-cli
+
+Guide a user end-to-end to (1) onboard Azure Monitor / Application Insights /
+Log Analytics observability data into Microsoft Fabric as a Mirrored Catalog
+(AzMon) item, and (2) turn that telemetry into **business-impact insights** by
+correlating observability signals with business data (bookings, orders,
+customers, flights, payments, revenue, tenants, accounts, subscriptions, usage
+KPIs, SLA/availability KPIs), ending in ready-to-paste **Operations Agent**
+instructions.
+
+This is a **self-contained Skills-for-Fabric package**. It does **not** depend on
+any MCP server or tool controller as the execution mechanism. Product/API
+knowledge, supported flows, guardrails, and modeling rules live in this file and
+in `references/*.md`.
+
+## Prerequisite Knowledge
+
+Before running this skill, read the shared common guidance:
+
+- [Authentication & token acquisition](../../common/COMMON-CORE.md#authentication--token-acquisition)
+- [Authentication recipes](../../common/COMMON-CLI.md#authentication-recipes)
+
+## Trigger phrases
+
+- onboard Azure Monitor data into Fabric
+- create Azure Monitor item in Fabric
+- connect Application Insights to Fabric
+- correlate App Insights telemetry with business data
+- onboard my LA workspace to Fabric
+- onboard Log Analytics workspace to Fabric
+- connect Log Analytics workspace to Fabric
+- understand if service availability impacted bookings
+- understand if latency impacted conversion
+- correlate exceptions with revenue or orders
+- build Operations Agent for Azure Monitor business impact
+- create business impact insights from Log Analytics data
+
+## When to use this skill (and related skills)
+
+`azmon-mirroredcatalogs-operations-cli` is for onboarding Azure Monitor /
+Application Insights / Log Analytics telemetry into Microsoft Fabric
+(mirroredCatalogs endpoint), correlating that telemetry with business data, and
+generating Operations Agent instructions. For general Eventhouse / KQL querying
+unrelated to Azure Monitor onboarding, use `eventhouse-consumption-cli`; for
+authoring Eventhouse items and databases, use `eventhouse-authoring-cli`.
+
+## Reference index
+
+Read these when the corresponding stage needs product/API detail. Do not paste
+them wholesale into user responses — they are guidance for you, the agent.
+
+| Reference | Use it for |
+|-----------|-----------|
+| [references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md) | Supported vs UI-only flows; connector modes; Fabric item/agent surfaces |
+| [references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md) | Mirrored Catalog item CRUD, definition, discovery, monitoring, refresh |
+| [references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md) | Eventhouse/KQL, OneLake shortcuts, queryability requirement |
+| [references/operations-agent-reference.md](references/operations-agent-reference.md) | Operations Agent instruction template, validation, troubleshooting |
+| [references/app-insights-table-reference.md](references/app-insights-table-reference.md) | App Insights / Azure Monitor telemetry tables and business meaning |
+| [references/app-insights-dynamic-fields-reference.md](references/app-insights-dynamic-fields-reference.md) | Dynamic fields (Properties/CustomDimensions) and hidden business keys |
+| [references/business-correlation-patterns.md](references/business-correlation-patterns.md) | Signal → business-impact patterns and candidate keys |
+| [references/business-insight-modeling-reference.md](references/business-insight-modeling-reference.md) | Bins, derived entities, direct join vs time-window, thresholds |
+
+## Secrecy & scope guardrails
+
+- Do NOT expose Azure Log Analytics backend APIs to the user.
+- Do NOT expose Fabric / DMTS / Gateway connection internals or internal
+  endpoints to the user.
+- Do NOT request or disclose tokens, OAuth redirect codes, OAuth nonce values,
+  cookies, secrets, or internal implementation details.
+- Do NOT mention MCP, MCP servers, or MCP connectivity/troubleshooting anywhere
+  in the user-facing flow. This Skill is self-contained.
+- Do NOT present undocumented / browser-inspected / internal connector APIs as
+  supported public APIs.
+- Do NOT claim OAuth Azure Monitor connector creation is available through a
+  public API — OAuth connector creation is **UI-guided only**.
+- Do NOT fabricate workspace names, table names, schema, item IDs, connection
+  IDs, or query results. Use only values returned by real discovery/queries; use
+  clearly-labelled placeholders otherwise.
+- Do NOT ask the user for JOIN logic, KQL, bins, or thresholds upfront.
+- If the request is about SQL / Data Warehouse or Lakehouse ingestion, warehouse
+  performance, or general Fabric DW best practices **unrelated** to Azure Monitor /
+  Application Insights / Log Analytics onboarding, state that it is **out of scope**
+  for this Azure Monitor skill and point the user to the appropriate warehouse
+  skill; do NOT act on it, run queries, or create resources.
+
+### Domain-agnostic rule
+
+Business entities named anywhere in this Skill or its references — bookings,
+orders, customers, flights, revenue, tenants, payments, and similar — are
+**EXAMPLES ONLY** (non-normative illustrations). The Skill is **domain-agnostic**
+and MUST NOT infer or assume the user's business domain from these examples, from
+table/column names that resemble an example, or from any prior context. The
+user's actual business entities MUST be discovered from real Fabric data
+(Eventhouse / KQL database / Warehouse / Lakehouse / shortcuts) and confirmed with
+the user before use. Until discovered and confirmed, refer to them generically —
+as *business entities*, *business datasets*, *business KPIs*, or *business
+outcomes*.
+
+## EXECUTION CAPABILITY POLICY
+
+The Skill is a guided staged workflow; actual execution depends on capabilities
+available in the current environment. Portal-guided instructions are allowed ONLY
+for OAuth Azure Monitor connector creation — the Skill MUST NOT switch the entire
+onboarding flow to portal guidance as a generic fallback. For all non-OAuth
+stages, the Skill MUST first discover whether a supported execution path exists.
+
+Supported execution paths may include:
+
+- Fabric REST APIs
+- Azure REST APIs
+- Fabric Actions
+- Azure CLI
+- Azure Resource Graph
+- Fabric REST **read-only** discovery via authenticated `az rest --method get`
+  against `https://api.fabric.microsoft.com/...` (discovery/read-only only)
+- Other documented supported capabilities available to the agent
+
+**Log Analytics REST API reference (agent-facing).** When the Skill needs to perform or validate Azure Log Analytics operations, it may consult the official [Log Analytics REST APIs](https://learn.microsoft.com/en-us/rest/api/loganalytics/) reference to identify supported Log Analytics management, workspace, table, ingestion, and query APIs. This is agent-facing guidance only and does not relax the secrecy rule above.
+
+These execution paths are distinct and MUST NOT be conflated:
+
+1. **Kusto / KQL data-plane execution** — telemetry queries; optional, and MUST
+   NOT be used when disabled.
+2. **Azure ARM control-plane discovery** — resource/metadata enumeration.
+3. **Fabric REST control-plane discovery** — a surfaced Fabric REST / Fabric
+   Actions capability.
+4. **Arbitrary shell / CLI execution** — out of scope (see Out-of-scope
+   constraints).
+5. **Fabric REST read-only discovery via authenticated `az rest --method get`** —
+   a narrow GET-only exception for Fabric discovery/read against
+   `https://api.fabric.microsoft.com/...`; never mutates anything and never
+   exposes tokens, secrets, or auth headers. NOT general shell/CLI access.
+
+MCP unavailability alone does NOT mean execution capability is unavailable.
+Unavailability of any single execution path does NOT imply the capability is
+unavailable. Before declaring a capability unavailable, the Skill MUST evaluate
+ALL supported execution paths listed above and confirm none is available.
+
+If no supported execution path exists, the Skill MUST: stop; identify the missing
+capability; explain why it is required; identify which stage is blocked; and wait
+for user confirmation.
+
+The Skill MUST NOT replace validation, Mirrored Catalog creation, discovery,
+monitoring, refresh, shortcut creation, schema verification, or Operations Agent
+creation with portal guidance, and MUST NOT claim an action completed when
+execution capability is unavailable.
+
+
+## PORTAL GUIDANCE POLICY
+
+Prefer automated execution paths (Fabric REST, Azure REST, Fabric Actions, Azure
+CLI, other supported automation) over UI-guided instructions. Before providing
+UI-guided instructions the Skill MUST: (1) evaluate the available execution paths,
+(2) attempt supported ones where available, (3) explain which were evaluated and
+why they cannot be used. OAuth Azure Monitor connector creation is the one
+explicitly supported UI-guided scenario and is exempt from this evaluation.
+
+
+## STRICT STAGED WORKFLOW CONTROLLER (ENFORCED)
+
+The Skill MUST operate as a strict staged workflow controller.
+
+### Stages
+
+1. Intent and scope
+2. Log Analytics workspace selection
+3. Fabric workspace selection
+4. Validation
+5. Connection resolution
+6. AzMon / Mirrored Catalog item creation or reuse
+7. **Business Insight Capture** (immediately after item creation/reuse)
+8. Azure Monitor table discovery
+9. Eventhouse / KQL database selection
+10. Shortcut planning
+11. Shortcut creation
+12. Schema and data verification
+13. Business data discovery and scoring
+14. Correlation planning
+15. Operations Agent instruction generation
+16. Optional Operations Agent creation / validation
+
+### Execution rules
+
+- The Skill MUST track and enforce the current stage.
+- The Skill MUST NOT skip stages.
+- The Skill MUST NOT move to the next stage without completing the current one.
+
+### Stage visibility (REQUIRED in every user-facing response)
+
+Begin every response with exactly this structure:
+
+```text
+Current stage: <stage name>
+What I found:
+<short summary>
+
+Next step:
+<one clear action>
+
+Waiting for your confirmation to continue.
+```
+
+If the current stage is unclear → **STOP** and ask the user where to resume.
+
+**Stage 15 exemption (ready-to-paste block).** The Stage 15 Operations Agent
+instructions are delivered as ONE self-contained, ready-to-paste fenced block.
+For that response only, place the stage-visibility header and the
+`Waiting for your confirmation to continue.` line OUTSIDE and AROUND the fenced
+block — the header (and a one-line summary) immediately before it, the
+confirmation line immediately after it. Do NOT insert the header, summary,
+`What I found` / `Next step` labels, or the confirmation line INSIDE the
+ready-to-paste block: the fenced block must contain only the Operations Agent
+instructions so the user can copy it verbatim.
+
+### Hard stop behavior
+
+After presenting any step that requires confirmation:
+
+- **STOP.**
+- **WAIT** for explicit user confirmation.
+- Do **not** continue automatically.
+
+### Confirmation gates (explicit confirmation REQUIRED before)
+
+- Creating or reusing any resource that modifies Fabric.
+- Selecting an Eventhouse / KQL database.
+- Creating shortcuts.
+- Proceeding from schema verification (Stage 12) to correlation planning
+  (Stage 14).
+- Generating final Operations Agent instructions if the correlation model has
+  not been confirmed.
+- Creating or modifying an Operations Agent.
+
+### Stage guardrails
+
+- Shortcut planning (Stage 10) MUST occur before schema verification or join
+  logic. If schema/join is attempted early → STOP and return to shortcut
+  planning.
+- Shortcut creation (Stage 11) MUST complete before schema verification.
+- Schema verification (Stage 12) MUST complete before correlation planning
+  (Stage 14).
+- If data is not queryable in Eventhouse via shortcuts → STOP → return to
+  shortcut planning / creation.
+- Correlation planning MUST NOT begin until data queryability via shortcuts is
+  confirmed.
+- Business Insight Capture (Stage 7) MUST be satisfied (intent provided OR a
+  suggested direction explicitly selected) before correlation planning. Never
+  assume intent.
+
+### Out-of-scope constraints
+
+The Skill MUST NOT run arbitrary shell/CLI/az/PowerShell commands, perform network
+debugging, investigate server connectivity, or execute infrastructure
+troubleshooting. These are out of scope unless explicitly part of the current
+stage.
+
+**Narrow exception — Fabric REST read-only discovery.** The Skill MAY use an
+authenticated `az rest --method get` call ONLY for Fabric REST read-only
+discovery, and ONLY when ALL hold: endpoint is
+`https://api.fabric.microsoft.com/...`; method is **GET** only; the operation is
+discovery/read-only; nothing is created, updated, deleted, or modified; no tokens,
+secrets, auth headers, or sensitive payloads are exposed; and the Skill states the
+capability path used. This exception does NOT permit arbitrary shell/CLI
+execution, non-GET `az rest` calls, or use of the Kusto / KQL data-plane when
+disabled.
+
+### Response style (ENFORCED)
+
+Behave like a **guided product experience**, not a backend debugger.
+
+- Use concise, business-friendly language.
+- Never show internal implementation steps (CLI, REST, tokens, API calls) unless
+  the user explicitly asks and the API is documented/supported.
+- Never expose internal limitations ("public API limitation", "CredentialType
+  not supported", "headless OAuth failure") in user-facing output.
+- Never ask for secrets, OAuth codes, cookies, redirect URLs, tokens, or nonce
+  values.
+- Summarize findings. Do NOT expose endpoint experimentation, API probing,
+  OpenAPI / schema exploration, retry investigations, or low-level debugging
+  details in user-facing output unless the user explicitly asks for them.
+- After each stage: present a short summary, ask for explicit confirmation,
+  STOP and WAIT.
+
+---
+
+## Stage 1 — Intent and scope
+
+Confirm what the user wants: onboard observability data into Fabric, explore a
+business insight, or both. Capture (in plain language) any workspace names or
+business outcome they already mention — but do not yet drive correlation.
+
+## Stage 2 — Log Analytics workspace selection
+
+Application Insights telemetry is queried through its backing Log Analytics
+workspace (workspace-based Application Insights). Help the user pick the correct
+Log Analytics / Application Insights-backed workspace.
+
+- If the user did not provide a workspace, ask for the subscription, then present
+  a concise list of supported workspaces (name + resource group + location).
+  Never expose raw API responses.
+- Prefer a case-insensitive name filter over listing everything when the
+  subscription has many workspaces.
+
+### Exact-name-not-found fallback (REQUIRED)
+
+When the user names a workspace and no **exact** match exists, the Skill MUST NOT
+fail. Instead:
+
+1. Ask for the subscription if not provided (do not guess).
+2. Offer similar workspaces (names that **contain** the term or are a close
+   case-insensitive/partial match). Broaden the search if a narrow filter returns
+   nothing.
+3. Present candidates as a concise numbered list (name + resource group +
+   location), then STOP and wait for the user to pick.
+4. If exactly one similar workspace is found, still confirm before proceeding.
+5. If none is found, say so plainly and ask for a different subscription or term.
+
+Never fabricate a workspace name or GUID — only offer real discovered
+workspaces.
+
+## Stage 3 — Fabric workspace selection
+
+Help the user choose the target Fabric workspace (display name + id). Use a
+case-insensitive substring filter when helpful. Read-only; nothing is created
+here. Never expose raw API responses or tokens.
+
+### Fabric Workspace Discovery & Capability Resolution Policy (REQUIRED)
+
+Fabric workspaces are **not** ARM resources, so missing automatic enumeration does
+NOT mean no workspace exists. Follow the full required policy in
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md#fabric-workspace-discovery--capability-resolution):
+discover all surfaced Fabric mechanisms first (Fabric REST/Actions, OneLake/Power
+BI, and read-only `az rest --method get` against `https://api.fabric.microsoft.com/...`);
+never terminate on missing enumeration; ask the user for a workspace Name / ID /
+URL; validate before continuing; and mark Stage 3 BLOCKED only after ALL discovery
+AND user-supplied paths are exhausted. UI-guided selection is the final fallback only.
+
+## Stage 4 — Validation
+
+Before any creation, verify:
+
+- The workspace exists.
+- The workspace is **not Sentinel** or otherwise unsupported.
+- The caller has the required Log Analytics access.
+- The caller has sufficient Fabric workspace permission to create the item.
+
+If validation fails, summarize which checks passed/failed in user terms, explain
+the missing capability, and offer to try another workspace or request access.
+See `references/azmon-fabric-api-reference.md` for supported-scope rules.
+
+### Sentinel detection source hierarchy (REQUIRED)
+
+Sentinel detection is a **control-plane** check and MUST NOT be treated as
+dependent on Kusto / KQL data-plane availability. Follow the full required
+hierarchy in
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md#sentinel-detection-source-hierarchy):
+enumerate ARM resources / `Microsoft.OperationsManagement/solutions`
+`SecurityInsights(<workspaceName>)` / `Microsoft.SecurityInsights/*` /
+feature metadata, then classify as **Sentinel / blocked**, **Not Sentinel
+(control-plane verified)**, or — only if all checks are unavailable —
+**not verifiable**. Never fabricate Sentinel status.
+
+### Validation capability discovery (REQUIRED)
+
+Apply the [EXECUTION CAPABILITY POLICY](#execution-capability-policy): evaluate ALL
+supported execution paths (Fabric REST, Azure REST, Fabric Actions, Azure CLI,
+Azure Resource Graph) before declaring validation capability unavailable. MCP is
+only one possible path.
+
+## Stage 5 — Connection resolution
+
+Two connection modes are supported. Keep them **separate**. Never route OAuth
+through Service Principal logic, and never route Service Principal through OAuth /
+interactive sign-in logic. See
+[references/azmon-fabric-api-reference.md](references/azmon-fabric-api-reference.md)
+for the authoritative connector rules.
+
+### Portal guidance boundary
+
+Portal-guided instructions are permitted ONLY for OAuth Azure Monitor connector creation.
+
+Portal guidance is NOT an allowed fallback for:
+
+- LAW validation
+- Fabric workspace validation
+- Connection detection
+- Connection reuse
+- Service Principal connector creation
+- Mirrored Catalog item creation
+- Discovery
+- Monitoring
+- Refresh
+- Eventhouse shortcut creation
+- Schema verification
+- Operations Agent creation
+
+If execution capability for these actions is unavailable, the Skill MUST stop and identify the missing capability.
+
+### Mode A — OAuth (UI-guided only)
+
+- OAuth connector **creation** is interactive, done once in **Fabric → Manage
+  Connections**. The Skill does **not** create OAuth connectors through any API.
+- The Skill **detects and reuses** an existing Azure Monitor OAuth connection for
+  this workspace (read-only, non-destructive).
+- Before classifying OAuth connection detection as "not verifiable", attempt the
+  available Fabric REST **read-only** connection discovery paths, in order:
+  1. A surfaced Fabric REST / Fabric Actions capability, if available.
+  2. Authenticated Fabric REST read-only discovery via `az rest --method get`
+     against `https://api.fabric.microsoft.com/...`, if Azure CLI execution is
+     available and permitted under the read-only Fabric REST discovery exception
+     (GET-only, no modifications, no secret/token/header exposure, capability
+     path stated). This detection is read-only; OAuth connector **creation**
+     remains UI-guided only.
+- Reuse a connection ONLY if it belongs to the **same** Log Analytics workspace
+  (exact data-source-path / LAW resource-id match). Any mismatch → treat as "no
+  matching connection".
+- If exactly one match → reuse automatically and continue.
+- If multiple matches → show display names and ask the user to choose (never
+  auto-pick).
+- If no match → guide the user with this exact, simple message and then WAIT:
+
+```text
+I couldn’t find an existing Azure Monitor connection for this workspace.
+Please create it once in Fabric Manage Connections, then come back and continue.
+
+1. Open Fabric.
+2. Go to Manage Connections.
+3. Select New connection → Azure Monitor.
+4. Sign in with your organizational account.
+5. Use the same Log Analytics Workspace.
+6. When done, come back here and type: Done.
+```
+
+When the user resumes, re-detect and continue automatically ("Connection
+detected. Continuing setup.").
+
+### Mode B — Service Principal (automated create-or-reuse)
+
+Present this as **"connect using Service Principal"** — the automated,
+non-interactive path (no user login, no UI step).
+
+- **Idempotent create-or-reuse**: if a matching Azure Monitor Service Principal
+  connector already exists for the same Log Analytics workspace (same data source
+  path + Service Principal credential type), reuse it — never create a duplicate.
+- Only **one** connector is created per run.
+- **Never** reuse a non-Service-Principal (e.g. OAuth) connector in this mode.
+- **Never** ask the user to paste a client secret into chat. Secrets come from
+  **environment variables or Key Vault references** only, are never echoed,
+  logged, exposed, or included in generated instructions.
+- If required Service Principal inputs are missing, describe **what** is missing
+  (tenant id, app/client id, and a securely-provided secret reference) using
+  presence checks only — never request the secret value in chat.
+
+Automation boundary: infrastructure (connector create-or-reuse, mirrored item
+creation) is automated; **business decisions** (Eventhouse/KQL DB selection,
+shortcut creation) always require explicit user confirmation.
+
+## Stage 6 — AzMon / Mirrored Catalog item creation or reuse
+
+Create the Azure Monitor **Mirrored Catalog** item in the target Fabric
+workspace, or reuse an existing matching item. This is a Fabric-modifying action
+→ confirm first. Supported Mirrored Catalog operations (item CRUD, definition,
+discovery, monitoring, refresh) are documented in
+[references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md).
+
+After the item is created or reused, immediately proceed to Business Insight
+Capture (Stage 7).
+
+## Stage 7 — Business Insight Capture (MANDATORY, happens here — early)
+
+Immediately after the AzMon item is created or reused, ask the user **what
+business insight they want to explore**, so discovery and table selection are
+guided by the business outcome.
+
+Ask in business language, e.g.:
+
+- Did service availability issues impact bookings?
+- Did request latency reduce customer conversions?
+- Did exceptions affect revenue or orders?
+- Did dependency failures impact specific customers, tenants, regions, or
+  flights?
+- Did incidents affect SLA, usage, or customer activity?
+- Did traffic drops correlate with usage KPI degradation?
+
+### Enforcement
+
+The Skill MUST NOT proceed to business correlation without either:
+
+- (a) user-provided business intent, OR
+- (b) explicit user selection from suggested directions.
+
+Never assume intent.
+
+### Fallback (when the user is unsure / vague / no exact match)
+
+Suggest 3–5 directions, each framed as **observability signal → business
+impact**, and ask the user to choose one:
+
+1. Availability failures → booking completion impact.
+2. Request latency → conversion or checkout drop.
+3. Exceptions → failed orders or revenue at risk.
+4. Dependency failures → customer / tenant / region impact.
+5. Traffic drops → usage KPI degradation.
+
+### Important distinction
+
+Capturing intent early is allowed and required. But the Skill MUST NOT generate
+correlation logic yet. Correlation logic only comes after shortcuts exist, schema
+is verified, data is queryable, dynamic fields are inspected, join candidates are
+validated, and data freshness is checked (Stages 10–14).
+
+## Stage 8 — Azure Monitor table discovery
+
+Browse candidate Azure Monitor / Application Insights tables relevant to the
+captured business goal. Use only real discovered scope/table values — never
+fabricate table names. Use
+[references/app-insights-table-reference.md](references/app-insights-table-reference.md)
+to explain what each table means in business terms and which tables best fit the
+stated goal.
+
+### Discovery API fallback policy (REQUIRED)
+
+The **primary** discovery mechanism is the Mirrored Catalog Discovery APIs. If
+discovery appears incomplete, do NOT immediately conclude tables are missing or
+switch to alternative metadata paths. First:
+
+1. Verify mirror status.
+2. Verify refresh / sync status.
+3. Verify discovery scope.
+4. Retry discovery.
+
+Only after these checks may the Skill evaluate alternative metadata paths. See
+[references/mirrored-catalog-reference.md](references/mirrored-catalog-reference.md).
+
+## Stage 9 — Eventhouse / KQL database selection
+
+Before asking the user to choose an Eventhouse, run **Eventhouse Recommendation
+Mode**:
+
+1. **Discover** available Eventhouses.
+2. **Inspect** their available contents (tables, shortcuts, KQL databases).
+3. **Score** each Eventhouse.
+4. **Present** a recommendation.
+
+Score each Eventhouse by:
+
+- Relevant business tables
+- Relevant telemetry tables
+- Existing shortcuts
+- Queryable tables
+- KQL database availability
+- Data freshness
+- Alignment to the selected business goal
+
+Present the result in this format:
+
+```text
+Recommended Eventhouse:
+<EventHouseName>
+
+Reason:
+<why this Eventhouse was chosen>
+
+Alternative Eventhouses:
+<list>
+```
+
+The Skill MUST NOT auto-select, even when one Eventhouse scores highest. This is a
+user decision (confirmation gate) — present the recommendation and **require
+explicit confirmation** before proceeding. See
+[references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md).
+
+## Stage 10 — Shortcut planning
+
+Plan OneLake shortcuts from the AzMon item's tables into the selected
+Eventhouse / KQL database **before** any schema verification or join logic.
+Present the plan and STOP for confirmation.
+
+Key rules (see the shortcuts reference for detail):
+
+- Keep source table names **exact** — a renamed shortcut may create the OneLake
+  link but fail to register as a queryable KQL table.
+- A OneLake link alone is **not** enough — the table must be registered as an
+  external/queryable table.
+
+### Shortcut acceleration (SHOULD)
+
+Query acceleration on shortcuts SHOULD be treated as the preferred configuration
+because testing showed schema verification, queryability validation, telemetry
+sampling, correlation analysis, and Operations Agent preparation became
+substantially faster when acceleration was enabled. Present the shortcut plan with
+an acceleration column:
+
+| Shortcut Name | Source | Target | Acceleration Supported (Yes/No) | Acceleration Enabled (Yes/No) |
+|---------------|--------|--------|---------------------------------|-------------------------------|
+
+If acceleration is disabled, explain the potential impact on: queryability
+validation, schema verification, telemetry sampling, correlation analysis, and
+Operations Agent preparation. Do NOT assume acceleration exists in every
+environment — use SHOULD, not MUST. See
+[references/eventhouse-shortcuts-reference.md](references/eventhouse-shortcuts-reference.md).
+
+## Stage 11 — Shortcut creation
+
+Only after explicit confirmation, create the planned shortcuts. Then verify each
+table is actually **queryable** in Eventhouse (e.g. `<Table> | take 1`). Do not
+assume a OneLake link means the table is queryable. If a table is not queryable →
+STOP and return to shortcut planning / creation.
+
+When creating ANY shortcut, apply the **Shortcut Acceleration Policy**:
+
+1. Determine whether acceleration is supported for the shortcut.
+2. Determine its current acceleration status.
+3. Enable acceleration when supported and appropriate (preferred configuration).
+4. Report the acceleration status back to the user.
+
+## Stage 12 — Schema and data verification (REQUIRED before correlation)
+
+Never build correlation logic on assumptions or screenshots. Before proposing any
+join, bin, or threshold, verify against the **actual** KQL database.
+
+### Preconditions
+
+1. Operational telemetry tables are available in the Eventhouse / KQL database.
+2. Business tables are available in the same database or queryable via shortcuts.
+3. Tables are **queryable**, not just visible in OneLake.
+4. Schema retrieved via `getschema`.
+5. Dynamic fields inspected and sampled.
+6. Candidate join keys extracted from top-level **and** dynamic columns.
+7. Join keys validated with **non-zero** match results (when a direct join is
+   proposed).
+8. Data freshness verified.
+9. Time window aligned to the real data range.
+10. Relevant categorical values confirmed from real data where rules depend on
+    them.
+
+### Steps
+
+1. **Retrieve real schema.** For each table:
+   `TableName | getschema | project ColumnName, ColumnType`. Use authoritative
+   column names/types — not names guessed from screenshots or table names.
+2. **Inspect and sample dynamic fields.** Business join keys are often nested in
+   dynamic columns (`Properties`, `CustomDimensions`, `Details`, `Measurements`,
+   `Payload`, `Context`). Sample rows and inspect keys. See
+   [references/app-insights-dynamic-fields-reference.md](references/app-insights-dynamic-fields-reference.md).
+3. **Extract candidate business identifiers** with explicit KQL
+   (`tostring(Properties.BookingId)`, with casing fallbacks via `coalesce`).
+4. **Validate join keys against real data.** Prove a candidate joins — run the
+   join and confirm non-zero matches:
+
+   ```kusto
+   AppEvents
+   | extend BookingId = tostring(Properties.BookingId)
+   | where isnotempty(BookingId)
+   | join kind=inner (Bookings | project BookingId = tostring(BookingId)) on BookingId
+   | summarize MatchedRows=count(), DistinctBookings=dcount(BookingId)
+   ```
+
+   Non-zero → **direct join, high confidence**. Zero → the key is wrong or data
+   doesn't overlap; find the real one.
+5. **Check freshness and align the window.**
+   `TableName | summarize Rows=count(), MinTime=min(TimeGenerated), MaxTime=max(TimeGenerated)`.
+   Do not assume `ago(1h)`; use a window covering the actual data range and
+   explain it in user terms.
+6. **Confirm categorical values** used by rules
+   (`Table | summarize count() by <field>`) so impact rules use real categories.
+
+### Telemetry source selection framework (REQUIRED)
+
+Telemetry source selection MUST be **data-driven**. Before selecting a correlation
+model, the Skill MUST inspect ALL candidate telemetry sources discovered (e.g.
+AppEvents, AppExceptions, AppRequests, AppDependencies, AppTraces, AppPageViews,
+AppBrowserTimings, AvailabilityResults, and any other telemetry source present) —
+not just one.
+
+Score each candidate telemetry source by:
+
+1. Business identifiers discovered.
+2. Dynamic-field richness.
+3. Direct-join confidence.
+4. Validated match count.
+5. Business-process context.
+6. Relevance to the selected business goal.
+
+Select the highest-scoring telemetry source. The Skill MUST NOT automatically
+prioritize AppExceptions, and MUST NOT automatically prioritize AppEvents — the
+winner is whichever source scores highest against real data.
+
+### Exit criteria (MANDATORY)
+
+Before Stage 14, ALL must hold: schema retrieved via `getschema`; join keys
+validated with non-zero matches (when a direct join is used); freshness verified
+and window aligned; relevant categorical values confirmed. If any fails → STOP,
+do not proceed.
+
+### Handoff (MANDATORY)
+
+Present a concise summary (verified join keys, match results, business impact if
+any, data time window). Then ask: "Do you want to generate Operations Agent
+instructions based on this verified model?" HARD STOP and wait.
+
+## Stage 13 — Business data discovery and scoring
+
+Business tables are **not** expected to exist in Log Analytics. They may live in
+an Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts.
+Absence of business tables in Log Analytics MUST NOT be interpreted as absence of
+business data — discover them across the available Fabric data surfaces.
+
+If the exact business table or join is not known, do **not** fail. Score
+candidate business databases/tables by likely relevance to the stated goal,
+present a ranked list with explanation, propose shortcut creation for the top
+candidates, and ask the user to choose. Never conclude "no correlation is
+possible" without presenting options. Scoring hints are in
+[references/business-correlation-patterns.md](references/business-correlation-patterns.md).
+
+## Stage 14 — Correlation planning
+
+The user should not need to know joins, KQL, thresholds, or bins. Infer
+candidates from verified top-level schema, verified dynamic fields, sampled
+values, business table schema, actual join test results, and data freshness. When
+asking for confirmation, ask about **business meaning**, not SQL/KQL, e.g.:
+
+> "I found `BookingId` inside `AppEvents.Properties` and it matches
+> `Bookings.BookingId`. Should I treat this as the booking identifier for
+> business impact?"
+
+Present a correlation plan (see
+[references/business-insight-modeling-reference.md](references/business-insight-modeling-reference.md))
+including: operational signal; business impact table; verified join keys;
+whether the join came from top-level columns or dynamic fields; match
+count/validation result; time window + freshness status; proposed bin size;
+metrics and thresholds. Then ask for confirmation and STOP.
+
+Default modeling guidance: prefer **direct joins** when verified identifiers
+exist; use **time-window correlation** only when no direct identifier is found
+(and state clearly it shows correlation, not causality); default bin size **5
+minutes** (larger when data is sparse or KPIs are slower); default derived entity
+**IncidentBin**.
+
+### Correlation planning validation (REQUIRED)
+
+When finalizing the correlation model, the Skill MUST explain **why** the selected
+telemetry source was chosen, justified using real data. Include:
+
+- Match counts.
+- Business identifiers discovered.
+- Direct-join confidence.
+- Validation results.
+
+## Stage 15 — Operations Agent instruction generation
+
+Only after the correlation model is confirmed. Produce a single clean copy/paste
+block using the template in
+[references/operations-agent-reference.md](references/operations-agent-reference.md).
+
+> **Wrapper exemption:** deliver the instructions as ONE self-contained fenced
+> block. Put the stage-visibility header and the
+> `Waiting for your confirmation to continue.` line OUTSIDE the block (before and
+> after it) — never inside — so the copy/paste block stays clean. See
+> [Stage visibility](#stage-visibility-required-in-every-user-facing-response).
+
+The instructions MUST include **explicit KQL**, not conceptual descriptions:
+
+- One verbatim **IncidentBin materialization query** whose **output columns are
+  exactly the alert fields** (includes the `tostring(Properties.x)` extraction,
+  the explicit `join`, and the exact aggregations).
+- A per-field KQL definition list mapping each output column to a one-line
+  expression.
+- Alert rules that reference **actual output columns**.
+
+Include **both** threshold sets:
+
+- **Production-like:** e.g. ErrorCount increases by more than 20% versus the
+  previous-hour baseline; AffectedCustomers ≥ configured business threshold;
+  RevenueAtRisk ≥ configured business threshold.
+- **Relaxed POC / debug:** e.g. `ErrorCount >= 1`; `ErrorCount >= 5 and
+  AffectedBusinessRecords >= 1`; `AffectedCustomers >= 1`.
+
+Required sections: Goal, Data sources, Field mapping definitions, Dynamic field
+extraction logic, Derived analysis entity, IncidentBin materialization query,
+Metric definitions, Correlation logic, Impact logic (production + POC), Alert
+behavior, Output requirements, Validation / POC mode.
+
+### PLAYBOOK MATERIALIZATION REQUIREMENT (MANDATORY)
+
+Testing demonstrated that instructions and KQL **text alone are NOT sufficient**
+for playbook generation — the Fabric Playbook Generator must be able to discover
+the alert fields directly from a real schema object. Before generating Operations
+Agent rules, the Skill MUST:
+
+1. **Materialize IncidentBins** as a real, queryable schema object (a physical
+   table or a function-backed table in the KQL database).
+2. **Expose the alert fields as physical output columns** on that object.
+3. **Verify the schema exists** (e.g. `IncidentBins | getschema`).
+
+Required output columns:
+
+- IncidentBin
+- ErrorCount
+- AffectedCustomers
+- AffectedBookings
+- RevenueAtRisk
+- TopImpactedEntities
+- TopImpactedSteps
+
+The Playbook Generator MUST be able to discover these fields directly from the
+materialized schema. KQL instructions alone are NOT sufficient. Business-specific
+column names (for example `AffectedBookings`, `TopImpactedFlights`) adapt to the
+business entities actually discovered in the data.
+
+## Stage 16 — Optional Operations Agent creation / validation
+
+Offer to create the Operations Agent in the user's Fabric workspace and attach the
+Eventhouse / KQL database that holds the verified data. Confirm target workspace
+and KQL database before creating anything. Then guide validation (start with POC
+thresholds so an alert fires on sparse seed data, then switch to production
+thresholds). See
+[references/operations-agent-reference.md](references/operations-agent-reference.md)
+for creation surface and troubleshooting.
+
+## Troubleshooting (user-facing)
+
+- **"No playbook generated" / cannot compute a field** → the instructions
+  described fields conceptually. Add the explicit KQL materialization query, add
+  per-field KQL definitions, ensure alert rules reference actual output columns,
+  add dynamic-field extraction, and clarify join keys/identifiers. Do not just
+  reword prose.
+- **Start succeeds but no Teams alert arrives** → likely no data matched the
+  rule. Switch to POC/debug thresholds; explain no data may have matched. Do not
+  imply platform failure without evidence.
+
+## Must / Prefer / Avoid
+
+### Must
+- Enforce stages, hard stops, and confirmation gates.
+- Keep OAuth (UI-guided) and Service Principal (automated create-or-reuse)
+  strictly separate.
+- Validate Sentinel and permissions before creation.
+- Verify schema, dynamic fields, join matches, and freshness before correlation.
+- Provide explicit KQL in Operations Agent instructions.
+
+### Prefer
+- Direct joins over time-window correlation.
+- Real discovered values over anything guessed.
+- Business-language confirmation over technical questions.
+
+### Avoid
+- Do not depend on or mention MCP in the user-facing flow.
+- Do not present internal/undocumented APIs as supported.
+- Do not claim OAuth connector creation via public API.
+- Do not fabricate workspaces, tables, schema, IDs, or query results.
+- Do not ask for secrets, OAuth codes, tokens, cookies, or nonces.
+- Do not claim causality when only time-window correlation exists.
+
+## Examples
+
+### Example 1 — Onboard Azure Monitor observability data, then check business impact
+**User:** "In my `Observability` workspace, onboard our Azure Monitor / Log Analytics observability data (it holds our Application Insights tables) into Fabric, then tell me whether last week's latency spike hurt checkout conversions."
+
+**Skill behavior:** Runs the staged workflow — confirms the target workspace and checks onboarding prerequisites (a reachable Azure Monitor / Log Analytics source or connection), stopping with an explicit list of what is missing if any prerequisite is absent. Once the observability data (including the Application Insights telemetry tables) is onboarded and queryable, it discovers the real business dataset in the workspace, correlates the latency signal against the conversion KPI using discovered keys, and reports a specific business-impact conclusion (or an error if the required data is unavailable). It never fabricates workspace names, tables, or query results, and never exposes tokens or connection internals.
+
+### Example 2 — Out-of-scope authoring request
+**User:** "Create a new Spark notebook and build a Delta table pipeline to load my business dataset."
+
+**Skill behavior:** Declines the out-of-scope authoring request, creates nothing in Fabric, and directs the user to the appropriate authoring skill (for example `spark-authoring-cli`) rather than taking over the task.

--- a/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-dynamic-fields-reference.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-dynamic-fields-reference.md
@@ -1,0 +1,175 @@
+# Application Insights dynamic fields reference
+
+**Critical:** many telemetry-to-business JOIN keys are **not** top-level columns.
+In Application Insights / Azure Monitor tables, business identifiers are often
+nested inside dynamic JSON-like columns. Schema verification MUST include
+dynamic-field inspection — never rely on top-level schema alone.
+
+## Common dynamic / object columns to inspect
+
+- `Properties`
+- `CustomDimensions`
+- `Details`
+- `Measurements`
+- `Payload`
+- `Context`
+- `customDimensions`
+- `customMeasurements`
+
+## Business identifiers that commonly hide inside dynamic fields
+
+`BookingId`, `booking_id`, `OrderId`, `order_id`, `CustomerId`, `customer_id`,
+`UserId`, `user_id`, `UserAuthenticatedId`, `TenantId`, `tenant_id`, `AccountId`,
+`FlightId`, `flight_number`, `PassportId`, `passport`, `SubscriptionId`,
+`CorrelationId`, `OperationId`, `SessionId`, `Region`, `Country`, `ProductId`,
+`ServiceName`.
+
+## High-priority Application Insights tables for dynamic-field inspection
+
+Before falling back to time-window correlation, inspect dynamic fields in the
+following order:
+
+Inspect these tables wherever they are queryable in the target KQL database —
+**including telemetry that is already present as a native table**, not only the
+shortcuts created in Stage 11. A business join key (e.g. `AppEvents.Properties`)
+may already exist in the Eventhouse independently of the mirrored-catalog
+shortcuts, so enumerate all telemetry tables in the database during Stage 12/13.
+
+1. AppEvents
+   - Properties
+   - Measurements
+   - Typical business identifiers:
+     BookingId, OrderId, CustomerId, FlightId, SessionId, UserId
+
+2. AppExceptions
+   - Properties
+   - Details
+   - Typical business identifiers:
+     PassportId, BookingId, CustomerId, TenantId, OperationId
+
+3. AppRequests
+   - Properties
+   - Typical business identifiers:
+     OperationId, SessionId, CustomerId, OrderId
+
+4. AppDependencies
+   - Properties
+   - Typical business identifiers:
+     CorrelationId, OrderId, TenantId, AccountId
+
+5. AppTraces
+   - Properties
+   - Typical business identifiers:
+     BookingId, CustomerId, OrderId, SessionId
+
+6. AppPageViews
+
+7. AppBrowserTimings
+
+Only after inspecting these tables and validating candidate identifiers should
+the Skill fall back to time-window correlation.
+
+## Required dynamic-field verification steps
+
+During schema verification (Stage 12):
+
+1. Retrieve the real table schema with `getschema`.
+2. Identify dynamic/object/string columns that may hold JSON-like business
+   context.
+3. Sample real rows from those columns.
+4. Inspect the keys inside dynamic columns.
+5. Extract candidate business identifiers with explicit KQL.
+6. Validate candidate joins against real business tables (non-zero matches).
+7. Prefer verified **direct joins** over time-window correlation.
+
+## KQL patterns
+
+### Inspect schema
+
+```kusto
+TableName
+| getschema
+| project ColumnName, ColumnType
+```
+
+### Sample dynamic properties
+
+```kusto
+AppEvents
+| take 10
+| project TimeGenerated, Name, Properties
+```
+
+### Extract possible business identifiers
+
+```kusto
+AppEvents
+| extend BookingId = tostring(Properties.BookingId)
+| project TimeGenerated, Name, BookingId
+```
+
+### Alternative casing / naming (coalesce)
+
+```kusto
+AppEvents
+| extend BookingId = coalesce(
+    tostring(Properties.BookingId),
+    tostring(Properties.bookingId),
+    tostring(Properties.booking_id)
+  )
+```
+
+### Typed (bool / numeric) dynamic values
+
+Not every dynamic value is a string. Boolean and numeric fields (e.g. a
+`faulted` / `isError` flag, a `durationMs` or `amount`) are stored with their
+real type and serialize as JSON literals (`true`/`false`, unquoted numbers).
+Comparing them with `tostring(...) == "True"` silently matches **nothing**.
+Cast to the real type and compare to a typed literal:
+
+```kusto
+AppEvents
+| where tobool(Properties.faulted) == true          // NOT tostring(...) == "True"
+| extend amount = toreal(Properties.amount),
+         retries = tolong(Properties.retryCount)
+```
+
+### Diagnose a zero-match filter before concluding "no data"
+
+If a dynamic-field filter or join returns **0 rows**, confirm the value's real
+type and distinct values before assuming the data is absent — a type/casing
+mismatch is the most common cause:
+
+```kusto
+AppEvents
+| extend f = Properties.faulted
+| summarize count() by value = tostring(f), type = gettype(f)
+```
+
+### Validate a direct join
+
+```kusto
+AppEvents
+| extend BookingId = tostring(Properties.BookingId)
+| where isnotempty(BookingId)
+| join kind=inner (
+    Bookings
+    | project BookingId = tostring(BookingId)
+  ) on BookingId
+| summarize MatchedRows=count(), DistinctBookings=dcount(BookingId)
+```
+
+## Confidence classification
+
+- If a valid business identifier is found inside `Properties` / `CustomDimensions`
+  and the join returns **non-zero** matches → classify as a **direct join, high
+  confidence**.
+- If no direct identifier is found after inspecting top-level columns **and**
+  dynamic fields → fall back to **time-window correlation**, and state clearly
+  that time-window correlation shows **correlation, not causality**.
+
+> **Lesson learned:** screenshots can be misleading. A join key nested in
+> `AppExceptions.Properties` (e.g. `passport`, `flight`) can yield a deterministic
+> direct join to a business table even when top-level columns show nothing usable,
+> and the real data window may be weeks older than assumed. Verify schema,
+> dynamic fields, join matches, and freshness against real data first.

--- a/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-table-reference.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/references/app-insights-table-reference.md
@@ -1,0 +1,168 @@
+# Application Insights / Azure Monitor table reference
+
+Common Application Insights / Azure Monitor (Log Analytics) telemetry tables, what
+signal each contains, the operational questions it answers, and how it can
+correlate with business data.
+
+> **Not a schema guarantee.** These are common shapes only. The **actual** schema
+> must always be verified against the real Eventhouse / KQL database with
+> `getschema` and sampling (see app-insights-dynamic-fields-reference.md). Column
+> names vary by app, SDK, and ingestion settings.
+
+## External references
+
+- [Azure Monitor tables for microsoft.insights/components (learn)](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/microsoft-insights-components)
+- [Azure Monitor Logs table reference](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/)
+
+## Workspace-based Application Insights tables (`App*`)
+
+### AppRequests
+- **Signal:** incoming server requests — success/failure, duration, result code,
+  operation name, endpoint.
+- **Operational questions:** Which endpoints fail or are slow? What is availability
+  / p95 latency? Where are 5xx spikes?
+- **Business correlation:** conversion, booking completion, checkout failures, API
+  SLA.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Id`, `OperationName`, `Url`,
+  `ResultCode`, `Success`, `DurationMs`, `Name`.
+- **Common dynamic fields:** `Properties`.
+
+### AppDependencies
+- **Signal:** outbound/downstream dependency calls (DB, HTTP, queue) — success,
+  duration, target, type.
+- **Operational questions:** Which downstream dependency failed or slowed? Which
+  target/region is degraded?
+- **Business correlation:** payment failures, inventory lookup failures, regional
+  dependency outages.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Target`, `DependencyType`,
+  `Name`, `Success`, `DurationMs`, `ResultCode`.
+- **Common dynamic fields:** `Properties`.
+
+### AppExceptions
+- **Signal:** application exceptions / failures — type, method, outer message,
+  problem id.
+- **Operational questions:** What is failing and where? Which exception types
+  spike during an incident?
+- **Business correlation:** failed bookings, failed orders, customer-impacting
+  errors.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `ProblemId`, `ExceptionType`,
+  `Method`, `OuterMessage`.
+- **Common dynamic fields:** `Properties`, `Details`.
+
+### AppTraces
+- **Signal:** diagnostic traces / structured logs — message, severity.
+- **Operational questions:** What diagnostic evidence supports a failure or
+  degraded behavior?
+- **Business correlation:** supporting evidence for failures or degraded service;
+  business keys sometimes embedded in `Properties`.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `OperationId`, `Message`, `SeverityLevel`.
+- **Common dynamic fields:** `Properties`.
+
+### AppEvents
+- **Signal:** custom business/product events emitted by the app (e.g.
+  `BookingStarted`, `CheckoutCompleted`).
+- **Operational questions:** Which funnel step dropped? Which product events
+  stopped firing during an incident?
+- **Business correlation:** funnel steps, booking started/completed, checkout,
+  sign-in — often the **richest** source of business keys in `Properties`.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `OperationId`, `UserId`, `SessionId`.
+- **Common dynamic fields:** `Properties`, `Measurements`.
+
+### AppPageViews
+- **Signal:** frontend page views — page name, url, load duration.
+- **Operational questions:** Which pages are slow or abandoned?
+- **Business correlation:** conversion, abandonment, user-journey drop-off.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Url`, `OperationId`, `UserId`,
+  `SessionId`, `DurationMs`.
+- **Common dynamic fields:** `Properties`.
+
+### AppBrowserTimings
+- **Signal:** client-side timing (network, send, receive, processing, total).
+- **Operational questions:** Where is frontend latency introduced?
+- **Business correlation:** conversion / abandonment tied to page latency.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Url`, `OperationId`,
+  `TotalDuration`.
+- **Common dynamic fields:** `Properties`.
+
+### AppAvailabilityResults / AvailabilityResults (if present)
+- **Signal:** synthetic availability tests — success, duration, location.
+- **Operational questions:** Is the service reachable from each test location?
+- **Business correlation:** availability failures → booking/checkout completion,
+  SLA.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Location`, `Success`, `DurationMs`,
+  `OperationId`.
+- **Common dynamic fields:** `Properties`.
+
+### AppMetrics (where useful)
+- **Signal:** custom metrics (name, value, aggregations).
+- **Business correlation:** business-relevant custom metrics (e.g. cart value,
+  active sessions) by time.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Sum`, `Count`, `ItemCount`.
+- **Common dynamic fields:** `Properties`.
+
+### AppPerformanceCounters (where useful)
+- **Signal:** host/process performance counters (CPU, memory, etc.).
+- **Business correlation:** resource saturation preceding user-facing degradation.
+- **Common time column:** `TimeGenerated`.
+- **Common identifying fields:** `Name`, `Category`, `Value`, `Instance`.
+
+### AppSystemEvents (where useful)
+- **Signal:** SDK/system events about the telemetry pipeline.
+- **Business correlation:** rarely a direct business key; useful for data-quality
+  context.
+- **Common time column:** `TimeGenerated`.
+
+### Usage-related tables (where relevant)
+- **Signal:** usage/volume of events, page views, sessions over time.
+- **Business correlation:** traffic drop → usage KPI degradation (active users,
+  transactions, revenue events).
+
+## Common cloud/role/location fields (across App* tables)
+
+Useful for regional / service-scoping of impact:
+`AppRoleName` / `CloudRoleName`, `AppRoleInstance`, `ClientCountryOrRegion`,
+`ClientCity`, `ClientType`, `OperationName`. Confirm presence via `getschema`.
+
+## Observability → business quick map
+
+| Table | Typical business impact |
+|-------|------------------------|
+| AppRequests | conversion, booking completion, checkout failures, API SLA |
+| AppExceptions | failed bookings/orders, customer-impacting errors |
+| AppDependencies | payment/inventory failures, regional dependency outages |
+| AppEvents | funnel steps, booking/checkout/sign-in events |
+| AppPageViews / AppBrowserTimings | conversion, abandonment, journey drop-off |
+| AppTraces | supporting evidence for failures / degradation |
+| AppAvailabilityResults | availability failures → booking/SLA impact |
+
+Always confirm the real schema before relying on any field above.
+
+## Telemetry source selection (data-driven, REQUIRED)
+
+No telemetry table is "best" by default. The winning source in one environment
+(e.g. AppEvents) is **not** a general rule. Telemetry source selection MUST be
+data-driven.
+
+Before selecting a correlation model, inspect **all** candidate telemetry sources
+discovered (AppEvents, AppExceptions, AppRequests, AppDependencies, AppTraces,
+AppPageViews, AppBrowserTimings, AvailabilityResults, and any others present).
+Score each candidate by:
+
+1. Business identifiers discovered.
+2. Dynamic-field richness.
+3. Direct-join confidence.
+4. Validated match count.
+5. Business-process context.
+6. Relevance to the selected business goal.
+
+Select the highest-scoring source. Do NOT automatically prioritize AppExceptions.
+Do NOT automatically prioritize AppEvents.

--- a/skills/azmon-mirroredcatalogs-operations-cli/references/azmon-fabric-api-reference.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/references/azmon-fabric-api-reference.md
@@ -1,0 +1,188 @@
+# Azure Monitor → Fabric API reference
+
+Guidance on which flows are **documented/supported** versus **UI-only** or
+**internal/unsupported**, and the rules for the two connector modes. This file is
+agent guidance — do not paste it verbatim to users.
+
+## Supported vs UI-only vs internal — at a glance
+
+| Capability | Status | Notes |
+|-----------|--------|-------|
+| Mirrored Catalog item CRUD | Documented REST API | See mirrored-catalog-reference.md |
+| Mirrored Catalog item definition | Documented REST API | Item definition format |
+| Mirrored Catalog discovery | Documented REST API | Browse scopes/tables |
+| Mirrored Catalog monitoring | Documented REST API | Item/table mirroring status |
+| Mirrored Catalog refresh / sync | Documented REST API | Trigger metadata sync |
+| Operations Agent item CRUD + definition | Documented Fabric item APIs | `type: "OperationsAgent"` |
+| **OAuth** Azure Monitor connector creation | **UI-only** | Created once in Fabric → Manage Connections. **No public API.** Detect + reuse only. |
+| **Service Principal** connector create-or-reuse | Automated | Idempotent create-or-reuse; secrets from env/Key Vault only |
+| OneLake shortcut creation | Documented, but see caveat | Link alone does not register a queryable KQL table — see eventhouse-shortcuts-reference.md |
+
+## Portal fallback boundary
+
+Portal-guided instructions are allowed ONLY for OAuth Azure Monitor connector creation.
+
+Portal guidance must NOT be used as a generic fallback for:
+
+- Log Analytics workspace validation
+- Fabric workspace validation
+- Connection detection
+- Connection reuse
+- Service Principal connector creation
+- Mirrored Catalog item creation
+- Discovery
+- Monitoring
+- Refresh
+- Eventhouse shortcut creation
+- Schema verification
+- Operations Agent creation
+
+Before declaring a capability unavailable, the Skill should determine whether another supported execution path exists:
+
+- Fabric REST APIs
+- Azure REST APIs
+- Fabric Actions
+- Azure CLI
+- Azure Resource Graph
+- Fabric REST **read-only** discovery via authenticated `az rest --method get`
+  against `https://api.fabric.microsoft.com/...`
+
+MCP unavailability does not automatically imply capability unavailability.
+
+### Fabric REST read-only discovery exception (bounded)
+
+Arbitrary shell / CLI / `az` / PowerShell execution remains out of scope. There
+is ONE narrow exception: the Skill MAY use an authenticated `az rest --method
+get` call for Fabric REST **read-only discovery** only, when ALL of these hold:
+
+- Endpoint is `https://api.fabric.microsoft.com/...`.
+- HTTP method is **GET** only.
+- The operation is discovery / read-only only.
+- Nothing is created, updated, deleted, or modified — no Fabric items, shortcuts,
+  mirrored catalog items, or connectors are created through the CLI.
+- No tokens, secrets, raw auth headers, or sensitive payloads are exposed.
+- The Skill clearly states the capability path used.
+
+This exception is limited to Stage 3 (Fabric workspace discovery) and Stage 5
+(Azure Monitor OAuth connection detection). It does not relax any other stage's
+boundary, does not authorize non-GET `az rest` calls, and does not permit use of
+the Kusto / KQL data-plane when disabled.
+
+## Connector rules (authoritative)
+
+Keep the two modes strictly separated. Never route OAuth through Service
+Principal logic and never route Service Principal through OAuth/interactive
+sign-in logic.
+
+### OAuth mode (UI-guided only)
+
+- OAuth connector **creation** is interactive in **Fabric → Manage Connections**.
+- The Skill only **detects** and **reuses** an existing Azure Monitor OAuth
+  connection. Detection is **non-destructive** (never create/update/delete).
+- **Never** claim public-API support for OAuth Azure Monitor connector creation.
+- **Never** document browser-inspected / internal connector endpoints, hidden
+  payloads, `CredentialType` internals, OAuth codes, tokens, cookies, nonces, or
+  redirect URLs as supported public APIs, and never surface them to the user.
+- Reuse a connection ONLY when the data source path / LAW resource id matches the
+  **same** Log Analytics workspace exactly. Any mismatch → treat as no match.
+- If the user explicitly supplies a connection id, validate it (must be an Azure
+  Monitor Mirrored Catalog connection whose data source path matches this
+  workspace) before reusing. Reject mismatches.
+
+User-facing message when no connection exists (keep it this simple):
+
+```text
+I couldn’t find an existing Azure Monitor connection for this workspace.
+Please create it once in Fabric Manage Connections, then come back and continue.
+```
+
+### Service Principal mode (automated create-or-reuse)
+
+- Automated, non-interactive: no user login, no UI step.
+- **Idempotent**: reuse an existing matching Azure Monitor Service Principal
+  connector for the same Log Analytics workspace (same data source path +
+  Service Principal credential type) instead of creating a duplicate.
+- Only **one** connector per run.
+- **Never** reuse a non-Service-Principal (e.g. OAuth) connector in this mode.
+- **Never** ask the user to paste a raw client secret into chat.
+- Secrets come from **environment variables or Key Vault references** only; they
+  are never echoed, logged, exposed, or included in generated instructions.
+- If required inputs are missing, describe **what** is missing (tenant id, app /
+  client id, and a securely-provided secret reference) using presence checks
+  only. Never request the secret value in chat.
+
+## Supported-scope / validation rules
+
+Before creating anything, verify: the workspace exists; it is **not Sentinel** or
+otherwise unsupported; the caller has required Log Analytics access; the caller
+can create the item in the target Fabric workspace. Surface pass/fail in user
+terms; never expose raw API responses.
+
+### Sentinel detection source hierarchy
+
+Sentinel detection is a **control-plane** check and MUST NOT default to requiring
+Kusto / KQL data-plane availability. Before classifying Sentinel status as "not
+verifiable", attempt all available control-plane / metadata checks, in order:
+
+1. Resource group inventory / ARM resource enumeration.
+2. `Microsoft.OperationsManagement/solutions` named `SecurityInsights(<workspaceName>)`.
+3. `Microsoft.SecurityInsights/*` resources, including `onboardingStates` if surfaced.
+4. Workspace / resource feature metadata, if available.
+
+Indicators found → **Sentinel / blocked**. Indicators absent after complete
+enumeration → **Not Sentinel, verified via control-plane**. Only if all these
+checks are unavailable or inconclusive → **not verifiable**. Kusto may be an
+additional path but is never a required dependency for Sentinel detection. This
+hierarchy does NOT generalize to Log Analytics data-plane/query permission (may
+require a KQL/data-plane path) or Fabric item-creation permission (may require a
+Fabric control-plane capability).
+
+## Fabric workspace discovery & capability resolution
+
+Fabric workspaces are **not** Azure Resource Manager resources. They cannot be
+enumerated through Azure resource listing, Azure Resource Graph, or `az`
+resource commands, so an ARM-only environment reaching Azure resources does
+**not** imply a Fabric control-plane path exists — and the reverse also holds:
+lack of automatic enumeration does NOT mean no Fabric workspace exists.
+
+Stage 3 (Fabric workspace selection) MUST follow this policy (SKILL.md links here
+for the full detail):
+
+- Discover all surfaced Fabric mechanisms first: Fabric REST APIs, Fabric
+  Actions, Fabric / OneLake / Power BI execution capabilities, authenticated
+  Fabric REST read-only discovery via `az rest --method get` against
+  `https://api.fabric.microsoft.com/...` (GET-only, read-only, no modifications,
+  no secret/token/header exposure, capability path stated), or any other
+  documented capability provider available to the agent environment.
+- If automatic enumeration is unavailable, do NOT terminate. Distinguish "no
+  Fabric control-plane capability at all" from "enumeration unavailable but the
+  workflow can continue with user-provided workspace info".
+- Ask the user for a **Fabric Workspace Name**, **Workspace ID**, or **Workspace
+  URL**, then validate it as far as the available capabilities allow.
+- Never fabricate a workspace, workspace id, or validation result, and never
+  claim a Fabric action succeeded when the required execution capability is
+  unavailable.
+- Mark Stage 3 BLOCKED only after every programmatic discovery path AND every
+  user-supplied resolution path (Name / ID / URL) is exhausted. UI-guided
+  selection is permitted only as the final fallback.
+
+## Fabric Operations Agent surface
+
+Operations Agent is a first-class Fabric item (`type: "OperationsAgent"`). It can
+be created and populated through documented Fabric item APIs (create item, then
+set the definition with the instructions and the KQL database data source). Teams
+notifications are a built-in action — no custom channel binding is required for
+basic alerts. See operations-agent-reference.md.
+
+## External references
+
+- [Items - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/items)
+- [Mirrored Catalog item definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/mirrored-catalog-definition)
+- [Discovery - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/discovery)
+- [Monitoring - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/monitoring)
+- [Refresh - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/refresh)
+
+> The Mirrored Catalog references above cover item CRUD, item definition,
+> discovery, monitoring, and refresh/sync operations. They do **not** document
+> OAuth Azure Monitor connector creation. Treat OAuth connector creation as
+> UI-guided only.

--- a/skills/azmon-mirroredcatalogs-operations-cli/references/business-correlation-patterns.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/references/business-correlation-patterns.md
@@ -1,0 +1,101 @@
+# Business correlation patterns reference
+
+Reusable **observability signal → business impact** patterns, candidate join
+keys, and scoring hints for ranking candidate business tables. Use these to guide
+discovery and correlation planning — always confirm business meaning with the
+user and verify keys against real data before relying on them.
+
+## Domain-agnostic rule (examples only)
+
+Every business entity named in this file — bookings, orders, customers, flights,
+revenue, tenants, payments, and similar — is an **EXAMPLE ONLY**. Do NOT infer the
+user's business domain from these examples. Discover the user's actual business
+entities from real Fabric data and confirm them with the user before use.
+
+Business tables are **not** expected to exist in Log Analytics. They may live in
+an Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts.
+Absence of business tables in Log Analytics MUST NOT be read as absence of
+business data.
+
+## Patterns
+
+### 1. Availability → Bookings
+- **Operational signal:** `AppRequests` failures, `AvailabilityResults` failures,
+  `AppExceptions`.
+- **Business impact:** failed / incomplete bookings.
+- **Candidate keys:** `BookingId`, `CustomerId`, `SessionId`, `OperationId`,
+  custom `Properties`.
+
+### 2. Latency → Conversion
+- **Operational signal:** `AppRequests` duration, `AppPageViews`,
+  `AppBrowserTimings`.
+- **Business impact:** conversion drop, abandonment, funnel degradation.
+- **Candidate keys:** `SessionId`, `UserId`, `CustomerId`, funnel event IDs.
+
+### 3. Exceptions → Orders / Revenue
+- **Operational signal:** `AppExceptions`, `AppTraces`.
+- **Business impact:** failed orders, revenue at risk.
+- **Candidate keys:** `OrderId`, `CustomerId`, `TenantId`, `OperationId`,
+  `Properties`.
+
+### 4. Dependency failures → Customer / Tenant impact
+- **Operational signal:** `AppDependencies` failures / latency.
+- **Business impact:** affected customers, tenants, regions, services.
+- **Candidate keys:** `TenantId`, `AccountId`, `Region`, `DependencyTarget`.
+
+### 5. Regional outage → Business KPI impact
+- **Operational signal:** `CloudRoleName`, `Region`, `ClientCountryOrRegion`,
+  location fields.
+- **Business impact:** regional bookings, customers, transactions, SLA.
+- **Candidate keys:** `Region`, `Country`, `Location`, `AirportCode`,
+  `DataCenter`.
+
+### 6. Traffic drop → Usage KPI degradation
+- **Operational signal:** `AppEvents`, `AppPageViews`, `AppRequests` volume drop.
+- **Business impact:** lower active users, reduced transactions, reduced revenue
+  events.
+- **Candidate keys:** `UserId`, `SessionId`, `ProductId`, event names.
+
+## Business data scoring hints
+
+When the exact business table or join is not known, **do not fail**. Score
+candidate business databases/tables by likely relevance to the stated goal,
+present a ranked list with explanation, propose shortcut creation for the top
+candidates, and ask the user to choose. Never conclude "no correlation is
+possible" without options.
+
+| Business goal | Prioritize tables |
+|---------------|-------------------|
+| Booking impact | Bookings, Reservations, Orders, Flights, Customers, Transactions |
+| Revenue impact | Orders, Payments, Revenue, Invoices, Subscriptions |
+| Customer impact | Customers, Accounts, Tenants, Users, Subscriptions |
+| Regional impact | Regions, Locations, Airports, DataCenters, Countries |
+| Service availability | AppRequests, AvailabilityResults, AppExceptions, AppDependencies + business completion tables |
+| Conversion | AppEvents, AppPageViews, AppRequests + funnel/business event tables |
+
+## Candidate key reference
+
+Infer candidates from column/table names; confirm meaning with the user and
+verify against real data before relying on them.
+
+- **Customer identifiers:** `CustomerId`, `UserId`, `PassportRef`, `AccountId`,
+  `TenantId`, `SubscriptionId`.
+- **Entity identifiers:** `FlightId`, `OrderId`, `BookingId`, `SessionId`,
+  `OperationId`, `RequestId`, `ResourceId`.
+- **Timestamps:** `TimeGenerated`, `Timestamp`, `EventTime`, `BookingTime`,
+  `CreatedTime`.
+- **Region/location:** `Region`, `Location`, `originAirport`,
+  `destinationAirport`, `Country`, `DataCenter`.
+
+## Table classification hints
+
+- **Operational telemetry:** AppEvents, AppExceptions, AppRequests, AppPageViews,
+  AppBrowserTimings, AppDependencies, AvailabilityResults, AzureMetrics, Perf,
+  Usage.
+- **Business tables:** Bookings, Customers, Flights, Orders, Payments,
+  CounterCheckins, Subscriptions, Invoices.
+- **Context/enrichment tables:** Flights, Regions, Products, Services, Tenants,
+  Airports.
+
+Confirm business meaning with the user; never fabricate tables the user has not
+confirmed.

--- a/skills/azmon-mirroredcatalogs-operations-cli/references/business-insight-modeling-reference.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/references/business-insight-modeling-reference.md
@@ -1,0 +1,114 @@
+# Business insight modeling reference
+
+How to turn a **verified** telemetry + business dataset into a correlation model
+without asking the user for joins, KQL, bins, or thresholds. The user confirms
+**business meaning**; the Skill translates it into the technical model.
+
+## Inputs the model is inferred from
+
+- Verified top-level schema (`getschema`).
+- Verified dynamic fields (sampled `Properties` / `CustomDimensions`).
+- Sampled values.
+- Business table schema.
+- Actual join test results (non-zero match counts).
+- Data freshness (real min/max time range).
+
+Never propose a model before these are verified (Stage 12).
+
+## Direct join vs time-window correlation
+
+- **Direct join (preferred, high confidence):** a shared identifier exists and a
+  test join returns non-zero matches. Use it. State the match count.
+- **Time-window correlation (fallback):** no shared identifier after inspecting
+  top-level and dynamic fields. Correlate events within the same time bin. Always
+  state that this shows **correlation, not causality**.
+
+## Bins
+
+- **Default bin size: 5 minutes.** Explain it as granular enough to catch short
+  operational spikes while aggregating enough events to be meaningful and reduce
+  per-event noise.
+- Use a **larger** bin when data is **sparse** (few events → 15–60 min) or when
+  business KPIs are **slower** (e.g. daily bookings). Adjust for very noisy /
+  high-volume data to stabilize the signal.
+
+## Derived entity
+
+- Default derived entity name: **IncidentBin** (unless a better
+  business-specific name exists).
+- Each IncidentBin represents one time window and is the unit of analysis for
+  metrics and alert rules.
+
+## Confirming business meaning (not SQL)
+
+Ask about meaning, e.g.:
+
+> "I found `BookingId` inside `AppEvents.Properties` and it matches
+> `Bookings.BookingId`. Should I treat this as the booking identifier for
+> business impact?"
+
+Do not ask "what join should I use?" or "what bin/threshold do you want?".
+
+## Correlation plan contents (present before generating instructions)
+
+- Operational signal (which table/event indicates the problem).
+- Business impact table.
+- Verified join keys.
+- Whether the join came from **top-level columns** or **dynamic fields**
+  (`Properties` / `CustomDimensions`).
+- Match count / validation result.
+- Time window + freshness status.
+- Proposed bin size.
+- Metrics and thresholds.
+
+Then ask for confirmation and STOP.
+
+### Correlation planning validation (REQUIRED)
+
+When finalizing the correlation model, explain **why** the selected telemetry
+source was chosen, justified with real data. Include: match counts, business
+identifiers discovered, direct-join confidence, and validation results. The
+selected telemetry source must be justified against actual data — never chosen by
+default or by assumption. Candidate telemetry sources must have been inspected and
+scored before selection (see app-insights-table-reference.md).
+
+## Metrics (typical)
+
+- `ErrorCount` — faulted operational events per IncidentBin.
+- `AffectedCustomers` — distinct impacted customers per IncidentBin.
+- `AffectedBusinessRecords` — impacted business records per IncidentBin.
+- `RevenueAtRisk` — summed revenue of impacted records per IncidentBin.
+- `TopImpactedEntities` — top impacted entities by impact.
+- `ImpactBand` — high / low / none.
+
+## Thresholds
+
+Always include **both** sets in the generated instructions.
+
+- **Production-like:**
+  - ErrorCount increases by more than 20% vs previous-hour baseline.
+  - AffectedCustomers ≥ configured business threshold.
+  - RevenueAtRisk ≥ configured business threshold.
+- **Relaxed POC / debug** (validate Start + Teams alert end-to-end):
+  - `ErrorCount >= 1`
+  - `ErrorCount >= 5 and AffectedBusinessRecords >= 1`
+  - `AffectedCustomers >= 1`
+
+## Freshness and time window
+
+Check the real data range before generating instructions:
+
+```kusto
+TableName
+| summarize Rows=count(), MinTime=min(TimeGenerated), MaxTime=max(TimeGenerated)
+```
+
+If data is old or sparse, do not assume `ago(1h)` — use a window covering the
+actual range and explain it in user terms. Watch for locale-formatted timestamps
+(DD/MM vs MM/DD) when reading results.
+
+## Handoff to instruction generation
+
+The materialization query output columns MUST match the alert fields exactly. See
+operations-agent-reference.md for the explicit-KQL requirement and the full
+instruction template.

--- a/skills/azmon-mirroredcatalogs-operations-cli/references/eventhouse-shortcuts-reference.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/references/eventhouse-shortcuts-reference.md
@@ -1,0 +1,112 @@
+# Eventhouse & OneLake shortcuts reference
+
+How the mirrored Azure Monitor tables become **queryable** in an Eventhouse / KQL
+database, and the queryability requirement that must be verified before any
+correlation logic.
+
+## Eventhouse / KQL database
+
+An Eventhouse hosts one or more KQL databases queried with KQL. The onboarding
+flow lands Azure Monitor telemetry (and, via additional shortcuts, business
+tables) into a KQL database so telemetry and business data can be correlated with
+KQL.
+
+- **Eventhouse / KQL database selection is a user decision.** Always present the
+  discovered options and require explicit confirmation. Never auto-select, even
+  when discovery has a recommended default.
+- The Eventhouse query URI (`queryServiceUri` in Eventhouse properties) is where
+  `getschema`, sampling, and validation queries run during schema verification.
+
+## OneLake shortcuts — the queryability requirement (CRITICAL)
+
+Making a mirrored table queryable requires **two** things:
+
+1. **Exact source table name.** A renamed shortcut (e.g. `LAQS_AppTraces` for
+   source `AppTraces`) creates the OneLake link but may NOT register as a
+   queryable KQL table (e.g. `General_BadRequest: Request is invalid`). Keep the
+   exact source table name.
+2. **The table must be registered as a queryable/external table.** A OneLake link
+   alone is not enough. The Fabric **UI "Add table"** flow both creates the
+   shortcut and registers the external table, so it becomes queryable. Creating
+   only the OneLake link means the table will not appear in
+   `.show external tables` and queries return 400.
+3. **Mirrored AzMon tables live under a `dbo` schema folder.** In the mirrored
+   catalog item's OneLake, tables are nested at `Tables/dbo/<TableName>`, not
+   directly under `Tables/<TableName>`. A shortcut's OneLake target path must
+   therefore include the schema segment (`target.oneLake.path =
+   "Tables/dbo/<TableName>"`). Confirm the exact folder by listing `Tables/`
+   first — it typically contains a single `dbo` directory holding every table.
+
+## Shortcut planning and creation (stage rules)
+
+- **Shortcut planning happens before schema verification or join logic.** Present
+  the plan and STOP for confirmation.
+- **Shortcut creation requires explicit confirmation.**
+- **Handle "already exists" idempotently.** If shortcut creation returns a
+  conflict (e.g. HTTP 409 `EntityConflict` / `ShortcutsOperationNotAllowed` when
+  the conflict policy is `Abort`), do **not** treat it as a failure and do **not**
+  overwrite. A shortcut of that name already exists — verify it points to the
+  intended source and is queryable (`.show external tables` + `TableName | take 1`),
+  then proceed. Only recreate if the existing shortcut targets a different source.
+- After creation, **verify queryability** with a lightweight query before building
+  any correlation logic. Stage 11 validates **queryability, NOT table size**, so
+  use a single-row probe rather than a full scan:
+
+  ```kusto
+  TableName
+  | take 1
+  ```
+
+  (`TableName | limit 1` is equivalent.) Avoid `TableName | count` here — on
+  large external Delta tables a `count` forces an unnecessary full scan, causing
+  long execution times and validation delays.
+
+- If a table is not queryable → **STOP** and return to shortcut planning /
+  creation. Do not build correlation logic on screenshots or assumed schema.
+- A brand-new AzMon item won't surface tables until its mirror has materialized
+  them; wait/refresh before expecting queryable tables.
+
+## Shortcut acceleration policy (SHOULD)
+
+Query acceleration SHOULD be treated as the preferred configuration for newly
+created shortcuts. Testing showed significant performance improvements once
+acceleration was enabled — schema verification, queryability validation,
+telemetry sampling, correlation analysis, and Operations Agent preparation all
+became substantially faster.
+
+When creating ANY shortcut:
+
+1. Determine whether acceleration is **supported**.
+2. Determine the **current** acceleration status.
+3. **Enable** acceleration when supported and appropriate.
+4. **Report** the acceleration status.
+
+During Shortcut Planning (Stage 10), show for each shortcut: Shortcut Name,
+Source, Target, Acceleration Supported (Yes/No), Acceleration Enabled (Yes/No). If
+acceleration is disabled, explain the potential impact on queryability validation,
+schema verification, telemetry sampling, correlation analysis, and Operations
+Agent preparation.
+
+This is a **SHOULD**, not a MUST — do not assume acceleration exists in every
+environment.
+
+## Verify external table registration
+
+After adding tables, confirm registration and queryability:
+
+```kusto
+.show external tables
+```
+
+```kusto
+TableName
+| take 1
+```
+
+Stage 11 validates queryability, NOT table size. Prefer the single-row probe
+`TableName | take 1` (or `TableName | limit 1`). Avoid `TableName | count`, which
+forces a full scan of large external Delta tables and slows validation.
+
+If a table is missing from `.show external tables`, it was linked but not
+registered — re-add it via the UI "Add table" flow (which both links and
+registers), keeping the exact source name.

--- a/skills/azmon-mirroredcatalogs-operations-cli/references/mirrored-catalog-reference.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/references/mirrored-catalog-reference.md
@@ -1,0 +1,89 @@
+# Mirrored Catalog reference
+
+Supported Fabric Mirrored Catalog operations for onboarding Azure Monitor /
+Application Insights / Log Analytics data as an AzMon item. All operations below
+are documented REST APIs.
+
+> **Preview / beta status:** The Azure Monitor Mirrored Catalog item is in
+> **Preview**, and its Discovery, Monitoring, and Refresh operations are `(beta)`
+> — they require the `beta=true` query parameter. Treat this surface as subject
+> to change and confirm the current shape against Microsoft Learn before relying
+> on it.
+
+## What a Mirrored Catalog (AzMon) item is
+
+A Fabric item that mirrors an external catalog (here, Azure Monitor / Log
+Analytics) into Fabric so its tables become discoverable and, via Eventhouse
+shortcuts, queryable in a KQL database. The item is created in a target Fabric
+workspace and bound to a connection (OAuth or Service Principal) for the source
+Log Analytics workspace.
+
+## Operation groups
+
+### Item CRUD
+
+Create, get, update, list, and delete the Mirrored Catalog item in a Fabric
+workspace. Creating the item requires a valid connection for the source Log
+Analytics workspace and sufficient Fabric workspace permission. Capture the
+returned item id for later monitoring/refresh calls.
+
+- [Items - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/items)
+
+### Item definition
+
+The item definition describes the mirrored catalog configuration (source binding,
+selected scope/tables where applicable). Read the current definition before
+editing; do not fabricate definition fields.
+
+- [Mirrored Catalog item definition](https://learn.microsoft.com/en-us/rest/api/fabric/articles/item-management/definitions/mirrored-catalog-definition)
+
+### Discovery
+
+Browse available source **scopes** (namespaces) and **tables** after the
+connection/item is available. Use only returned scope/table values — never
+fabricate table names. Discovery is read-only.
+
+- [Discovery - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/discovery)
+
+#### Discovery API fallback policy
+
+The Mirrored Catalog Discovery APIs are the **primary** discovery mechanism. If
+discovery appears incomplete, do NOT immediately switch to alternative metadata
+paths. First:
+
+1. Verify mirror status.
+2. Verify refresh / sync status.
+3. Verify discovery scope.
+4. Retry discovery.
+
+Only after these checks may alternative metadata paths be evaluated.
+
+### Monitoring
+
+Report readiness/status of the mirrored item and of individual tables rather than
+guessing readiness. A brand-new item will not surface tables until its mirror has
+materialized them.
+
+- [Monitoring - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/monitoring)
+
+### Refresh / run sync job
+
+Trigger a catalog metadata refresh / sync after item creation to bring table
+metadata up to date. Do not claim refresh completed unless the service confirms
+it.
+
+- [Refresh - REST API (MirroredCatalog)](https://learn.microsoft.com/en-us/rest/api/fabric/mirroredcatalog/refresh)
+
+## Guardrails
+
+- These APIs cover item CRUD, definition, discovery, monitoring, and
+  refresh/sync. They do **not** document OAuth Azure Monitor connector creation —
+  treat OAuth connector creation as UI-guided (see azmon-fabric-api-reference.md).
+- Discovery/monitoring output is authoritative for names/status; do not invent
+  values.
+- Mirroring metadata into the catalog is **not** the same as a table being
+  queryable in Eventhouse. Queryability requires an Eventhouse shortcut that
+  registers the table (see eventhouse-shortcuts-reference.md).
+- Business tables are **not** expected in Log Analytics. They may exist in an
+  Eventhouse, KQL database, Warehouse, Lakehouse, or via Fabric shortcuts. Their
+  absence in Log Analytics does NOT mean business data is absent.

--- a/skills/azmon-mirroredcatalogs-operations-cli/references/operations-agent-reference.md
+++ b/skills/azmon-mirroredcatalogs-operations-cli/references/operations-agent-reference.md
@@ -1,0 +1,243 @@
+# Operations Agent reference
+
+Everything needed to generate, create, validate, and troubleshoot a Microsoft
+Fabric **Operations Agent** over the Eventhouse/KQL database holding the verified
+telemetry + business data. The end product is a clean copy/paste block of
+instructions the user pastes into Fabric.
+
+## Core principle
+
+The user is **not** expected to know join logic, time binning, derived-entity
+modeling, metric computation, or thresholds. Never open with "what JOIN should I
+use?" or "what bin/threshold do you want?". Infer candidates from the **verified**
+schema (Stage 12), propose in business language, confirm business meaning, then
+translate to the technical model on the user's behalf.
+
+## Give explicit per-field KQL, not conceptual descriptions (REQUIRED)
+
+The Fabric playbook generator will **not infer** joins, aggregations, or how to
+compute a metric. Conceptual-only field names (e.g. "AffectedCustomers",
+"RevenueAtRisk") cause generation to fail with **"No playbook generated"** and
+"I was not able to determine how to compute X". To avoid this:
+
+- Provide **one verbatim materialization query** whose **output columns ARE the
+  alert fields** (the `summarize`/`extend` produces `ErrorCount`,
+  `AffectedCustomers`, `RevenueAtRisk`, … by `IncidentBin`). Include the
+  `tostring(Properties.x)` extraction, the explicit `join`, and the exact
+  aggregations (`count()`, `dcount()`, `dcountif()`, `sum()`, `make_set()`).
+- Add a **field-definition list** restating each output column's KQL in one line
+  (e.g. `AffectedCustomers = dcount(passport) by IncidentBin`), so message
+  placeholders map 1:1 to columns.
+- Make each **alert rule reference a concrete output column**. If one metric
+  drives both the trigger and the message text (e.g. `RevenueAtRisk >= 1000` and
+  `$<RevenueAtRisk>` in the message), say so explicitly.
+
+## Playbook materialization requirement (MANDATORY)
+
+Operations Agent creation can succeed while **playbook generation still fails**
+until the incident entity is materialized as a real, queryable schema object.
+Testing confirmed that instructions and KQL text alone are NOT sufficient — the
+Playbook Generator discovers alert fields from an actual schema, not from prose.
+
+Before generating Operations Agent rules:
+
+1. **Materialize IncidentBins** as a real, queryable schema object (a physical
+   table, or a stored-function-backed table, in the KQL database).
+2. **Expose the alert fields as physical output columns.**
+3. **Verify the schema exists** (`IncidentBins | getschema`).
+
+Required output columns:
+
+- IncidentBin
+- ErrorCount
+- AffectedCustomers
+- AffectedBookings
+- RevenueAtRisk
+- TopImpactedEntities
+- TopImpactedSteps
+
+The Playbook Generator MUST be able to discover these fields directly from the
+materialized schema. KQL instructions alone are NOT sufficient. Business-specific
+column names adapt to the business entities actually discovered in the data.
+
+## Required sections of the generated instructions
+
+Goal · Data sources · Field mapping definitions · Dynamic field extraction logic ·
+Derived analysis entity · IncidentBin materialization query · Metric definitions ·
+Correlation logic · Impact logic (production + POC) · Alert behavior · Output
+requirements · Validation / POC mode.
+
+## Instruction template
+
+Fill `<...>` placeholders with confirmed table/column names. Leave unknowns as
+explicit placeholders — do not invent schema. Output as one copy/paste block.
+
+```text
+Goal:
+Detect operational incidents and correlate them with business impact.
+
+Data sources:
+Operational telemetry tables:
+- <OperationalTable>
+Business tables:
+- <BusinessTable>
+Context/enrichment tables:
+- <ContextTable>
+
+Field mapping definitions:
+- Customer identifier: <BusinessTable>.<CustomerIdColumn>
+- Operational time:    <OperationalTable>.<OperationalTimestampColumn>
+- Business time:       <BusinessTable>.<BusinessTimestampColumn>
+
+Dynamic field extraction logic:
+- Extract business keys nested in dynamic columns, e.g.
+  BusinessKey = tostring(<OperationalTable>.Properties.<KeyName>)
+- Use coalesce() for casing/naming variants:
+  BusinessKey = coalesce(
+    tostring(Properties.<KeyName>),
+    tostring(Properties.<keyName>),
+    tostring(Properties.<key_name>))
+
+Join keys:
+- Join <OperationalTable> to <BusinessTable> on <JoinKey> when available.
+- If no direct key exists, correlate within the same 5-minute time bin
+  (correlation, not causality).
+
+Derived analysis entity:
+Create IncidentBin. Each IncidentBin is one 5-minute window and is the unit of
+analysis for rules and alerts.
+
+IncidentBin materialization query (output columns == alert fields):
+<OperationalTable>
+| where <OperationalTimestampColumn> between (datetime(<MinTime>) .. datetime(<MaxTime>))
+| extend BusinessKey = tostring(Properties.<KeyName>)
+| where isnotempty(BusinessKey)
+| join kind=inner (
+    <BusinessTable>
+    | project BusinessKey = tostring(<JoinKey>), <CustomerIdColumn>, <RevenueColumn>
+  ) on BusinessKey
+| summarize
+    ErrorCount             = count(),
+    AffectedCustomers      = dcount(<CustomerIdColumn>),
+    AffectedBusinessRecords = dcount(BusinessKey),
+    RevenueAtRisk          = sum(<RevenueColumn>),
+    TopImpactedEntities    = make_set(<ContextColumn>, 3),
+    TopImpactedSteps       = make_set(<OperationStepColumn>, 3)
+    by IncidentBin = bin(<OperationalTimestampColumn>, 5m)
+
+Metric definitions:
+- ErrorCount = count() of faulted operational events by IncidentBin.
+- AffectedCustomers = dcount(<CustomerIdColumn>) by IncidentBin.
+- AffectedBusinessRecords = dcount(BusinessKey) by IncidentBin.
+- RevenueAtRisk = sum(<RevenueColumn>) by IncidentBin.
+- TopImpactedEntities = make_set(<ContextColumn>, 3) by IncidentBin.
+- TopImpactedSteps = make_set(<OperationStepColumn>, 3) by IncidentBin.
+
+Correlation logic:
+Evaluate each IncidentBin for operational degradation and business impact.
+Use direct joins when verified identifiers exist; otherwise time-window
+correlation (correlation, not causality).
+
+Impact logic:
+Production-like thresholds:
+- ErrorCount increases by more than 20% vs previous-hour baseline.
+- AffectedCustomers >= <configured business threshold>.
+- RevenueAtRisk >= <configured business threshold>.
+POC / debug thresholds (validate Start + Teams alert end-to-end):
+- ErrorCount >= 1
+- ErrorCount >= 5 and AffectedBusinessRecords >= 1
+- AffectedCustomers >= 1
+
+Alert behavior:
+- One alert per 5-minute IncidentBin.
+- Include business context and recommended action.
+
+Output requirements:
+Alert title, incident time window, ErrorCount, AffectedCustomers,
+AffectedBusinessRecords, RevenueAtRisk, TopImpactedEntities, business impact
+summary, recommended action, investigation link if available.
+
+Validation / POC mode:
+Start with POC thresholds to confirm Start runs and a Teams alert arrives, then
+switch to production-like thresholds for steady-state monitoring.
+```
+
+## Creating the agent (optional Stage 16)
+
+Operations Agent is a first-class Fabric item (`type: "OperationsAgent"`), so it
+can be created and populated through documented Fabric item APIs.
+
+> **Auth restriction (verified — MUST check before this stage).** The Create
+> OperationsAgent API supports a **User (delegated) identity only** — **service
+> principal and managed identity are NOT supported**
+> ([Microsoft Learn: Create Operations Agent](https://learn.microsoft.com/en-us/rest/api/fabric/operationsagent/items/create-operations-agent)
+> — Microsoft Entra supported identities: User = Yes, Service principal & Managed
+> identities = No). If the current session is authenticated as a service principal
+> or managed identity, STOP and instruct the user to switch to delegated user auth
+> before creating the agent; the create call will otherwise fail. (The
+> OperationsAgent item is in Preview.)
+
+1. Create the agent item in the target workspace (capture the returned item id).
+2. Read the current definition, set `configuration.instructions` to the Instruction template
+   block, and add the KQL database under `configuration.dataSources` as a
+   `KustoDatabase` entry keyed by a friendly alias; then update the definition.
+   Do **not** include an empty `playbook` object (it fails with "No rule
+   definitions available in the playbook.").
+3. Use the real **KQL database** item id (the `KQLDatabase` item whose display
+   name matches the target Eventhouse — not the `Eventhouse` item).
+
+Note (verified behavior): `updateDefinition` reliably saves the **instructions**
+text, but live **bindings** (`dataSources[].id`, `messageDestination`) may read
+back as placeholders (all-zeros / null) even on `200` — the portal Build page is
+authoritative and typically shows the attached KQL database. Have the user open
+the agent's **Build** page to confirm the Knowledge data source, let the playbook
+generate, then **Save** and **Start**. Teams notifications are a built-in action;
+no custom channel binding is required for basic alerts.
+
+## Validation & troubleshooting
+
+- **"No playbook generated" / "cannot compute X"** → conceptual-only fields, or
+  the incident entity was not materialized as a real schema object. Materialize
+  IncidentBins so its output columns are physical, discoverable columns; add the
+  explicit materialization query (output columns == alert fields), the
+  per-field KQL list, dynamic-field extraction, and concrete join keys; ensure
+  each alert rule references an actual output column. Map specific messages:
+  missing thresholds → add numeric thresholds; missing field mapping → add
+  explicit field definitions; missing customer/entity id → add the identifier
+  mapping; missing join key → specify keys or fall back to 5-minute correlation;
+  missing time column → specify the timestamp columns.
+- **Start succeeds but no Teams alert** → likely no data matched (thresholds too
+  strict for the window). Switch to POC thresholds (`ErrorCount >= 1`, or
+  `ErrorCount >= 5 and AffectedCustomers >= 1`), then restore production
+  thresholds. Do not imply platform failure without evidence.
+
+## Guardrails
+
+- Do not fabricate schema — use placeholders when names are unknown.
+- Confirm business meaning before producing final instructions.
+- Say "correlated", not "caused", when only time-window correlation exists.
+- Do not require the user to know KQL or joins.
+- Only recommend adding Actions when the user needs capabilities beyond the
+  built-in Teams alerts.
+
+
+## External References
+
+### Microsoft Learn
+
+Create and Configure Operations Agents - Microsoft Fabric
+
+https://learn.microsoft.com/en-us/fabric/real-time-intelligence/operations-agent
+
+### Microsoft Community Hub
+
+Microsoft Fabric Operations Agent Step by Step Walkthrough
+
+https://techcommunity.microsoft.com/blog/analyticsonazure/microsoft-fabric-operations-agent-step-by-step-walkthrough/4512572
+
+Use these references when:
+- creating new Operations Agents
+- understanding playbook generation behavior
+- troubleshooting rule generation failures
+- validating expected Operations Agent workflow
+

--- a/skills/check-updates/SKILL.md
+++ b/skills/check-updates/SKILL.md
@@ -1,221 +1,508 @@
 ---
 name: check-updates
 description: >
-  Check for skills-for-fabric marketplace updates at session start. Compares local version 
-  against GitHub releases and shows changelog if updates are available. Use when the 
-  user wants to: (1) check for skill updates, (2) see what's new in skills-for-fabric, 
-  (3) verify current version. Triggers: "check for updates", "am I up to date", 
-  "what version", "update skills", "show changelog".
+  Check an installed skills-for-fabric plugin bundle or git clone for updates,
+  show the matching changelog, and provide host-appropriate update guidance.
+  Use when the user wants to: (1) check for skill updates, (2) see what changed,
+  (3) verify the installed version. Triggers: "check for updates", "am I up to
+  date", "what version", "update skills", "show changelog".
 ---
 
 # Check for Updates
 
-This skill checks for updates to the skills-for-fabric marketplace at the start of each session.
+This is a read-only update checker. It identifies the installation that supplied
+this skill, compares its version with the repository's `main` branch, and shows
+the update path supported by the current agent host. It never updates
+automatically.
 
-## When to Run
+## Cadence
 
-Run this check **once per week** when any skills-for-fabric skill is first invoked. Skip if already checked within the last 7 days.
+Keep these two controls separate:
 
-## Session State
+- **Invocation guard:** Other Fabric skills invoke this skill once per session
+  before continuing.
+- **Network guard:** Automatic invocations perform a remote lookup at most once
+  every 7 days for each detected installation identity.
 
-The update check marker is stored in a **persistent, user-level directory** shared across all sessions and all plugins in the Fabric Skills marketplace:
+If the user's current request directly asks for a version, changelog, or update
+check, treat it as an **explicit invocation** and bypass the 7-day network guard.
+If this skill was invoked only by another skill's session-start notice, treat it
+as an **automatic invocation**.
+
+Always continue with the caller's original task after an automatic invocation,
+including when the check is skipped or fails.
+
+## Procedure
+
+### Step 1: Resolve the Installation Context
+
+Determine one candidate installation root:
+
+1. If the user explicitly supplied an installation path, use that exact path.
+2. Otherwise, start from the active
+   `<skills-root>/check-updates/SKILL.md` file.
+3. When `<skills-root>` is named `skills`, consider its parent as a containing
+   root. Use that containing root only if it has a supported plugin manifest or
+   both `package.json` and a direct `.git` file or directory plus the positive
+   skills-for-fabric Git identity defined below.
+4. Otherwise, use `<skills-root>` as the candidate root. This includes personal
+   copies under `~/.copilot/skills` and `~/.agents/skills`, plus project copies
+   under `.github/skills`, `.agents/skills`, and `.claude/skills`.
+5. If the runtime does not expose the active skill path, report the context as
+   unknown. Do not guess.
+
+Never infer the installation from the shell's current working directory. Never
+walk upward beyond the candidate root. A project containing an unrelated parent
+`.git` directory is not evidence that the skill came from that repository.
+
+Resolve the runtime host independently from the installation channel:
+
+```text
+copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+```
+
+Use the host identity exposed by the current session or runtime. Do not infer it
+from a plugin manifest, install path, or working directory. A deterministic test
+may supply an explicit runtime-host override; normal use may not. If the host
+cannot be established, use `unknown`.
+
+For runtime detection of an already installed plugin, use the first existing
+manifest in this cross-tool precedence:
+
+1. `.plugin/plugin.json`
+2. `plugin.json`
+3. `.github/plugin/plugin.json`
+4. `.claude-plugin/plugin.json`
+
+In this repository, `.github/plugin/plugin.json` is the canonical source
+manifest. `.plugin/plugin.json` and `plugin.json` are compatibility fallbacks
+for other installed layouts or test fixtures. The final location supports
+packages that expose only a Claude-compatible manifest. Do not treat this
+runtime probe order as authoring guidance for this repository.
+
+Then classify the candidate root in this order:
+
+| Channel | Required files at the candidate root | Read |
+|---|---|---|
+| Plugin | one supported plugin manifest | top-level `name`, `version`, `repository` |
+| Git clone | `package.json`, a direct `.git` file or directory, and a positive skills-for-fabric Git identity | top-level `version`, `repository.url` |
+| Copied skills | no plugin or Git layout, plus either a root `SKILL.md` or direct child skill directories containing `SKILL.md` | tentative skill directory names only |
+| Unknown | none of the exact layouts | no identity or update command |
+
+Plugin detection takes precedence if both layouts are present. This lets a
+development fixture retain plugin semantics while using a local Git remote.
+
+A positive Git identity requires both of these checks:
+
+- The final unscoped segment of `package.json` `name` is
+  `skills-for-fabric`. Accepted examples include `skills-for-fabric`,
+  `@microsoft/skills-for-fabric`, and contributor-fork scopes.
+- After removing a trailing slash and `.git`, the final repository path segment
+  is `skills-for-fabric`, compared case-insensitively.
+
+If either check fails, do not promote that containing root to the Git channel
+and do not run Git against it. Continue candidate-root resolution and classify
+the resulting candidate independently; a nested `skills` root may therefore be
+a loose copy. A generic Node repository that happens to contain a `skills/`
+directory is not a skills-for-fabric installation.
+
+A copied channel is terminal until an explicit request confirms its source:
+
+- For an automatic invocation, do not ask a question. Optionally show one short
+  note that the unverified loose copy was skipped and can be checked explicitly,
+  then continue the caller's original task.
+- For an explicit invocation without source confirmation, list the tentative
+  copied skill names, state that source and version are unverified, ask the
+  confirmation question in the copied-channel section, and stop.
+
+Neither path continues to the network guard or remote-version steps.
+
+Build one context object:
+
+```text
+runtimeHost: copilot-cli | claude-code | cursor | windsurf | codex | other | unknown
+channel: plugin | git | copy | unknown
+root: exact candidate root
+installKind: marketplace | direct | none
+installScope: user | project | local | managed | none
+manifestName: plugin manifest name | none
+installedName: marketplace entry name | none
+marketplace: marketplace name | none
+sourceId: direct-install source ID | none
+identity: plugin:<marketplace>/<installed-name> | plugin:direct/<source-id> | git:<repository-url-as-stored>|<root>
+localVersion: manifest version
+repository: URL exactly as stored in the selected manifest
+updateTarget: <installed-name>@<marketplace> | <manifest-name> | <root> | none
+copiedSkills: direct skill directory names | none
+```
+
+For a plugin, keep the manifest name separate from the installed marketplace
+entry name. They can differ. Resolve the installed entry from native runtime
+metadata or the native plugin listing when it identifies the candidate root.
+
+For GitHub Copilot CLI marketplace installs, the documented path is
+`~/.copilot/installed-plugins/<marketplace>/<installed-name>`, so those two path
+segments are authoritative.
+
+For a direct Copilot CLI install at
+`~/.copilot/installed-plugins/_direct/<source-id>`, set `installKind` to
+`direct`, use the source ID only for the cache identity, and use the manifest
+name as the bare update target. `_direct` is not a marketplace name.
+
+For Claude Code marketplace installs, resolve the installed entry and scope from
+Claude's native plugin metadata. `claude plugin list --json` can identify the
+entry; the declaring settings file identifies its scope:
+
+- `~/.claude/settings.json` -> `user`
+- `.claude/settings.json` -> `project`
+- `.claude/settings.local.json` -> `local`
+- managed settings -> `managed`
+
+If the same entry exists at more than one scope, list the choices and ask which
+one to update. Do not guess a scope. A plugin loaded only from a skills
+directory, `--plugin-dir`, or `--plugin-url` has no marketplace install record;
+do not fabricate an update command for it.
+
+If native metadata and the installed path are unavailable, use the manifest
+name with marketplace `fabric-collection` only when the mapping is
+unambiguous. The `fabric-skills` manifest is not unambiguous because the legacy
+`skills-for-fabric` marketplace entry uses the same payload. In that case,
+report that the installed entry could not be resolved, ask the user to inspect
+the native plugin list, and do not guess an identity or update command.
+
+For Git `package.json`, accept either a repository object with a `url` property
+or a repository URL string. Keep the repository value exactly as stored and
+append the exact resolved root when building the cache identity. This prevents
+one clone from suppressing checks for another clone of the same repository.
+When parsing a GitHub owner and repository for remote tools, strip only a
+trailing `.git` and trailing slash. Do not alter owner spelling, case,
+underscores, or punctuation.
+
+Validate that required fields are present and that `localVersion` is semantic
+version text. If validation fails, report the malformed field and classify the
+context as unknown rather than using partial metadata.
+
+### Step 2: Apply the Network Guard
+
+Use an exact cache path supplied by the caller only for a deterministic test.
+Otherwise, use this persistent cache file:
 
 ```text
 ~/.config/fabric-collection/last-update-check.json
 ```
-  
-This file contains a JSON object mapping plugin names to the **UTC date** (YYYY-MM-DD) of their last update check:
+
+On Windows, this is:
+
+```text
+$env:USERPROFILE\.config\fabric-collection\last-update-check.json
+```
+
+The file is a flat JSON object keyed by installation identity:
 
 ```json
 {
-  "fabric-skills": "2026-02-17",
-  "another-plugin": "2026-02-16"
+  "plugin:fabric-collection/fabric-consumption": "2026-07-15",
+  "plugin:direct/github-com-example-skills": "2026-07-15",
+  "git:https://github.com/example/skills-for-fabric.git|C:\\repos\\skills-for-fabric": "2026-07-14"
 }
 ```
 
-Before checking, read `~/.config/fabric-collection/last-update-check.json`:
-- If the file exists and the entry for the current plugin is within the last **7 days** (compared to the current **UTC date**), skip the check.
-- If the file is missing, the plugin entry is absent, or the date is more than 7 days old (compared to the current **UTC date**), run the update check.
+Use UTC dates in `YYYY-MM-DD` format.
 
-> **IMPORTANT — use UTC consistently**: Always use the current UTC date when saving and comparing the last-update-check timestamp. Do not use the local system timezone, as it varies across environments and can cause the check to run too often or be skipped. In shell, use `date -u +%Y-%m-%d` (Linux/macOS) or `(Get-Date).ToUniversalTime().ToString("yyyy-MM-dd")` (PowerShell).
+- For an automatic invocation, skip the remote lookup when this identity has a
+  valid date within the last 7 days.
+- For an explicit invocation, perform the remote lookup even when a fresh cache
+  entry exists.
+- Entries for different installed plugin entries or Git clone roots do not
+  suppress each other.
+- Preserve every unrelated entry when writing the file.
+- If the file contains malformed JSON, warn and do not overwrite it.
+- Do not read or write a cache entry for a copied or unknown context.
 
-> **Note**: Create the `~/.config/fabric-collection/` directory if it does not exist. On Windows, use `$env:USERPROFILE\.config\fabric-collection\`.
+After a remote attempt completes, record today's UTC date for the detected
+identity whether the attempt found an update, found no update, or failed, unless
+the cache file was malformed. This prevents an automatic network failure from
+repeating in every session. Do not rewrite the marker when the network guard
+skipped the attempt.
 
-## Update Check Procedure
+### Step 3: Read the Remote Version
 
-### Step 1: Get Local Version
+Read `package.json` and `CHANGELOG.md` from the same repository and the same
+`main` ref. Try these methods in order and stop after the first successful one:
 
-Read the `version` field from the local plugin manifest. Two install layouts exist:
+1. **Git CLI:** Only when the candidate root itself has a direct `.git` file or
+   directory. Do not use `git rev-parse` as the availability check because it
+   can discover an unrelated parent repository.
 
-- **GitHub Copilot CLI plugin install** (`~/.copilot/installed-plugins/fabric-collection/fabric-skills/`): the manifest is `.github/plugin/plugin.json` — there is no `package.json` here.
-- **Manual git clone**: the manifest is `package.json` at the repo root.
+   ```bash
+   git -C "<root>" fetch origin main --quiet
+   git -C "<root>" show origin/main:package.json
+   git -C "<root>" show origin/main:CHANGELOG.md
+   ```
 
-Read whichever is present. Both files contain a top-level `"version": "<semver>"` field.
+2. **Authenticated GitHub tools:** Use GitHub MCP file tools or `gh api` with
+   the owner and repository parsed exactly from the manifest URL. Read
+   `package.json` and `CHANGELOG.md` at ref `main`.
+3. **Public raw content:** For a public repository, read both files from
+   `https://raw.githubusercontent.com/<owner>/<repo>/main/`.
 
-### Step 2: Determine Repository Owner and Name
+Do not use the latest GitHub Release tag as the remote version. Plugin
+marketplace updates follow repository content, and a release tag can lag behind
+the version available to plugin users.
 
-Read the `repository` field from the same manifest you used in Step 1, and parse the URL to get `owner` and `repo`. The two layouts store the field differently:
+If version retrieval fails, show the detected channel, identity, and local
+version with a concise warning. Do not fabricate a remote version. If only the
+changelog retrieval fails, still report the version comparison and note that
+the changelog was unavailable.
 
-- **Copilot CLI plugin install** (`.github/plugin/plugin.json`) — plain URL string:
-  ```text
-  "repository": "https://github.com/<owner>/<repo>"
-  ```
-- **Manual git clone** (`package.json` at the repo root) — object whose `url` ends with `.git`:
-  ```text
-  "repository": { "type": "git", "url": "https://github.com/<owner>/<repo>.git" }
-  ```
+### Step 4: Compare and Report
 
-There is no bare `plugin.json` at the repo root in either layout, and there is no top-level `package.json` in the Copilot CLI plugin install — always use the path that matches your actual layout.
+Compare semantic versions:
 
-> **CRITICAL**: Use the owner string **exactly as it appears** in the URL. Do NOT alter, normalize, or "correct" the owner name — including underscores, mixed case, or any other punctuation. Whatever the manifest's `repository` URL says, that is the correct owner. (LLMs sometimes "auto-correct" underscores to hyphens — don't.)
+- `remoteVersion > localVersion`: update available.
+- `remoteVersion <= localVersion`: up to date.
 
-### Step 3: Fetch Latest Release
+For an update, show the relevant `CHANGELOG.md` entries between the local and
+remote versions, then provide only guidance verified for both the detected
+channel and `runtimeHost`.
 
-Use the available tools in your environment to get the latest version. **Try methods in strict order — only fall back to the next method if the previous one fails or is unavailable.**
+**Plugin channel**
 
-> **IMPORTANT**: Methods A and B work with both public and private repositories. Method C only works with public repos. Always attempt A or B first.
+Never emit one host's plugin command for another host.
 
-**Method A — Git CLI (preferred for git-clone installs)**
+| Runtime host | Verified guidance |
+|---|---|
+| GitHub Copilot CLI | For a marketplace install, show `/plugin update <installed-name>@<marketplace>`. For a direct install, show `/plugin update <manifest-name>`. |
+| Claude Code | For a marketplace install with a resolved scope, show `claude plugin update <installed-name>@<marketplace> --scope <scope>`, then tell the user to run `/reload-plugins` or restart Claude Code. |
+| Cursor | Direct the user to **Customize > Plugins**. For a team marketplace, an administrator can use **Refresh** or **Enable Auto Refresh**. Do not emit a plugin CLI command. |
+| Windsurf, Codex, other, or unknown | Report the available version and repository, but provide no executable plugin command because none is verified for this layout. |
 
-Only available if the skills-for-fabric directory is a Git working tree (i.e. it has a `.git` entry — either a directory in a normal clone, or a file in a worktree/submodule). The Copilot CLI plugin install at `~/.copilot/installed-plugins/fabric-collection/fabric-skills/` has no `.git` entry — for that install layout, skip to Method B. If you want a tool-agnostic check, run `git rev-parse --is-inside-work-tree` and only proceed if it prints `true`.
-
-If you do have a Git clone, fetch the remote `package.json` without pulling:
-
-```bash
-git fetch origin main --quiet
-git show origin/main:package.json
-```
-
-Extract the `version` field from the JSON output. This method is the most reliable because it uses the already-configured remote URL and authentication, and avoids any owner/repo name parsing.
-
-**Method B — GitHub MCP tools (preferred for agentic environments)**
-
-If you have access to GitHub MCP server tools (e.g., `get_file_contents`), use them to read the remote `package.json`. Use the owner and repo extracted in Step 2 **exactly as parsed** (do not modify the strings):
-
-```text
-get_file_contents(owner: "<owner>", repo: "<repo>", path: "package.json")
-```
-
-Extract the `version` field from the response. This method works with private repositories because MCP tools use authenticated GitHub access.
-
-**Method C — GitHub REST API (fallback only, public repos)**
-
-> ⚠️ **Only use this method if Methods A and B both fail or are unavailable.** This method does not work with private repositories.
-
-If the repository is public, make a GET request using the owner/repo from Step 2:
-
-```text
-GET https://api.github.com/repos/<owner>/<repo>/releases/latest
-```
-
-Extract the `tag_name` field (e.g., `v0.2.0`) and remove the `v` prefix.
-
-> **Note**: This method returns 404 for private repositories. If you receive a 404 error, do NOT assume the repository doesn't exist — retry with Method A or B.
-
-### Step 4: Compare Versions
-
-Compare the local version with the remote version using semantic versioning:
-- If remote > local: Update available
-- If remote <= local: Up to date
-
-### Step 5: Display Results
-
-#### If Up to Date
-
-Show a brief confirmation and proceed:
-```text
-✅ skills-for-fabric v0.1.0 is up to date.
-```
-
-#### If Update Available
-
-Show detailed information:
+GitHub Copilot CLI marketplace install:
 
 ```text
-╔══════════════════════════════════════════════════════════════════╗
-║  🔄 skills-for-fabric Update Available                                ║
-║                                                                  ║
-║  Current: v0.1.0  →  Latest: v0.2.0                             ║
-╚══════════════════════════════════════════════════════════════════╝
-
-## What's New in v0.2.0
-
-[Display relevant CHANGELOG.md entries here]
-
-## Update Commands
-
-Choose the update method based on how you installed skills-for-fabric.
-
-### GitHub Copilot CLI (recommended)
-/plugin update fabric-skills@fabric-collection
-
-If you originally installed the plugin under the legacy id, this also works:
-  /plugin update skills-for-fabric@fabric-collection
-
-The plugin was renamed in 0.3.0 (skills-for-fabric → fabric-skills),
-but the legacy id is kept as a deprecated alias of fabric-skills, so
-either /plugin update command pulls the canonical payload.
-
-(Optional cleanup) To migrate your installed entry from the legacy id
-to the canonical fabric-skills id:
-  /plugin uninstall skills-for-fabric@fabric-collection
-  /plugin install fabric-skills@fabric-collection
-
-### Manual (Git clone)
-cd /path/to/skills-for-fabric
-git pull
-
-(There are no installation scripts to re-run on 0.3.0+.)
-
-─────────────────────────────────────────────────────────────────
-Would you like to update now? (The current skill will still work)
+/plugin update <installed-name>@<marketplace>
 ```
 
-### Step 6: Set Update Marker
+The installed marketplace entry is authoritative. For example, an installed
+`fabric-consumption@fabric-collection` entry produces:
 
-After completing the check (regardless of result), update `~/.config/fabric-collection/last-update-check.json` with today's **UTC date** (YYYY-MM-DD) for the current plugin. Create the directory and file if they don't exist. Preserve entries for other plugins already in the file.
+```text
+/plugin update fabric-consumption@fabric-collection
+```
+
+If the installed entry is the legacy `skills-for-fabric` alias, update that
+alias first so the installed entry can receive the current payload, even though
+its copied manifest is named `fabric-skills`:
+
+```text
+/plugin update skills-for-fabric@fabric-collection
+```
+
+Afterward, optional migration to the canonical entry is:
+
+```text
+/plugin uninstall skills-for-fabric@fabric-collection
+/plugin install fabric-skills@fabric-collection
+```
+
+GitHub Copilot CLI direct install:
+
+```text
+/plugin update <manifest-name>
+```
+
+The native CLI update target for a direct install is the bare manifest name.
+Do not append `@_direct` or use the opaque source ID as the update target.
+
+Claude Code marketplace install:
+
+```text
+claude plugin update <installed-name>@<marketplace> --scope <scope>
+```
+
+The entry name and scope must come from Claude's installed-plugin metadata. Do
+not reuse Copilot's `_direct` behavior for Claude Code.
+
+**Git channel**
+
+```text
+git -C "<detected-root>" pull --ff-only
+```
+
+**Unknown channel**
+
+State which expected files were absent and provide no update command. Never
+default to `fabric-skills`.
+
+**Copied-skill channel**
+
+A loose copy has no trustworthy repository, installed version, or native update
+target. This includes a skill materialized from a local file or URL by
+`copilot skill add` when no source metadata accompanies it.
+
+For an automatic invocation, do not interrupt the caller with a source question.
+Skip the copied-skill update flow, optionally state that an explicit update
+check can identify a supported replacement, and continue the caller's task.
+Do not list an executable command.
+
+For an explicit invocation, list the tentative skill names found at the
+candidate root, state that their provenance cannot be verified from the files
+alone, and ask:
+
+```text
+Were these skills copied from https://github.com/microsoft/skills-for-fabric?
+If yes, I can inspect the official public repository and show the supported
+plugin bundle that will refresh them. I will not install or remove anything
+without your confirmation.
+```
+
+Before the user confirms the source, do not contact the network, compare
+versions, write cache state, or offer an executable install/update command.
+
+After explicit confirmation:
+
+1. Read `.github/plugin/marketplace.json` from the `main` ref of
+   `microsoft/skills-for-fabric`, using authenticated GitHub tools first and
+   public raw content second.
+2. Match the tentative skill directory names against the skill paths inside
+   each marketplace plugin source. Treat only exact path matches as evidence.
+3. Prefer a focused plugin that covers all matched non-utility skills. If more
+   than one plugin qualifies, list the valid choices and ask the user to choose.
+   Never choose `fabric-skills` merely because `check-updates` appears in it.
+4. Offer only the replacement path supported by `runtimeHost`:
+
+   GitHub Copilot CLI:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   /plugin install <matched-plugin>@fabric-collection
+   ```
+
+   Claude Code, using `user` for a personal copied-skills root or `project` for
+   a project copied-skills root:
+
+   ```text
+   /plugin marketplace add microsoft/skills-for-fabric
+   claude plugin install <matched-plugin>@fabric-collection --scope <scope>
+   ```
+
+   Tell the user to run `/reload-plugins` or restart Claude Code after the
+   install. If the Claude scope cannot be resolved, ask instead of guessing.
+
+   For Cursor, Windsurf, Codex, other, or unknown hosts, link to the official
+   repository's installation instructions and provide no executable replacement
+   command. The current public repository does not expose a verified native
+   plugin marketplace for those hosts.
+
+This installs a complete current bundle instead of overwriting loose files and
+leaving mixed-version dependencies. Keep the loose copy until the native plugin
+is installed and verified. Ask separately before removing it. If no exact
+official mapping exists or the public repository is unavailable, report that
+and do not fabricate a bundle or copy individual files.
+
+## Examples
+
+### Focused plugin bundle
+
+```text
+Host: copilot-cli
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: /plugin update fabric-consumption@fabric-collection
+```
+
+### Claude Code plugin bundle
+
+```text
+Host: claude-code
+Detected: plugin:fabric-collection/fabric-consumption
+Current: 0.3.7
+Latest: 0.3.8
+Update: claude plugin update fabric-consumption@fabric-collection --scope user
+Reload: /reload-plugins
+```
+
+### Git clone
+
+```text
+Detected: git:https://github.com/example/skills-for-fabric.git|C:\repos\skills-for-fabric
+Current: 0.3.7
+Latest: 0.3.8
+Update: git -C "C:\repos\skills-for-fabric" pull --ff-only
+```
+
+### Unknown layout
+
+```text
+Could not determine the skills-for-fabric installation at <candidate-root>.
+Expected a supported plugin manifest, or a positively identified
+skills-for-fabric package.json plus a direct .git entry.
+No update command was guessed.
+```
+
+### Confirmed official loose copy
+
+```text
+Host: copilot-cli
+Detected loose skills: check-updates, powerbi-report-planning
+Confirmed source: https://github.com/microsoft/skills-for-fabric
+Supported refresh:
+  /plugin marketplace add microsoft/skills-for-fabric
+  /plugin install powerbi-authoring@fabric-collection
+The loose files were not changed or removed.
+```
 
 ## Must
 
-- Check for updates only once per week (based on UTC calendar date, not session lifetime or local timezone)
-- Always proceed with the requested skill after the check (non-blocking)
-- Handle network errors gracefully (show warning, continue with skill)
-- Display the CHANGELOG.md content for versions between current and latest
+- Resolve identity from the active skill root or an explicit user path.
+- Resolve the runtime host independently from the installation layout.
+- Keep once-per-session invocation separate from the 7-day network guard.
+- Use the installed marketplace entry, not merely the manifest name, in plugin
+  identities and update commands.
+- Keep direct installs distinct from marketplace installs.
+- Require positive package and repository identity before using the Git channel.
+- Isolate Git cache entries by repository and exact clone root.
+- Preserve unrelated cache entries and use UTC dates.
+- Require source confirmation before looking up a loose copy in the official
+  public repository.
+- Match copied skill names to exact public marketplace skill paths.
+- Emit only update or replacement commands verified for the runtime host.
+- Continue non-blockingly after automatic checks.
 
 ## Prefer
 
-- Use Git CLI (Method A) or GitHub MCP tools (Method B) for version checking — these work with private repos
-- Fall back to the public GitHub REST API (Method C) **only** if Methods A and B both fail
-- Show a concise summary rather than overwhelming detail
-- Cache the check result in `~/.config/fabric-collection/last-update-check.json`
-- Provide copy-pasteable update commands
+- Use a root-local Git remote before authenticated GitHub tools.
+- Fetch version and changelog from the same repository ref.
+- Replace confirmed official loose copies through a complete native plugin
+  bundle rather than overwriting individual files.
+- Show concise, copy-pasteable output.
 
 ## Avoid
 
-- Blocking the user from using skills if update check fails
-- Checking on every skill invocation (once per week is sufficient)
-- Attempting Method C (public API) before trying Methods A or B
-- Relying solely on unauthenticated public API calls (will fail for private repos)
-- Auto-updating without user consent
+- Inferring installation context from the current working directory.
+- Letting `git` discover a parent repository.
+- Treating an unrelated package plus `.git` as a skills-for-fabric clone.
+- Inferring the runtime host from a manifest or install path.
+- Showing Copilot or Claude plugin commands to another host.
+- Defaulting focused bundles to `fabric-skills`.
+- Using GitHub Release tags as the plugin marketplace version.
+- Repeating failed automatic network checks every session.
+- Treating a same-named loose folder as proof that it came from the official
+  repository.
+- Replacing individual copied files without their complete bundle dependencies.
+- Updating without explicit user consent.
 
 ## Error Handling
 
-If the update check fails (network error, API rate limit, etc.):
+On failure, report the operation that failed and continue:
 
 ```text
-⚠️ Could not check for skills-for-fabric updates (network error).
-   Continuing with current version (v0.1.0).
-   Run '/skill check-updates' manually to retry.
+Could not check plugin:fabric-collection/fabric-consumption for updates: remote package.json was unavailable.
+Current installed version: 0.3.7
+The automatic check is non-blocking; continuing with the requested task.
 ```
 
-## Manual Invocation
-
-Users can manually check for updates at any time:
-- GitHub Copilot CLI: `/skill check-updates`
-- Other tools: Invoke the check-updates skill directly
-
-## Reference
-
-- **GitHub Repository**: https://github.com/microsoft/skills-for-fabric
-- **Releases**: https://github.com/microsoft/skills-for-fabric/releases
-- **CHANGELOG**: See `CHANGELOG.md` in repository root
+If the user says only "update my skills", clarify whether they want to check for
+an update or execute the detected native update command. Do not execute an
+update based on ambiguous intent.

--- a/skills/databricks-migration/SKILL.md
+++ b/skills/databricks-migration/SKILL.md
@@ -2,7 +2,7 @@
 name: databricks-migration
 description: >
   Port Databricks notebooks and jobs to Microsoft Fabric. Provides an exhaustive dbutils
-  to notebookutils substitution table: fs operations (mount removal via OneLake Shortcuts),
+  to notebookutils substitution table: fs operations (runtime mounts or OneLake Shortcuts),
   secret scope to Key Vault URL conversion, notebook run and exit, widget replacement with
   parameter-tagged cells, and library install replacement with Fabric Environments.
   Covers Unity Catalog three-level namespace reduction to Lakehouse two-level schemas,
@@ -24,9 +24,11 @@ description: >
 > **CRITICAL NOTES**
 > 1. To find workspace details (including its ID) from a workspace name: list all workspaces, then use JMESPath filtering
 > 2. To find item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace, then use JMESPath filtering
-> 3. `dbutils.widgets` has **no direct equivalent** in Fabric — use notebook parameters (cell tag `parameters`) or `notebookutils.runtime.context` for context injection
+> 3. `dbutils.widgets` has **no direct equivalent** in Fabric — use notebook parameters (cell tag `parameters`); `notebookutils.runtime.context` is execution metadata, not parameter storage. If showing context fields, use documented names such as `currentWorkspaceId`, `currentWorkspaceName`, `currentNotebookId`, `currentNotebookName`, `isForPipeline`, and `isForInteractive`; `activityId` is the Livy job ID
 > 4. `dbutils.library` (runtime library install) has **no equivalent** — use Fabric Environments for reproducible library management
 > 5. Unity Catalog uses a 3-level namespace (`catalog.schema.table`); Fabric Lakehouse uses 2-level (`schema.table` within a named Lakehouse)
+> 6. For an under-specified workspace-wide migration, ask focused questions about inventory, workload topology, security, data locations, and runtime constraints before recommending a Fabric topology
+> 7. A completed Fabric migration must not retain executable `dbutils.*` calls in dual-runtime branches or `try/except` guards — replace the calls and Databricks paths outright
 
 # Databricks → Microsoft Fabric Migration
 
@@ -53,7 +55,7 @@ For Fabric Warehouse DDL/DML authoring, see [sqldw-authoring-cli](../sqldw-autho
 | Before/After Code Patterns | [code-patterns.md](resources/code-patterns.md) |
 | Cluster Config → Fabric Spark Pools | [§ Cluster Config → Fabric Spark Pools](#cluster-config--fabric-spark-pools) |
 | Databricks Jobs → Spark Job Definitions | [§ Databricks Jobs → Spark Job Definitions](#databricks-jobs--spark-job-definitions) |
-| Delta Sharing → OneLake Shortcuts | [§ Delta Sharing → OneLake Shortcuts](#delta-sharing--onelake-shortcuts) |
+| Delta Sharing → Fabric External Data Sharing and OneLake Shortcuts | [§ Delta Sharing → Fabric External Data Sharing and OneLake Shortcuts](#delta-sharing--fabric-external-data-sharing-and-onelake-shortcuts) |
 | MLflow → Fabric ML Experiments | [§ MLflow → Fabric ML Experiments](#mlflow--fabric-ml-experiments) |
 | Must / Prefer / Avoid | [§ Must / Prefer / Avoid](#must--prefer--avoid) |
 | Authentication & Token Acquisition | [COMMON-CORE.md § Authentication](../../common/COMMON-CORE.md#authentication--token-acquisition) |
@@ -73,7 +75,7 @@ For Fabric Warehouse DDL/DML authoring, see [sqldw-authoring-cli](../sqldw-autho
 | **Delta Live Tables (DLT)** | **Fabric Notebooks** + **Data Pipelines** | No DLT equivalent — rewrite DLT datasets as parameterized notebook cells with pipeline orchestration |
 | **Databricks SQL Warehouses** | **Fabric Warehouse** or **Lakehouse SQL Endpoint** | SQL warehouse sessions → Warehouse (for write) or SQL Endpoint (for read-only) |
 | **MLflow Tracking** | **Fabric ML Experiments** | MLflow SDK is supported in Fabric — see [§ MLflow](#mlflow--fabric-ml-experiments) |
-| **Delta Sharing** | **OneLake Shortcuts** + **Fabric external data sharing** | See [§ Delta Sharing → OneLake Shortcuts](#delta-sharing--onelake-shortcuts) |
+| **Delta Sharing** | **OneLake Shortcuts** + **Fabric external data sharing** | See [§ Delta Sharing → Fabric External Data Sharing and OneLake Shortcuts](#delta-sharing--fabric-external-data-sharing-and-onelake-shortcuts) |
 | **Databricks Feature Store** | **Fabric Feature Store** (preview) | Direct conceptual equivalent; APIs differ |
 | **dbutils** (all sub-modules) | **`notebookutils`** (most sub-modules) | See [dbutils-to-notebookutils.md](resources/dbutils-to-notebookutils.md) for full mapping |
 
@@ -145,14 +147,16 @@ The complete side-by-side API table is in [dbutils-to-notebookutils.md](resource
 
 ---
 
-## Delta Sharing → OneLake Shortcuts
+## Delta Sharing → Fabric External Data Sharing and OneLake Shortcuts
 
 | Databricks Delta Sharing Pattern | Fabric Equivalent |
 |---|---|
-| Provider publishes a Delta share | Fabric **external data sharing** (preview) or OneLake Shortcut to ADLS Gen2 where Delta data resides |
-| Recipient reads shared data | Create a **OneLake Shortcut** pointing to the ADLS Gen2 Delta table; access via Lakehouse |
+| Provider publishes a Delta share | Fabric **external data sharing** for cross-tenant Fabric data, or a OneLake Shortcut to ADLS Gen2 where the Delta data resides |
+| Recipient reads shared data | Accept the external data share into a Lakehouse (Fabric creates a read-only OneLake Shortcut), or create a direct **OneLake Shortcut** to accessible ADLS Gen2 data |
 | Cross-workspace table sharing within org | **OneLake Shortcuts** pointing to another workspace's Lakehouse tables — no data copy |
-| Cross-tenant sharing | Fabric **external data sharing** (GA roadmap) — use ADLS Gen2 shortcut as interim |
+| Cross-tenant sharing | Fabric **external data sharing** — live, read-only, in-place access through a shortcut in the recipient tenant |
+
+When producing a migration workload map, include both paths: direct OneLake Shortcuts for accessible ADLS or same-tenant OneLake data, and Fabric external data sharing for native cross-tenant recipient sharing.
 
 ---
 
@@ -175,6 +179,7 @@ Fabric ML Experiments are built on the MLflow SDK — most code is directly port
 ## Must / Prefer / Avoid
 
 ### MUST DO
+- **Inventory before prescribing a workspace topology** — for workspace-wide requests that omit workload inventory, dependencies, security requirements, data locations, or runtime constraints, ask focused clarifying questions and present conditional choices before selecting a Fabric design
 - **Replace all `dbutils.*` calls** using the mapping in [dbutils-to-notebookutils.md](resources/dbutils-to-notebookutils.md) — `dbutils` is not available in Fabric notebooks
 - **Migrate `dbutils.fs.mount()` to `notebookutils.fs.mount()`** (✅ supported — Microsoft Entra default, or `accountKey` / `sasToken` from Key Vault). For cross-workspace or persistent sharing, prefer **OneLake Shortcuts** instead. Always pair `mount()` with `unmount()` in `try/finally` — Fabric mounts are not released automatically on session end
 - **Replace `dbutils.secrets.get(scope, key)`** with `notebookutils.credentials.getSecret(keyVaultUrl, secretName)` — secret scopes map to Azure Key Vault URLs
@@ -192,7 +197,9 @@ Fabric ML Experiments are built on the MLflow SDK — most code is directly port
 - **Starter Pool** for migrating interactive notebook workflows — eliminates cluster startup time that was a common pain point in Databricks job clusters
 
 ### AVOID
-- **Do not import `dbutils` or attempt `dbutils = ...` assignments** in Fabric notebooks — this will raise `NameError`; always use `notebookutils`
+- **Do not prescribe a one-size-fits-all workspace topology** when the source inventory and migration constraints are missing
+- **Do not import `dbutils` or attempt `dbutils = ...` assignments** in Fabric notebooks — import attempts fail with `ModuleNotFoundError`, while unresolved `dbutils` references raise `NameError`; always use `notebookutils`
+- **Do not retain `dbutils.*` calls behind runtime-detection guards** (`try/except`, `if IS_DATABRICKS`) — replace the calls and Databricks paths outright with `notebookutils` and Fabric paths
 - **Do not assume Unity Catalog governance policies transfer automatically** — RBAC, row-level security, and column masking must be reconfigured in Fabric using workspace roles and Lakehouse permissions
 - **Do not use `%pip install` in production Fabric notebooks** at runtime — use Fabric Environments for stable, versioned library management
 - **Do not attempt to port Delta Live Tables (DLT) pipelines verbatim** — DLT has no Fabric equivalent; rewrite as parameterized notebooks orchestrated by Fabric Pipelines

--- a/skills/databricks-migration/resources/code-patterns.md
+++ b/skills/databricks-migration/resources/code-patterns.md
@@ -125,15 +125,15 @@ environment = dbutils.widgets.get("environment")
 
 # AFTER — Fabric: use a "parameters" tagged cell
 # Tag the cell below as "parameters" in the notebook UI
+# Pipeline Base parameters or parent-notebook arguments override these defaults
+# by injecting the runtime values into a generated cell.
 batch_date = "2024-01-01"   # overridden by pipeline or parent notebook at runtime
 environment = "dev"
-
-# Read pipeline-injected values programmatically (if needed):
-ctx = notebookutils.runtime.context
-params = ctx.get("parameters", {})
-batch_date = params.get("batch_date", "2024-01-01")
-environment = params.get("environment", "dev")
 ```
+
+`notebookutils.runtime.context` contains execution metadata such as workspace,
+notebook, activity, and user identifiers. It does **not** store notebook
+parameter values; use the variables overridden from the marked parameters cell.
 
 ---
 

--- a/skills/dataflows-authoring-cli/SKILL.md
+++ b/skills/dataflows-authoring-cli/SKILL.md
@@ -1,22 +1,21 @@
 ---
 name: dataflows-authoring-cli
 description: >
-  Create, update, delete, and refresh Fabric Dataflows Gen2 via write-side CLI
-  against Fabric Items and Connections APIs. Builds mashup.pq + queryMetadata
-  definitions, triggers parameterized refreshes, manages connections, and
-  configures output destinations (Lakehouse, Warehouse, ADX, Azure SQL).
-  Includes preview-driven authoring loop (executeQuery + customMashupDocument).
-  Lists `supportedConnectionTypes`/`credentialType` per connector.
-  For executing saved queries or reading refresh status, use
-  `dataflows-consumption-cli`.
-  Triggers: "create dataflow", "update dataflow", "delete dataflow",
-  "trigger dataflow refresh", "refresh dataflow", "preview Power Query M",
-  "preview mashup", "preview before save", "iterate dataflow M",
-  "create Fabric data source connection", "create dataflow connection",
-  "bind connection", "list supportedConnectionTypes",
-  "dataflow output destination", "dataflow write to lakehouse",
-  "dataflow write to warehouse", "dataflow write to ADX",
-  "DataDestinations annotation".
+  Create, update, delete, and refresh Fabric Dataflows Gen2 with write-side CLI
+  via Fabric APIs. Build mashup.pq and queryMetadata.json,
+  preview candidate M with executeQuery/customMashupDocument, bind connections,
+  and configure output destinations. For saved
+  query execution or refresh-status reads, use `dataflows-consumption-cli`. If
+  a request explicitly insists on the Dataflows consumption or read-only path
+  for a mutation, do not route here; let consumption refuse before any
+  separately confirmed authoring handoff. Triggers: "create dataflow", "update
+  dataflow", "delete dataflow", "trigger dataflow refresh", "preview Power
+  Query M", "preview before save", "customMashupDocument", "create Fabric data
+  source connection", "create SQL Server source REST", "POST /v1/connections",
+  "supportedConnectionTypes", "passwordReference", "bind
+  connection", "dataflow output destination", "dataflow write to lakehouse",
+  "dataflow write to warehouse", "dataflow write to ADX", "DataDestinations
+  annotation".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -28,6 +27,16 @@ description: >
 > **CRITICAL NOTES**
 > 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering
 > 2. To find the item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace and, then, use JMESPath filtering
+
+> **PRE-MUTATION REQUIREMENTS GATE (mandatory)**
+> Before any mutation, confirm enough user intent for the requested operation.
+> For create or update requests, establish the source, query/schema and
+> transformation, destination behavior, and refresh behavior (including an
+> explicit choice of no destination or no refresh). If the request is generic,
+> such as "set up the Dataflow I need for reporting," ask a structured
+> clarifying question and stop before mutation. Do not infer requirements from
+> unrelated workspace items or create a best-guess source, connection, or
+> Dataflow.
 
 # dataflows-authoring-cli — Dataflows Gen2 Authoring via CLI
 
@@ -52,7 +61,7 @@ description: >
 | [authoring-cli-quickref.md](references/authoring-cli-quickref.md) | One-liner recipes, status enums, base64 helpers, connection-binding quick patterns |
 | [authoring-script-templates.md](references/authoring-script-templates.md) | Full bash + PowerShell templates; end-to-end smoke test; LRO polling pattern |
 | [connection-management.md](references/connection-management.md) | List/create/inspect connections; `supportedConnectionTypes`; resolve `ClusterId`; ID format cheat sheet |
-| [connectors.md](references/connectors.md) | M-side source connectors: live-verified function inventory, Lakehouse deep navigation, runtime-disabled functions (`Web.Page`, `Web.BrowserContents`), `Html.Table` / `Csv.Document` / `Json.Document` patterns |
+| [connectors.md](references/connectors.md) | M-side source connectors: live-verified function inventory, Lakehouse deep navigation, gateway scope for `Web.Page` / `Web.BrowserContents`, and `Html.Table` / `Csv.Document` / `Json.Document` patterns |
 | [m-language.md](references/m-language.md) | M language semantics for Dataflow Gen2: `try` record shapes, per-cell error wrapping in column transforms, `each` scoping in row vs sub-table contexts, optional field access `[?]` / `Record.FieldOrDefault`, quoted identifiers, sandbox-disabled symbols (`File.Contents`) |
 | [mashup-preview.md](references/mashup-preview.md) | `executeQuery` contract: bootstrap branch, auto-wrap rule, hard avoid for unbounded preview |
 | [output-destinations.md](references/output-destinations.md) | Output destination patterns: Lakehouse Table, Lakehouse Files, Warehouse, ADX, Azure SQL. `DataDestinations` annotation, hidden query, `loadEnabled` rules, connection limitations |

--- a/skills/dataflows-authoring-cli/references/connectors.md
+++ b/skills/dataflows-authoring-cli/references/connectors.md
@@ -27,18 +27,28 @@ All functions below have their symbol registered in the Fabric mashup engine (`V
 | `Snowflake.Databases`, `AzureStorage.DataLake`, `Excel.Workbook` | 🔑 Symbol present; not exercised end-to-end here |
 | `Html.Table`, `Csv.Document`, `Json.Document`, `Lines.FromBinary`, `#table` | ✅ Pure parsers — no binding — see [Pure-data parsers](#pure-data-parsers) |
 | `Variable.Value` | 🔑 Symbol present; requires a Variable Library on the dataflow — see [Variable.Value](#variablevalue) |
-| `Web.Page`, `Web.BrowserContents` | ❌ Disabled at runtime — see [Runtime-disabled functions](#runtime-disabled-functions) |
+| `Web.Page`, `Web.BrowserContents` | Gateway-backed in cloud dataflows; disabled in the direct `executeQuery` runtime tested here - see [Browser functions and gateway scope](#browser-functions-and-gateway-scope) |
 
 Full enumeration at runtime via [`#shared`](#shared).
 
-## Runtime-disabled functions
+## Browser functions and gateway scope
+
+Microsoft Learn documents `Web.Page` and `Web.BrowserContents` as available in
+cloud dataflows through an on-premises data gateway. See
+[Using a gateway with the Web connector](https://learn.microsoft.com/en-us/power-query/connectors/web/web-troubleshoot#using-a-gateway-with-the-web-connector).
+
+The direct, gateway-free `executeQuery` runtime probed for this skill returned
+the following errors, even for inline literals:
 
 | Function | Verbatim engine error |
 |---|---|
 | `Web.BrowserContents` | `The module named 'WebBrowserContents' has been disabled in this context.` |
 | `Web.Page` | `The module named 'Html' has been disabled in this context.` |
 
-Both fail even on inline literals (no network or credential dependency). For HTML parsing in Fabric Dataflow Gen2 use [`Html.Table`](#pure-data-parsers) — different module, fully enabled.
+For gateway-free authoring and preview, use `Web.Contents` plus
+[`Html.Table`](#pure-data-parsers). If browser rendering is required, use a
+gateway-backed Web connection and validate through the supported cloud-dataflow
+path rather than direct `executeQuery`.
 
 ## Lakehouse navigation
 
@@ -220,7 +230,7 @@ Without it the privacy firewall blocks evaluation when two or more sources are r
 ### MUST
 
 1. **Match the M function kind to the binding kind.** REST casing differs (REST `"SQL"` ↔ M `Sql.Database`) — see [connection-management.md § Step 1](connection-management.md#step-1--list-supported-connection-types).
-2. **Use `Html.Table` for HTML parsing.** `Web.Page` and `Web.BrowserContents` are disabled at runtime.
+2. **Use `Html.Table` for gateway-free HTML parsing.** `Web.Page` and `Web.BrowserContents` require an on-premises gateway in cloud dataflows and are disabled in the direct `executeQuery` runtime tested here.
 3. **For combined-source documents, add `[AllowCombine = true]`** before `section Section1;`.
 4. **Decode the Arrow stream and inspect `PQ Arrow Metadata`** when reading `executeQuery` results — 200 OK is not success.
 
@@ -232,8 +242,8 @@ Without it the privacy firewall blocks evaluation when two or more sources are r
 
 ### AVOID
 
-1. **`Web.BrowserContents`** — `module 'WebBrowserContents' has been disabled`.
-2. **`Web.Page`** — `module 'Html' has been disabled`.
+1. **`Web.BrowserContents` in direct `executeQuery`** - use a gateway-backed Web connection when browser rendering is required.
+2. **`Web.Page` in direct `executeQuery`** - use a gateway-backed Web connection when the legacy browser function is required.
 3. **`Sql.Database("server")`** (1-arg form) — engine rejects with arity error. Always supply the database name.
 4. **`{[Id="Tables"]}` at the lakehouse-`[Data]` level** — there is no `Tables` folder; tables are listed directly. (`{[Id="Files"]}` IS valid — it's the only folder entry.)
 

--- a/skills/dataflows-authoring-cli/references/m-language.md
+++ b/skills/dataflows-authoring-cli/references/m-language.md
@@ -165,7 +165,7 @@ Use the record form when downstream code (`try ... otherwise` chains, `Table.Rep
 Credentials are required to connect to the File source. (Source at <path>.)
 ```
 
-There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a Lakehouse, Warehouse, OData feed, or `Web.Contents` instead — see [connectors.md § Function inventory](connectors.md#function-inventory). For runtime-disabled `Web.Page` / `Web.BrowserContents`, see [connectors.md § Runtime-disabled functions](connectors.md#runtime-disabled-functions).
+There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a Lakehouse, Warehouse, OData feed, or `Web.Contents` instead -- see [connectors.md Function inventory](connectors.md#function-inventory). For the gateway and direct-`executeQuery` boundary of `Web.Page` / `Web.BrowserContents`, see [connectors.md Browser functions and gateway scope](connectors.md#browser-functions-and-gateway-scope).
 
 ## MUST / PREFER / AVOID
 
@@ -184,7 +184,7 @@ There is no File credential type for Fabric Dataflow Gen2 cloud refresh. Use a L
 **AVOID**
 
 1. Treating an Arrow-null cell value as "the column has nulls" without testing — it may be an errored cell. Probe with `try Conv{i}[Col]` to disambiguate.
-2. `File.Contents`, `Web.Page`, `Web.BrowserContents` — see [§ `File.Contents`](#filecontents--exposed-but-unusable) and [connectors.md § Runtime-disabled functions](connectors.md#runtime-disabled-functions).
+2. `File.Contents`, plus `Web.Page` / `Web.BrowserContents` in direct `executeQuery` - see [`File.Contents`](#filecontents--exposed-but-unusable) and [connectors.md Browser functions and gateway scope](connectors.md#browser-functions-and-gateway-scope).
 3. Discriminating on `Error.Reason` without setting it explicitly. Both built-in errors and `error "msg"` use `Reason = "Expression.Error"`. For custom reasons use the record form: `error [Reason = "...", Message = "..."]`.
 
 ## See also

--- a/skills/dataflows-consumption-cli/SKILL.md
+++ b/skills/dataflows-consumption-cli/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: dataflows-consumption-cli
 description: >
-  Monitor, inspect, and query saved Fabric Dataflows Gen2 via read-only CLI.
-  List dataflows, decode base64 definitions (mashup.pq, queryMetadata.json,
-  .platform), discover parameters, retrieve refresh status and job history,
-  classify queries by staging, and execute queries against saved dataflows via
-  the read-side `executeQuery` mashup engine (Arrow IPC response). Runs
-  persisted or ad-hoc read-only executeQuery requests; parses/renders Arrow
-  results. For previewing
-  candidate M before persisting, or for `supportedConnectionTypes`/`credentialType`
-  discovery and connection configuration, use `dataflows-authoring-cli`
-  (not this skill).
-  Triggers: "list dataflows", "inspect dataflow", "decode dataflow definition",
-  "dataflow parameters", "dataflow refresh status", "refresh history",
+  Monitor, inspect, and query saved Fabric Dataflows Gen2 with read-only CLI.
+  List dataflows, decode mashup.pq/queryMetadata.json/.platform, inspect parameters,
+  refresh status, job history, staging, and destinations, or run saved/ad-hoc
+  read-only executeQuery requests and parse Arrow. Handle explicit
+  requests to mutate through the Dataflows consumption or read-only path by
+  refusing the write; offer `dataflows-authoring-cli` only after separate
+  confirmation. For candidate M before persistence or connection configuration, use
+  `dataflows-authoring-cli`. Triggers: "list dataflows", "inspect dataflow",
+  "decode dataflow definition", "dataflow parameters", "refresh history",
   "last refresh status", "dataflow job history", "execute dataflow query",
-  "executeQuery saved query", "executeQuery fetch rows", "ad-hoc dataflow query",
-  "parse Arrow response", "Arrow IPC", "dataflow staging analysis".
+  "executeQuery saved query", "executeQuery fetch rows", "ad-hoc dataflow
+  query", "parse Arrow response", "Arrow IPC", "dataflow staging analysis",
+  "use Dataflows consumption path to delete", "Dataflows read-only mutation
+  refusal", "separate Dataflows authoring handoff".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -36,9 +35,12 @@ description: >
 > call (e.g. `az rest --method delete/put/patch` against a dataflow, or a POST that
 > creates/overwrites). The only permitted POSTs are the explicitly read-side
 > `getDefinition` and `executeQuery` operations documented below.
-> If the user asks to delete, create, modify, or persist a dataflow, **refuse the
-> mutation** and route them to `dataflows-authoring-cli` — do not run the destructive
-> command, even if the user provides the exact API call.
+> If the user asks to delete, create, modify, or persist a dataflow, **explicitly
+> refuse the mutation in the final response** and name
+> `dataflows-authoring-cli` only as a future handoff. Do not invoke that skill,
+> perform discovery in preparation for the write, or continue the write workflow
+> in the same turn. A mutation may begin only after the user explicitly confirms
+> a separate authoring request.
 
 # dataflows-consumption-cli — Dataflows Gen2 Consumption via CLI
 

--- a/skills/dataflows-save-as-authoring-cli/SKILL.md
+++ b/skills/dataflows-save-as-authoring-cli/SKILL.md
@@ -23,6 +23,18 @@ description: >
 > 1. To find the workspace details (including its ID) from workspace name: list all workspaces and, then, use JMESPath filtering
 > 2. To find the item details (including its ID) from workspace ID, item type, and item name: list all items of that type in that workspace and, then, use JMESPath filtering
 
+> **GENERATION BOUNDARY -- HARD STOP (mandatory)**
+> This skill executes save-as only from Gen1 to Gen2.1. For an execution
+> request whose source is Gen2, or whose source generation is not established,
+> state that no public save-as or in-place upgrade endpoint is available and
+> stop before API calls. This does not block a read-only readiness scan whose
+> purpose is to discover and classify Gen1 candidates.
+> Do not interpret "choose the closest endpoint and proceed" as approval to
+> export a definition and create a copy, do not invoke the authoring skill
+> automatically, and do not mutate anything. Ask the user to clarify the
+> intended outcome and explicitly approve any separately documented
+> alternative.
+
 # dataflows-save-as-authoring-cli — Dataflow Save-As Gen1 → Gen2.1 CI/CD via CLI
 
 A save-as companion for creating upgraded Gen2.1 copies from Power BI Gen1 dataflows using readiness assessment and guarded execution.

--- a/skills/eventstream-authoring-cli/SKILL.md
+++ b/skills/eventstream-authoring-cli/SKILL.md
@@ -5,15 +5,16 @@ description: >
   the Items REST API. Build definitions with 25 source types (Event Hubs, IoT Hub,
   CDC, Kafka, SampleData), 8 operators (Filter, Aggregate, GroupBy, Join,
   ManageFields, Union, Expand, SQL), 4 destinations (Lakehouse, Eventhouse,
-  Activator, Custom Endpoint), DefaultStream/DerivedStream routing. Use to:
-  (1) author Eventstream topology, (2) add Event Hub source, (3) add filter
-  operator, (4) add CDC source with Debezium flattening, (5) wire destinations,
-  (6) modify/delete Eventstream definitions. Triggers: "create eventstream",
-  "deploy eventstream", "eventstream topology", "add source to eventstream",
-  "add event hub source", "add filter operator", "eventstream filter",
-  "eventstream destination", "CDC source", "eventstream operator",
-  "eventstream definition", "update eventstream", "wire eventstream",
-  "real-time ingestion pipeline", "eventstream topology deployment".
+  Activator, Custom Endpoint), DefaultStream/DerivedStream routing. **Invoke this
+  skill** to: (1) author Eventstream topology, (2) add Event Hub source, (3) add
+  filter operator, (4) add CDC source with Debezium flattening, (5) wire
+  destinations, (6) modify/delete Eventstream definitions. Invoke before making
+  topology changes. Triggers: "create eventstream", "deploy eventstream",
+  "eventstream topology", "add source to eventstream", "add event hub source",
+  "add filter operator", "eventstream filter", "eventstream destination",
+  "CDC source", "eventstream operator", "eventstream definition",
+  "update eventstream", "wire eventstream", "real-time ingestion pipeline",
+  "eventstream topology deployment".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -181,8 +182,8 @@ The Update Definition API returns `202 Accepted` for long-running operations. Po
 **Required structure for ALL operator condition fields:**
 - `column` → object with `{node, columnName, columnPath, expressionType: "ColumnReference"}`
 - `value` → object with `{dataType, value, expressionType: "Literal"}`
-- `operatorType` → string: `GreaterThan`, `LessThan`, `Equals`, `NotEquals`, `GreaterThanOrEqual`, `LessThanOrEqual`
-- `dataType` → `Float`, `Int`, `Long`, `String`, `DateTime`
+- `operatorType` → string: `Equals`, `NotEquals`, `GreaterThan`, `GreaterThanOrEquals`, `LessThan`, `LessThanOrEquals`, `Contains`, `DoesNotContain`, `StartsWith`, `DoesNotStartWith`, `EndsWith`, `DoesNotEndWith`, `IsEmpty`, `IsNull`, `IsNotNull`, `IsNotNullOrEmpty`
+- `dataType` → `BigInt`, `Float`, `Nvarchar(max)`, `DateTime`, `Bit`
 
 This same nested-object pattern applies to **all operators** that reference columns (Filter, Aggregate, GroupBy, Join, ManageFields).
 
@@ -227,3 +228,352 @@ Returns `200 OK` on success.
 - Do NOT exceed 11 combined CustomEndpoint sources and CustomEndpoint/Eventhouse-direct-ingestion destinations
 - Do NOT confuse Eventstream with Eventhouse — they are separate Fabric workloads
 - Do NOT hardcode workspace or item IDs — always discover them via the API
+
+---
+
+## Examples
+
+> **Platform note** — examples use PowerShell. Always write the JSON body to
+> a temp file via `[IO.File]::WriteAllText()` (no BOM) and pass
+> `--body "@$file"` to `az rest`, rather than inline `--body "..."` which
+> `cmd.exe` can mangle. Use `-Compress` with `ConvertTo-Json` to avoid
+> newline issues. The one safe inline exception is `--body '{}'` for empty bodies.
+
+### Example 1: Create an Eventstream with a Source
+
+**Prompt**: "Create an Eventstream called SensorIngestion in my dev workspace with a sample data source."
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+# 2. Create empty Eventstream
+$esBody = @{ displayName = "SensorIngestion"; description = "IoT sensor pipeline" } | ConvertTo-Json -Compress
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) "es_create.json"
+[IO.File]::WriteAllText($bodyFile, $esBody, [System.Text.UTF8Encoding]::new($false))
+$created = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$bodyFile" | ConvertFrom-Json
+
+# 3. Get the created Eventstream ID from response
+$esId = $created.id
+if (-not $esId) { throw "Eventstream creation did not return an ID" }
+
+# 4. Build topology — DefaultStream uses inputNodes (not parentName)
+$topology = @{
+    compatibilityLevel = "1.0"
+    sources = @(@{
+        name = "SampleSource"
+        type = "SampleData"
+        properties = @{ type = "Bicycles" }
+    })
+    streams = @(@{
+        name = "SensorIngestion-stream"
+        type = "DefaultStream"
+        properties = @{}
+        inputNodes = @(@{ name = "SampleSource" })
+    })
+    operators = @()
+    destinations = @()
+}
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+
+# 5. Deploy definition
+$defBody = @{
+    definition = @{
+        parts = @(@{
+            path = "eventstream.json"
+            payload = $topologyB64
+            payloadType = "InlineBase64"
+        })
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+$defFile = Join-Path ([IO.Path]::GetTempPath()) "es_def.json"
+[IO.File]::WriteAllText($defFile, $defBody, [System.Text.UTF8Encoding]::new($false))
+# Note: updateDefinition returns 202 Accepted (LRO). Poll until completion.
+$updateJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/updateDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$defFile"
+if ($LASTEXITCODE -ne 0) { throw "updateDefinition request failed" }
+
+$updateResp = $updateJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($updateResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($updateResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Update succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "updateDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 2: Add a Filter Operator with a DerivedStream
+
+**Prompt**: "Add a filter to my SensorIngestion Eventstream that keeps only events where No_Bikes > 5 and expose the filtered output as a DerivedStream."
+
+> **Important**: Adding a Filter operator node alone does not redirect the DefaultStream.
+> To make the filtered output consumable, wire a DerivedStream (or destination) to the
+> filter's output via `inputNodes`.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get current definition (handles LRO if API returns 202)
+$respJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/getDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body '{}'
+if ($LASTEXITCODE -ne 0 -or -not $respJson) { throw "getDefinition request failed" }
+$resp = $respJson | ConvertFrom-Json
+
+if ($resp.definition) {
+    $def = $resp  # Synchronous — got definition immediately
+} elseif ($resp.operationId) {
+    # Asynchronous (LRO) — poll operation status
+    $def = $null
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') {
+            $def = (az rest --method get `
+              --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)/result" `
+              --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+            break
+        } elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "getDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+    if (-not $def.definition) { throw "getDefinition LRO timed out (last status: $($status.status))" }
+} else {
+    throw "getDefinition returned neither a definition nor an operationId"
+}
+
+# 3. Decode existing topology
+$esPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstream.json' } | Select-Object -First 1
+if (-not $esPart) { throw "eventstream.json part not found in definition" }
+$topology = [Text.Encoding]::UTF8.GetString(
+  [Convert]::FromBase64String($esPart.payload)) | ConvertFrom-Json
+
+# 4. Add Filter operator (PascalCase name — no underscores or hyphens)
+#    Column: expressionType + columnName; Value: expressionType + dataType + value
+$filter = @{
+    name = "FilterLowBikes"
+    type = "Filter"
+    inputNodes = @(@{ name = "SensorIngestion-stream" })
+    properties = @{
+        conditions = @(@{
+            operatorType = "GreaterThan"
+            column = @{
+                expressionType = "ColumnReference"
+                node = $null
+                columnName = "No_Bikes"
+                columnPath = $null
+            }
+            value = @{
+                expressionType = "Literal"
+                dataType = "BigInt"
+                value = "5"
+            }
+        })
+    }
+}
+$existingOps = @($topology.operators | Where-Object { $_ -ne $null })
+$topology.operators = $existingOps + @($filter)
+
+# 5. Add DerivedStream wired to filter output (makes filtered data available)
+$derivedStream = @{
+    name = "FilteredOutput"
+    type = "DerivedStream"
+    properties = @{
+        inputSerialization = @{ type = "Json"; properties = @{ encoding = "UTF8" } }
+    }
+    inputNodes = @(@{ name = "FilterLowBikes" })
+}
+$existingStreams = @($topology.streams | Where-Object { $_ -ne $null })
+$topology.streams = $existingStreams + @($derivedStream)
+
+# 6. Re-encode and update
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+$esPart.payload = $topologyB64
+
+$defBody = @{ definition = @{ parts = $def.definition.parts } } | ConvertTo-Json -Depth 5 -Compress
+$defFile = Join-Path ([IO.Path]::GetTempPath()) "es_def.json"
+[IO.File]::WriteAllText($defFile, $defBody, [System.Text.UTF8Encoding]::new($false))
+# Note: updateDefinition returns 202 Accepted (LRO). Poll until completion.
+$updateJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/updateDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$defFile"
+if ($LASTEXITCODE -ne 0) { throw "updateDefinition request failed" }
+
+$updateResp = $updateJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($updateResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($updateResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Update succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "updateDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 3: Deploy Full Topology (Create with Inline Definition)
+
+**Prompt**: "Create a complete Eventstream called EventPipeline with a Custom Endpoint source, a filter for high-value events, and a DerivedStream for the filtered output."
+
+> **Note**: This uses the Fabric Items API (`POST /items`) to create the Eventstream with its
+> definition in a single call, rather than create-then-update.
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+# 2. Build complete topology with filter + DerivedStream
+$topology = @{
+    compatibilityLevel = "1.0"
+    sources = @(@{
+        name = "CustomSource"
+        type = "CustomEndpoint"
+        properties = @{}
+    })
+    streams = @(
+        @{
+            name = "EventPipeline-stream"
+            type = "DefaultStream"
+            properties = @{}
+            inputNodes = @(@{ name = "CustomSource" })
+        }
+        @{
+            name = "FilteredEvents"
+            type = "DerivedStream"
+            properties = @{
+                inputSerialization = @{ type = "Json"; properties = @{ encoding = "UTF8" } }
+            }
+            inputNodes = @(@{ name = "FilterPremium" })
+        }
+    )
+    operators = @(@{
+        name = "FilterPremium"
+        type = "Filter"
+        inputNodes = @(@{ name = "EventPipeline-stream" })
+        properties = @{
+            conditions = @(@{
+                operatorType = "GreaterThan"
+                column = @{
+                    expressionType = "ColumnReference"
+                        node = $null
+                        columnName = "Amount"
+                        columnPath = $null
+                    }
+                value = @{
+                    expressionType = "Literal"
+                    dataType = "BigInt"
+                    value = "100"
+                }
+            })
+        }
+    })
+    destinations = @()
+}
+
+# 3. Create with inline definition (single API call)
+$topologyJson = $topology | ConvertTo-Json -Depth 10 -Compress
+$topologyB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($topologyJson))
+
+$body = @{
+    displayName = "EventPipeline"
+    type = "Eventstream"
+    definition = @{
+        parts = @(@{
+            path = "eventstream.json"
+            payload = $topologyB64
+            payloadType = "InlineBase64"
+        })
+    }
+} | ConvertTo-Json -Depth 5 -Compress
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) "es_create_full.json"
+[IO.File]::WriteAllText($bodyFile, $body, [System.Text.UTF8Encoding]::new($false))
+
+# Create-with-definition returns 202 Accepted (LRO). Poll until completion.
+$createJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/items" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body "@$bodyFile"
+if ($LASTEXITCODE -ne 0) { throw "Create Eventstream request failed" }
+
+$createResp = $createJson | ConvertFrom-Json -ErrorAction SilentlyContinue
+if ($createResp.operationId) {
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($createResp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') { Write-Host "Create succeeded"; break }
+        elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "Create LRO $($status.status): $($status.error.message)"
+        }
+    }
+}
+```
+
+### Example 4: Delete an Eventstream
+
+**Prompt**: "Delete the SensorIngestion Eventstream from my dev workspace."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='dev'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'dev' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Delete
+az rest --method delete `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId" `
+  --resource "https://api.fabric.microsoft.com"
+```

--- a/skills/eventstream-consumption-cli/SKILL.md
+++ b/skills/eventstream-consumption-cli/SKILL.md
@@ -5,16 +5,16 @@ description: >
   the Items REST API. Discover Eventstreams across workspaces, decode base64 graph
   topologies tracing event flow from source through operators to destination nodes.
   Validate connection IDs, wiring, retention policies (1-90 days), and throughput
-  levels. Retrieve Custom Endpoint Kafka credentials via Topology API. Use to:
-  (1) list Eventstreams, (2) inspect Eventstream topology showing sources and
-  destinations, (3) validate Eventstream configurations, (4) check Eventstream
-  retention policy and throughput level, (5) get connection strings. Triggers:
-  "list eventstreams", "inspect eventstream", "inspect eventstream topology",
-  "eventstream sources and destinations",
-  "eventstream health", "eventstream configuration", "eventstream retention",
-  "eventstream retention policy", "eventstream throughput level",
-  "eventstream connection string", "custom endpoint credentials",
-  "kafka connection", "check eventstream".
+  levels. Retrieve Custom Endpoint Kafka credentials via Topology API. **Invoke
+  this skill** to: (1) list Eventstreams, (2) inspect Eventstream topology showing
+  sources and destinations, (3) validate Eventstream configurations, (4) check
+  Eventstream retention policy and throughput level, (5) get connection strings.
+  Triggers: "list eventstreams", "inspect eventstream",
+  "describe eventstream topology", "eventstream operator nodes",
+  "eventstream sources and destinations", "eventstream health",
+  "eventstream status", "eventstream configuration", "eventstream retention",
+  "eventstream throughput level", "eventstream connection string",
+  "custom endpoint credentials", "check eventstream".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -284,3 +284,247 @@ Decode `eventstreamProperties.json` and check:
 - Do NOT assume all source types appear in API enums — preview sources exist only in the UI
 - Do NOT modify Eventstream topology with this consumption skill — use `eventstream-authoring-cli` for writes
 - Do NOT attempt to query event data through the Eventstream API — use downstream skills (eventhouse-consumption-cli, sqldw-consumption-cli) for querying landed data
+
+---
+
+## Examples
+
+> **Platform note** — examples use PowerShell. Always write the JSON body to
+> a temp file via `[IO.File]::WriteAllText()` (no BOM) and pass
+> `--body "@$file"` to `az rest`, rather than inline `--body "..."` which
+> `cmd.exe` can mangle. Use `-Compress` with `ConvertTo-Json` to avoid
+> newline issues. The one safe inline exception is `--body '{}'` for empty bodies.
+> For large workspaces, check for `continuationUri` in list responses to handle
+> pagination.
+
+### Example 1: List All Eventstreams in a Workspace
+
+**Prompt**: "List all Eventstreams in my analytics workspace showing their names and IDs."
+
+```powershell
+# 1. Discover workspace ID
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+# 2. List Eventstreams (handles pagination)
+$allItems = @()
+$resp = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+$allItems += $resp.value
+while ($resp.continuationUri) {
+    $resp = az rest --method get `
+      --url $resp.continuationUri `
+      --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+    $allItems += $resp.value
+}
+$allItems | Select-Object displayName, id, description | Format-Table
+```
+
+### Example 2: Inspect Eventstream Topology
+
+**Prompt**: "Show me the topology of my SensorIngestion Eventstream — all sources, operators, and destinations."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get topology (returns JSON directly — no base64 decoding needed)
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+# 3. Summarize nodes (filter nulls from arrays)
+Write-Host "Sources:"
+@($topo.sources | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type), id: $($_.id))"
+}
+Write-Host "Operators:"
+@($topo.operators | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+Write-Host "Destinations:"
+@($topo.destinations | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+Write-Host "Streams:"
+@($topo.streams | Where-Object { $_ -ne $null }) | ForEach-Object {
+    Write-Host "  - $($_.name) (type: $($_.type))"
+}
+```
+
+### Example 3: Check Retention and Throughput Settings
+
+**Prompt**: "What are the retention and throughput settings for my SensorIngestion Eventstream?"
+
+> **Note**: Retention and throughput settings are stored in the `eventstreamProperties.json`
+> part of the definition (not `eventstream.json`). If this part is absent, the Eventstream
+> uses platform defaults.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs
+$wsId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='analytics'] | [0].id" -o tsv)
+if (-not $wsId) { throw "Workspace 'analytics' not found" }
+
+$esId = (az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/items?type=Eventstream" `
+  --resource "https://api.fabric.microsoft.com" `
+  --query "value[?displayName=='SensorIngestion'] | [0].id" -o tsv)
+if (-not $esId) { throw "Eventstream 'SensorIngestion' not found" }
+
+# 2. Get definition (handles LRO if API returns 202)
+$respJson = az rest --method post `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/getDefinition" `
+  --resource "https://api.fabric.microsoft.com" `
+  --headers "Content-Type=application/json" `
+  --body '{}'
+if ($LASTEXITCODE -ne 0 -or -not $respJson) { throw "getDefinition request failed" }
+$resp = $respJson | ConvertFrom-Json
+
+if ($resp.definition) {
+    $def = $resp  # Synchronous — got definition immediately
+} elseif ($resp.operationId) {
+    # Asynchronous (LRO) — poll operation status
+    $def = $null
+    for ($i = 0; $i -lt 12; $i++) {
+        Start-Sleep -Seconds 5
+        $status = (az rest --method get `
+          --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)" `
+          --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+        if ($status.status -eq 'Succeeded') {
+            $def = (az rest --method get `
+              --url "https://api.fabric.microsoft.com/v1/operations/$($resp.operationId)/result" `
+              --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json)
+            break
+        } elseif ($status.status -in @('Failed', 'Cancelled')) {
+            throw "getDefinition LRO $($status.status): $($status.error.message)"
+        }
+    }
+    if (-not $def.definition) { throw "getDefinition LRO timed out (last status: $($status.status))" }
+} else {
+    throw "getDefinition returned neither a definition nor an operationId"
+}
+
+# 3. Decode eventstreamProperties.json part (holds retention + throughput)
+$propsPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstreamProperties.json' } | Select-Object -First 1
+if ($propsPart) {
+    $props = [Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String($propsPart.payload)) | ConvertFrom-Json
+    Write-Host "Retention: $($props.retentionTimeInDays) days"
+    Write-Host "Throughput Level: $($props.eventThroughputLevel)"
+} else {
+    # Fall back to topology-level properties (older format)
+    $esPart = $def.definition.parts | Where-Object { $_.path -eq 'eventstream.json' } | Select-Object -First 1
+    if (-not $esPart) { throw "eventstream.json part not found in definition" }
+    $topology = [Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String($esPart.payload)) | ConvertFrom-Json
+    if ($topology.properties.retentionTimeInDays) {
+        Write-Host "Retention: $($topology.properties.retentionTimeInDays) days"
+    } else {
+        Write-Host "Retention: (platform default — not explicitly configured)"
+    }
+    if ($topology.properties.eventThroughputLevel) {
+        Write-Host "Throughput Level: $($topology.properties.eventThroughputLevel)"
+    } else {
+        Write-Host "Throughput Level: (platform default — not explicitly configured)"
+    }
+}
+```
+
+### Example 4: Get Custom Endpoint Connection Metadata
+
+**Prompt**: "Get the Kafka connection metadata for the Custom Endpoint source in my SensorIngestion Eventstream."
+
+> **Security**: The connection endpoint returns access keys. Get user confirmation before
+> calling it and avoid logging raw credentials.
+
+```powershell
+# 1. Discover workspace + Eventstream IDs (omitted for brevity)
+
+# 2. Get topology to find Custom Endpoint source ID
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+$ceSource = @($topo.sources | Where-Object { $_.type -eq 'CustomEndpoint' }) | Select-Object -First 1
+if (-not $ceSource) { throw "No CustomEndpoint source found in this Eventstream" }
+$sourceId = $ceSource.id
+
+# 3. Get connection metadata
+$conn = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/sources/$sourceId/connection" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+Write-Host "Fully Qualified Namespace: $($conn.fullyQualifiedNamespace)"
+Write-Host "Event Hub Name:            $($conn.eventHubName)"
+Write-Host "Kafka Bootstrap Server:    $($conn.fullyQualifiedNamespace):9093"
+```
+
+### Example 5: Validate Eventstream Configuration
+
+**Prompt**: "Check if my SensorIngestion Eventstream has any configuration issues."
+
+```powershell
+# 1. Discover workspace + Eventstream IDs (omitted for brevity)
+
+# 2. Get topology
+$topo = az rest --method get `
+  --url "https://api.fabric.microsoft.com/v1/workspaces/$wsId/eventstreams/$esId/topology" `
+  --resource "https://api.fabric.microsoft.com" | ConvertFrom-Json
+
+# 3. Validate sources
+@($topo.sources | Where-Object { $_ -ne $null }) | ForEach-Object {
+    $src = $_
+    Write-Host "Source: $($src.name) (type: $($src.type))"
+    if ($src.properties.dataConnectionId) {
+        Write-Host "  Cloud connection: $($src.properties.dataConnectionId)"
+    }
+    if ($src.type -in @('AzureEventHub','AzureEventHubExtended','AzureIoTHub','ConfluentCloud','ApacheKafka','AmazonMSKKafka') -and
+        -not $src.properties.consumerGroupName) {
+        Write-Host "  WARNING: No consumer group set (required for $($src.type))"
+    }
+}
+
+# 4. Validate destinations
+@($topo.destinations | Where-Object { $_ -ne $null }) | ForEach-Object {
+    $dst = $_
+    Write-Host "Destination: $($dst.name) (type: $($dst.type))"
+    if (-not $dst.inputNodes -or $dst.inputNodes.Count -eq 0) {
+        Write-Host "  WARNING: No input wired — destination will receive no events"
+    }
+    if ($dst.type -eq 'Eventhouse' -and -not $dst.properties.tableName) {
+        Write-Host "  WARNING: No target table configured"
+    }
+    if ($dst.type -eq 'Eventhouse' -and $dst.properties.dataIngestionMode -eq 'DirectIngestion') {
+        if (-not $dst.properties.connectionName -or -not $dst.properties.mappingRuleName) {
+            Write-Host "  WARNING: DirectIngestion requires connectionName and mappingRuleName"
+        }
+    }
+}
+
+# 5. Check node count limits
+$ceCount = @($topo.sources | Where-Object { $_.type -eq 'CustomEndpoint' }).Count +
+           @($topo.destinations | Where-Object { $_.type -eq 'CustomEndpoint' }).Count +
+           @($topo.destinations | Where-Object { $_.type -eq 'Eventhouse' -and
+             $_.properties.dataIngestionMode -eq 'DirectIngestion' }).Count
+Write-Host "CustomEndpoint + DI count: $ceCount / 11 limit"
+if ($ceCount -gt 11) {
+    Write-Host "WARNING: Exceeds limit of 11 CustomEndpoint + DirectIngestion nodes"
+}
+```

--- a/skills/semantic-model-authoring/SKILL.md
+++ b/skills/semantic-model-authoring/SKILL.md
@@ -4,14 +4,15 @@ description: >
   Develops and manages Power BI semantic models across Desktop, PBIP projects, and Fabric Service. Handles:
   (1) creating new models (Import, DirectQuery, Direct Lake),
   (2) editing existing models (e.g. measures, tables, columns, relationships),
-  (3) deploying models to Fabric workspaces,
-  (4) working with PBIP project files,
-  (5) refreshing semantic models,
-  (6) configuring data sources and permissions,
-  (7) DAX performance optimization.
+  (3) preparing semantic models for AI/Copilot consumption,
+  (4) deploying models to Fabric workspaces,
+  (5) working with PBIP project files,
+  (6) refreshing semantic models,
+  (7) configuring data sources and permissions,
+  (8) DAX performance optimization.
   Supports both Power BI Desktop and Fabric Service development workflows. For read-only DAX queries, use `semantic-model-consumption`.
   Does NOT handle report layout/visual authoring, workspace administration, or RLS/OLS role membership management.
-  Triggers: "create semantic model", "edit semantic model", "add a DAX measure to semantic model", "refresh semantic model", "set semantic model permissions", "Prepare semantic model for AI/Copilot".
+  Triggers: "create semantic model", "edit semantic model", "add a DAX measure to semantic model", "refresh semantic model", "set semantic model permissions", "Prepare semantic model for AI or Copilot".
 ---
 
 > **Update Check — ONCE PER SESSION (mandatory)**
@@ -182,7 +183,7 @@ Steps:
 
 ## Workflow: Semantic Model AI Readiness
 
-**When this applies:** User asks to make a semantic model ready for Microsoft Fabric Copilot, a Power BI Data Agent, or any conversational BI experience. Triggers include "Copilot readiness", "AI readiness", "prep for AI", "prepare model for Copilot".
+**When this applies:** User asks to make a semantic model ready for Microsoft Fabric Copilot, a Power BI Data Agent, or any conversational BI experience. Triggers include "Copilot readiness", "AI readiness", "Prep for AI", "prepare model for Copilot".
 
 Load [semantic-model-ai-readiness.md](./references/semantic-model-ai-readiness.md) before starting.
 
@@ -190,9 +191,9 @@ Steps:
 
 1. **Confirm scope & gather context** - via `ask_user`, confirm consumption mode (reports only / conversational BI / both) and model stability per the *When to Apply* section. Collect business context (process, key metrics, common natural-language questions, vocabulary). Do not invent.
 2. **Connect & inventory** - per [Connecting to a Semantic Model](#connecting-to-a-semantic-model). Capture model contents and the source location (PBIP / Fabric workspace / Desktop-only).
-3. **Evaluate & route** - walk the [Readiness Checklist](./references/semantic-model-ai-readiness.md#readiness-checklist) in order; for each gap, classify the fix per [Editing Capability by Source and Tier](./references/semantic-model-ai-readiness.md#editing-capability-by-source-and-tier) (MCP-editable TOM metadata vs PBIP-only artifact).
+3. **Evaluate & route** - walk the [Readiness Checklist](./references/semantic-model-ai-readiness.md#readiness-checklist) in order; for each gap, classify the fix per [Editing Capability](./references/semantic-model-ai-readiness.md#editing-capability) (agent-editable TOM metadata vs AI-specific artifacts the user configures in the Power BI "Prep data for AI" UI).
 4. **Present findings** grouped by severity, each tagged with routing (agent-applicable vs user-action-required). Wait for approval.
-5. **Apply approved changes** - TOM metadata via [Modify an Existing Model](#workflow-modify-an-existing-model); PBIP-only artifacts via direct file edits or Fabric `getDefinition`/`updateDefinition` round-trip; Desktop-only PBIX -> instruct user.
+5. **Apply approved changes** - apply TOM metadata fixes via [Modify an Existing Model](#workflow-modify-an-existing-model); for AI instructions, AI Data Schema, and Verified Answers, instruct the user to configure them in the Power BI "Prep data for AI" UI and, only if the user agrees, offer suggestions per the readiness reference; Desktop-only PBIX -> instruct user.
 6. **Save, validate, recommend live testing** - per [Saving Changes to a Semantic Model](#saving-changes-to-a-semantic-model) and [Validation Checklist](#validation-checklist); advise the user to test representative natural-language prompts in Copilot or the Data Agent and iterate.
 
 ---

--- a/skills/semantic-model-authoring/references/pbip.md
+++ b/skills/semantic-model-authoring/references/pbip.md
@@ -10,14 +10,6 @@ It can include a Semantic Model + Report or just a Report (live connect).
 PBIPFolder/
 ├── [Name].SemanticModel/
 |   ├── /definition # The semantic model definition using TMDL language [REQUIRED]
-│   ├── Copilot/ # Copilot tooling [OPTIONAL]
-│   │   ├── Instructions/ # Contains the AI instructions configured for the semantic model, stored as a single markdown file.
-│   │   │   ├── instructions.md 
-│   │   ├── VerifiedAnswers/ # Contains the configured Verified answers for the semantic model, using PBIR format.
-│   │   │   ├── definitions/
-│   │   ├── schema.json # Contains the schema selection and field synonyms configured for the semantic model. 
-│   │   ├── settings.json # Contains top level Copilot tooling settings. 
-│   │   ├── examplePrompts.json # Contains zero prompts set up for the semantic model.
 |   ├── definition.pbism # The semantic model definition file [REQUIRED]
 |   ├── * # Other semantic model metadata files and folders
 ├── [Name].Report/        
@@ -117,91 +109,6 @@ Example of a `[name].pbip` file:
 ```
 
 Refer to [JSON Schema](https://github.com/microsoft/json-schemas/blob/main/fabric/pbip/pbipProperties/1.0.0/schema.json) for more details.
-
-## Copilot/Instructions/instructions.md
-
-```markdown
-# AI Instructions for Semantic Model
-
-## Business Context & Terminology
-- You are a sales analyst for a retail company analyzing sales performance, customer behavior, and product trends
-...
-```
-
-### Copilot/schema.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/schema/1.0.0/schema.json",
-  "tables": [
-    {
-      "id": "[lineage tag]",
-      "name": "[Table name 1]",
-      "visibility": "Visible",
-      "columns": [
-        {
-          "id": "[lineage tag]",
-          "name": "[Column name 1]",
-          "visibility": "Visible",
-          "synonyms": ["[synonym 1]", "[synonym 2]"]
-        },
-        {
-          "id": "[lineage tag]",
-          "name": "[Column name 2]",
-          "visibility": "Hidden",
-          "synonyms": []
-        }
-      ],
-      "measures": [
-        {
-          "id": "[lineage tag]",
-          "name": "[measure name]",
-          "visibility": "Visible",
-          "synonyms": []
-        }
-      ],
-      "hierarchies": [
-        {
-          "id": "[lineage tag]",
-          "name": "[Hierarchy name]",
-          "visibility": "Visible",
-          "levels": [
-            {
-              "id": "[lineage tag]",
-              "name": "[Level name]",
-              "visibility": "Visible",
-              "synonyms": []
-            }
-          ],
-          "synonyms": []
-        }
-      ],
-      "synonyms": []
-    }
-  ]
-}
-```
-
-### Copilot/settings.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/settings/1.0.0/schema.json",
-  "indexingEnabled": true
-}
-```
-
-### Copilot/examplePrompts.json
-
-```json
-{
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/copilot/examplePrompts/1.0.0/schema.json",
-  "prompts": [
-    "Top 5 customers by Sales Amount",
-    "Margin % by product category"
-  ]
-}
-```
 
 ## References
 

--- a/skills/semantic-model-authoring/references/semantic-model-ai-readiness.md
+++ b/skills/semantic-model-authoring/references/semantic-model-ai-readiness.md
@@ -21,14 +21,14 @@ Ask the user which consumption methods are planned before scoping the readiness 
 
 ## Editing Capability
 
-The agent's ability to *apply* a Copilot readiness item depends on (a) whether the item lives in TOM model metadata or in PBIP-only artifacts, and (b) where the model lives. 
+The agent's ability to *apply* a Copilot readiness item depends on whether the item lives in TOM model metadata (agent-editable) or is an AI-specific artifact that must be configured by the user in the Power BI "Prep data for AI" UI.
 
 | Semantic Model Objects                                                                                   | Editing path                                                                                                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **TOM metadata** - names, descriptions, relationships, measures, hidden flags, data types, summarization | **Prioritize MCP** (any source).                                                                                                                                                                                       |
-| **Everything else** - synonyms, AI instructions, AI Data Schema selection, Verified Answers              | **Edit PBIP files** under `<Name>.SemanticModel/Copilot/`. Edit directly on a PBIP project, or via Fabric workspace `getDefinition`/`updateDefinition` round-trip. Not via MCP. PBIX files cannot be edited by Agents. Load [pbip.md](pbip.md) to understand the file structure. |
+| **TOM metadata** - names, descriptions, relationships, measures, hidden flags, data types, summarization | **Edit via MCP or TMDL** (any source). The agent applies these changes directly.                                                                                                                                       |
+| **AI-specific artifacts** - AI instructions, AI Data Schema selection & synonyms, Verified Answers       | **Not editable by the agent.** Instruct the user to configure these in the Power BI "Prep data for AI" UI. The agent may *offer* suggestions only when appropriate - see sections [4](#4-ai-instructions), [5](#5-ai-data-schema), and [6](#6-verified-answers). |
 
-When presenting findings to the user, tag each item with its routing so the user knows which fixes the agent can apply and which require Desktop work.
+When presenting findings to the user, tag each item with its routing so the user knows which fixes the agent can apply to the model metadata and which the user must configure in the "Prep data for AI" UI.
 
 **Important:** When incapable of editing any metadata, refer the user to [copilot-prepare-data-ai](https://learn.microsoft.com/power-bi/create-reports/copilot-prepare-data-ai) documentation.
 
@@ -57,6 +57,8 @@ Without this, Copilot will produce poor results regardless of any other configur
 - Anticipate common questions: include predefined measures users are most likely to request (e.g., `YTD Sales`, `MoM Growth`, `ROI`, `CAC`, `LTV`). Copilot answers more reliably when the metric already exists as an explicit measure.
 - Consolidate or clearly differentiate duplicate or overlapping measures.
 - Define logical hierarchies on dimension tables to support drill-down (e.g., `Year > Quarter > Month > Day` on a date dimension; `Country > State > City` on a geography dimension).
+- Set `summarizeBy` correctly on numeric columns - especially `None` for IDs, year, month number, postal codes, etc., to prevent accidental sums.
+- Set the `isDefaultLabel` on the column that defines the natural label for each dimension table, allowing Copilot to identify the table's default "name" column (for example, **Product Name** in the **Product** table).
 
 **DON'T:**
 - Leave unused columns or tables in the model - they pollute the schema Copilot sees and increase the chance of wrong field selection.
@@ -68,8 +70,6 @@ Business-friendly naming is one of the highest-impact changes for Copilot readin
 **DO:**
 - Use human-readable names on every visible table, column, and measure (e.g., `Transaction Amount`, not `TR_AMT` or `tr_amt`).
 - Use the language Copilot will be queried in (typically English) for visible names, even if the source system uses another language.
-- Set `summarizeBy` correctly on numeric columns - especially `None` for IDs, year, month number, postal codes, etc., to prevent accidental sums.
-- Set the `isDefaultLabel` (or equivalent default field) on dimension tables so Copilot can identify the natural "name" column.
 
 **DON'T:**
 - Ship CamelCase, snake_case, UPPER_CASE, or technical abbreviations on visible objects.
@@ -95,7 +95,7 @@ Descriptions provide context that names alone cannot convey. Descriptions writte
 
 AI instructions are freeform text that Copilot reads automatically. They are one of the most impactful controls for conversational BI quality.
 
-> **Editing path:** PBIP-level artifact. See [Editing Capability](#editing-capability).
+> **Editing path:** Not editable by the agent - the user configures AI instructions in the Power BI "Prep data for AI" UI. After the model-metadata changes are applied, prompt the user to ask whether they want the agent to draft suggested AI instructions. See [Editing Capability](#editing-capability).
 
 **DO:**
 - Metric routing for ambiguous terms ("when users ask about margin, use `[Standard Margin]`").
@@ -114,22 +114,21 @@ AI instructions are freeform text that Copilot reads automatically. They are one
 **DON'T:**
 - Duplicate large blocks of business logic that already live in descriptions.
 - Encode information that should instead be a measure, a synonym, or a relationship.
-- Rely on instructions to enforce hard rules - the LLM may still ignore them. For non-negotiable behaviour, fix the model itself.
-- Exceed 10.000 characters
+- Restate what descriptions and model metadata already convey.
+- Rely on instructions to enforce hard rules - the LLM may still ignore them. For non-negotiable behavior, fix the model itself.
+- Exceed 10,000 characters
 
 ### 5. AI Data Schema
 
 The AI data schema controls which tables, columns, and measures are exposed to Copilot. It also defines synonyms for tables/columns/measures. Scoping this correctly prevents Copilot from getting confused by helper objects.
 
-> **Editing path:** PBIP-level artifact. See [Editing Capability](#editing-capability).
+> **Editing path:** Not editable by the agent - the user configures the AI Data Schema in the Power BI "Prep data for AI" UI. Prompt the user to ask whether they want suggestions, but only recommend an AI-schema visibility change when the desired AI visibility differs from the model's default visibility (e.g., a measure that should stay visible for reports and ad-hoc exploration but be excluded from AI agents). Do not mirror the report-model visibility as an AI-schema change. See [Editing Capability](#editing-capability).
 
 **DO:**
 - Include only tables, columns, and measures that a business user would meaningfully ask about.
 - Include all dependent objects for selected measures (any column or measure referenced by a selected measure must also be visible to Copilot).
 - Exclude helper measures, intermediate calculations, and technical bridge tables.
 - Exclude duplicate or overlapping measures.
-- Keep the AI schema selection consistent across "Prep for AI" and any Data Agent configuration that points to this model.
-- Configure `synonyms` on tables, columns, and measures for alternative terms users employ (e.g., `Revenue`, `Sales`, `Turnover` for the same measure).
   
 **DON'T:**
 - Default to "expose everything" - it dilutes the signal Copilot uses to pick the right field.
@@ -141,7 +140,6 @@ Verified Answers are pre-built report visuals that Copilot can return for specif
 > **Editing path:** Don't edit verified answers automatically. Instead suggest good candidates for verified answers and ask the user to configure manually in the tool. See [copilot-prepare-data-ai](https://learn.microsoft.com/power-bi/create-reports/copilot-prepare-data-ai-verified-answers) documentation.
 
 **DO:**
-- When reviewing a PBIP, check whether a Verified Answers definition exists in the project. Note its presence in the readiness summary.
-- If absent and the user is interested, point them to the Power BI Desktop authoring experience - do not attempt to author Verified Answers from this skill.
-- Inspect the model measures, based on the measure names, descriptions recommend the top five questions worth setting as verified answers
+- Inspect the model measures and, based on the measure names and descriptions, recommend the top five questions worth setting as Verified Answers.
+- Prompt the user to configure Verified Answers in the Power BI "Prep data for AI" UI - do not attempt to author Verified Answers from this skill.
 


### PR DESCRIPTION
Syncs internal release v0.3.9 to the public repository.

## Highlights

- Adds `azmon-mirroredcatalogs-operations-cli` to the full and operations bundles.
- Reworks `check-updates` for marketplace plugins, direct plugins, Git clones, and confirmed loose skill copies.
- Tightens Activator and Dataflows safeguards for missing sources, read-only requests, and underspecified mutations.
- Expands Databricks migration guidance and adds Eventstream authoring and consumption examples.
- Updates every plugin manifest and both marketplace files to v0.3.9.

## Validation

- Repository structural quality check passed with advisory warnings only.
- Plugin marketplace generation and manifest checks passed.
- Marketplace files are byte-identical, and every plugin manifest count matches its shipped skill directories.
- The public dry run introduced no new broken references compared with v0.3.8.

## After merge

Run the public release phase:

```powershell
.\ReleaseScripts\PublishToPublic.ps1 -PublishRelease -Version 0.3.9
```